### PR TITLE
docs: Add NENE2-compliant coding standards, development docs, and review checklists

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,11 +16,16 @@ See [ADR 0009](docs/adr/0009-separate-from-billing-and-reconciliation.md).
 ## Read First
 
 - **Scope contract (binding):** `docs/explanation/scope-contract.md`
+- **Compliance (binding):** `docs/explanation/received-document-compliance.md`
 - **No competitor names (binding):** `docs/adr/0013-no-third-party-product-names.md`
 - **Portfolio strategy:** [publication-strategy `docs/products/nene-vault.md`](https://github.com/hideyukiMORI/publication-strategy/blob/main/docs/products/nene-vault.md)
 - **Product vision:** `docs/explanation/product-vision.md`
 - **Requirements:** `docs/explanation/requirements.md`
-- **Compliance (binding):** `docs/explanation/received-document-compliance.md`
+- **Domain model:** `docs/explanation/domain-model.md`
+- **Terminology (binding spellings):** `docs/explanation/terminology.md`
+- **Glossary:** `docs/explanation/glossary.md`
+- **Retention calculation (ADR 0004):** `docs/adr/0004-retention-period-calculation.md`
+- **Audit event schema (ADR 0014):** `docs/adr/0014-audit-event-schema.md`
 - **Scope boundary:** `docs/explanation/scope-boundary.md`
 - **NENE2 conventions:** `docs/development/nene2-compliance.md`
 - **Sibling integration:** `docs/integrations/sibling-products.md`

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ without becoming accounting software or expense workflow. Built on
 - **Self-hosted OSS** — MIT; Tier A shared hosting or Tier B Docker/VPS
 - **Optional links** — HTTP reference to Invoice/Clear entities; **no shared DB**
 - **No third-party product names** in repository docs — [ADR 0013](./docs/adr/0013-no-third-party-product-names.md)
+- **UI: Japanese + English only** — [ADR 0005](./docs/adr/0005-ui-language-scope-ja-en.md)
 
 ## Documentation (read first)
 
@@ -50,7 +51,8 @@ without becoming accounting software or expense workflow. Built on
 
 ## Status
 
-**Phase 0** — governance and product design. Runtime scaffold follows Issues #4+.
+**Phase 0 complete** — governance and product design done (PR #1, #2 merged 2026-05-30).
+Phase 1 runtime scaffold follows Issues #4+.
 
 ## Ecosystem
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -4,20 +4,34 @@ NeNe Vault is built through small, Issue-driven changes. This document is the sh
 
 ## Required Reading
 
+The following documents exist now and must be read before contributing:
+
+| Topic | Document |
+| --- | --- |
+| Agent entry point | `AGENTS.md` |
+| Scope contract (binding) | `docs/explanation/scope-contract.md` |
+| Compliance (binding) | `docs/explanation/received-document-compliance.md` |
+| Product vision | `docs/explanation/product-vision.md` |
+| Requirements | `docs/explanation/requirements.md` |
+| Sibling product boundaries | `docs/integrations/sibling-products.md` |
+| Workflow | `docs/workflow.md` |
+| Roadmap | `docs/roadmap.md` |
+| Current work | `docs/todo/current.md` |
+
+The following documents are also available:
+
 | Topic | Document |
 | --- | --- |
 | NENE2 inheritance map | `docs/inheritance-from-nene2.md` |
-| Sibling product boundaries | `docs/integrations/sibling-products.md` |
-| Workflow | `docs/workflow.md` |
 | Coding standards | `docs/development/coding-standards.md` |
 | Naming conventions | `docs/development/naming-conventions.md` |
-| Glossary | `docs/explanation/glossary.md` |
 | Backend standards (PHP/API) | `docs/development/backend-standards.md` |
-| Commit messages | `docs/development/commit-conventions.md` |
-| AI tools | `docs/integrations/ai-tools.md` |
-| Agent entry point | `AGENTS.md` |
-| Roadmap | `docs/roadmap.md` |
-| Current work | `docs/todo/current.md` |
+| Commit conventions | `docs/development/commit-conventions.md` |
+| ADR operation | `docs/development/adr.md` |
+| Self-review policy | `docs/development/self-review.md` |
+| Glossary | `docs/explanation/glossary.md` |
+| Self-review checklists | `docs/review/` |
+| AI tool configuration | `docs/integrations/ai-tools.md` (Phase 1+) |
 
 ## Collaboration Policy
 
@@ -40,19 +54,21 @@ Do not commit passwords, tokens, private URLs, production credentials, or local 
 Sensitive keys for this product include:
 
 - Admin JWT secrets
-- Invoice upstream API bearer token (and optional NeNe Records / NeNe Concierge tokens)
-- SMTP credentials for dunning email delivery
+- Storage path configuration (if it leaks internal directory structure)
+- Optional bearer tokens for sibling link validation (Invoice API, Clear API)
+- SMTP credentials if email inbound is implemented (Phase 3+)
 
 ## Engineering Theme
 
 NeNe Vault should stay readable, secure, and self-hostable:
 
-- strict, typed, explicit boundaries (inherited from NENE2)
-- decoupled use cases and infrastructure
+- Strict, typed, explicit boundaries (inherited from NENE2)
+- Decoupled use cases and infrastructure
 - OpenAPI contracts before client assumptions
-- Reconciliation/dunning compliance enforced at the API layer; no quote/invoice/tax/PDF logic (ADR 0009)
+- Received-document archive posture enforced at the API layer; no issuance,
+  reconciliation, dunning, or CSV logic (ADR 0009)
 - MCP access only through documented HTTP boundaries
-- **never** merge into or embed inside NeNe Records (ADR 0002)
+- **Never** merge into or embed inside sibling products (ADR 0002)
 
 ## Upstream Framework
 

--- a/docs/adr/0003-dual-tier-deployment.md
+++ b/docs/adr/0003-dual-tier-deployment.md
@@ -1,0 +1,94 @@
+# ADR 0003: Dual-Tier Deployment — Shared Hosting (Tier A) and Docker (Tier B)
+
+## Status
+
+accepted
+
+## Context
+
+NeNe Vault targets Japan SMB operators who self-host back-office software rather
+than subscribing to bundled cloud SaaS. Two infrastructure patterns dominate this
+segment:
+
+- **Shared hosting** (レンタルサーバー) — common among small operators, no root
+  access, MySQL provided, PHP via web root, deploy via FTP/ZIP upload.
+- **VPS / Docker** — used by developers and agencies running multiple NeNe
+  products side-by-side on one server.
+
+Optimising for only one tier excludes a significant part of the target audience.
+A single codebase must support both without divergent maintenance.
+
+Alternatives considered:
+
+1. **Shared hosting only** — rejected; developers running Invoice + Clear + Vault
+   together on a VPS get no first-class Docker support and cannot use Compose
+   networking.
+2. **Docker only** — rejected; non-developer operators on shared hosting cannot
+   use Docker and would need a separate product or manual setup.
+3. **Dual-tier with a single codebase** (chosen) — one PHP application packaged
+   two ways; deployment differences handled by env vars and installer tooling,
+   not by branching application logic.
+
+## Decision
+
+NeNe Vault ships as a **single PHP codebase** deployable in two official tiers:
+
+### Tier A — Shared Hosting
+
+- Release artifact: versioned **ZIP** containing pre-installed Composer
+  dependencies (`vendor/` bundled).
+- **Web installer** (`/install`) guides operator through database credentials,
+  storage path, and initial superadmin setup; self-destructs after use.
+- Database: **MySQL** (minimum version per NENE2 requirement).
+- Storage root: local filesystem path configured during install; must be outside
+  web root (`storage/vault/` by default).
+- Target: operators who deploy via FTP/cPanel without shell access.
+
+### Tier B — Docker / VPS
+
+- **Docker Compose** configuration ships in the repository (`compose.yml`).
+- No bundled `vendor/` — `composer install` runs at build time.
+- Storage: mounted volume (`./storage/vault`).
+- Can run beside `nene-invoice`, `nene-clear`, and `nene-profile` on one host
+  with shared Compose network (optional; each product stays a separate container
+  with its own database).
+- Target: developers and agencies managing multiple NeNe products.
+
+### Shared constraints (both tiers)
+
+- **No third-party object storage in MVP** — local filesystem only; S3-compatible
+  adapter is Phase 4+ (ADR 0012).
+- **Env-var-driven configuration** — no tier-specific code paths in application
+  logic; tier differences live in deployment tooling only.
+- **Backup is operator responsibility** — docs mandate filesystem backup + DB
+  backup together; Vault does not ship a backup scheduler.
+
+## Consequences
+
+**Benefits**
+
+- Reaches both the non-developer SMB operator (Tier A) and the developer/agency
+  audience (Tier B) from one codebase.
+- Consistent with sibling product deployment model (Invoice, Clear ship Tier A
+  + B).
+
+**Costs**
+
+- Release pipeline must produce two artifacts: ZIP (Tier A) and image/Compose
+  config (Tier B).
+- Web installer adds a security surface; must self-destruct and be covered by
+  CI check.
+- `vendor/` bundling for Tier A requires a separate build step.
+
+**Follow-up**
+
+- Phase 3: implement web installer and release ZIP build pipeline.
+- Phase 4: `DocumentStorageInterface` adapter for S3-compatible backends.
+
+## Related
+
+- [`../explanation/scope-contract.md`](../explanation/scope-contract.md) D10
+- ADR 0012: File storage architecture
+- [`../explanation/product-vision.md`](../explanation/product-vision.md) — dual deployment section
+- Supersedes: none
+- Superseded by: none

--- a/docs/adr/0004-retention-period-calculation.md
+++ b/docs/adr/0004-retention-period-calculation.md
@@ -1,0 +1,147 @@
+# ADR 0004: Retention Period Calculation — Anchor on Transaction Date, Default 10 Years
+
+## Status
+
+accepted
+
+> **Engineering interpretation of 電子帳簿保存法 and related tax laws — not
+> legal advice.** The calculation described here reflects a conservative, safe
+> interpretation. Operators with specific fiscal-year or loss-carryforward
+> situations must confirm the applicable period with their 税理士.
+
+## Context
+
+NeNe Vault must enforce a minimum retention period on every stored document.
+The Japanese statutory minimum for received electronic records is "7 years from
+the filing deadline of the fiscal year to which the transaction belongs" (see
+`received-document-compliance.md` §1 and §5 for the full statutory basis).
+
+### The problem with "7 years from transaction date"
+
+A naïve implementation would retain documents for 7 years from
+`transaction_date`. This appears correct but is systematically shorter than the
+statutory minimum in many cases:
+
+```
+Example — calendar-year corporation:
+
+  Transaction date:    2024-01-15  (in fiscal year 2024)
+  Fiscal year ends:    2024-12-31
+  Tax return due:      2025-02-28  (2 months after FY end — basic case)
+  Statutory 7-year period: 2025-02-28 → 2032-02-28
+
+  "7 years from transaction_date" retains until: 2031-01-15
+  Shortfall: 13 months  ← non-compliant
+```
+
+For a late-December transaction the shortfall is smaller (~3 months), but for
+January transactions in a December fiscal year it exceeds 13 months.
+
+The gap exists because Vault does not require operators to configure their fiscal
+year or filing deadline — and it should not, as that is accounting-layer
+information.
+
+### Why not calculate exactly?
+
+Exact calculation requires:
+1. Operator's fiscal year end (配当基準日 / 決算月) — varies widely
+2. Tax return filing mode (extended deadline of 3 months for certain entities,
+   or up to 6 months with NTA approval)
+3. Tax type (法人税, 所得税, 消費税 have the same 7-year rule but may have
+   different fiscal reference points for individual operators)
+4. Whether a 繰越欠損金 extends to 10 years
+
+Collecting and validating this data to drive retention calculations would couple
+Vault to accounting logic it must not own (scope-contract X4). The correct
+answer is: use a conservative default that makes the calculation unnecessary.
+
+### Why 10 years as the default
+
+10 years from `transaction_date` covers:
+
+| Obligation | Required duration from transaction | 10-year anchor |
+| --- | --- | --- |
+| 法人税 7 years from filing deadline | Up to ~9 years from transaction (FY end + 2 months filing + 7 years) | ✅ covered |
+| 消費税 7 years from filing deadline | Same calculation | ✅ covered |
+| 会社法 10 years from fiscal year end | Up to ~10.5 years from early-year transaction | ⚠️ edge case: Jan transaction in Dec FY — need 10 years 6 months from transaction. Configure 11 years if required. |
+| 所得税 7 years from filing deadline | Up to ~9 years from transaction | ✅ covered |
+| 繰越欠損金 up to 10 years from filing deadline | Up to ~12 years from early-year transaction | ⚠️ operator must configure 12–13 years manually if applicable |
+
+For the vast majority of SMB operators, a 10-year anchor from `transaction_date`
+is safe. For operators with 繰越欠損金 or unusual fiscal years, the
+`retention_years` setting can be raised to 12–13 years with 税理士 guidance.
+
+Alternatives considered:
+
+1. **7 years from transaction_date (default)** — rejected; systematically shorter
+   than the statutory minimum for early-year transactions (up to 13 months short).
+2. **Require fiscal-year configuration, compute exact date** — rejected; introduces
+   accounting-domain logic Vault must not own; complex to validate; incorrect
+   fiscal-year input silently produces wrong dates.
+3. **8 years from transaction_date** — considered; covers most 法人税/消費税 cases
+   but still leaves a gap for calendar-year corps with very early transactions
+   and 会社法 obligations.
+4. **10 years from transaction_date (chosen)** — covers all common cases without
+   fiscal-year configuration; aligns with 会社法 requirement; easy for operators
+   and advisors to verify.
+
+## Decision
+
+1. **Retention clock anchors on `transaction_date`.**
+   If `transaction_date` is null, `uploaded_at` is used as a conservative
+   substitute and the document is flagged `date_uncertain = true` (see
+   `received-document-compliance.md` §5.3).
+
+2. **Default `retention_years = 10`.**
+   `retention_expires_at = transaction_date + retention_years`.
+   This replaces the earlier draft requirement of "default 7 years" — that
+   calculation is insufficient.
+
+3. **Configurable range: 7–99 years.**
+   - Minimum 7: the operator asserts their statutory obligation is covered; system
+     shows a warning: "A retention period below 10 years may not cover all
+     statutory obligations. Confirm with your 税理士 that the 7-year period
+     running from your filing deadline is satisfied."
+   - Maximum 99: no artificial ceiling; permanent retention is a valid policy.
+
+4. **`retention_years` is per-organization** (in `vault_settings`).
+   Individual documents inherit the organization's setting at upload time and
+   store the calculated `retention_expires_at` as a fixed date — changing the
+   org setting afterwards does NOT retroactively shorten the retention on
+   existing documents. It may only lengthen them (the system recomputes and
+   takes the later of the two dates).
+
+5. **Any change to `vault_settings.retention_years` creates a
+   `vault_settings.changed` audit event** with before/after values and actor.
+
+## Consequences
+
+**Benefits**
+
+- Eliminates the 13-month shortfall for early-year transactions without requiring
+  fiscal-year configuration.
+- A 税理士 or 公認会計士 reviewing the system finds a clearly safe anchor that
+  requires no additional calculation.
+- Retroactive shortening of retention on existing documents is impossible.
+
+**Costs**
+
+- Default retention extends from 7 to 10 years — operators keep documents longer
+  than the statutory minimum, which uses more storage. This is intentional and
+  the correct trade-off.
+- Operators with 繰越欠損金 (up to 10 years from filing deadline) may still need
+  to configure 12–13 years manually; system cannot detect this automatically.
+
+**Follow-up**
+
+- Document the calculation and the warning text in the operator guide (Phase 2).
+- Consult 税理士 to confirm the 10-year anchor is universally accepted (Phase 0
+  review gate).
+
+## Related
+
+- Compliance: [`../explanation/received-document-compliance.md`](../explanation/received-document-compliance.md) §5
+- Requirements: [`../explanation/requirements.md`](../explanation/requirements.md) §6
+- Domain model: [`../explanation/domain-model.md`](../explanation/domain-model.md)
+- Supersedes: informal "default 7 years" wording in early requirements draft
+- Superseded by: none

--- a/docs/adr/0005-ui-language-scope-ja-en.md
+++ b/docs/adr/0005-ui-language-scope-ja-en.md
@@ -1,0 +1,82 @@
+# ADR 0005: UI Language Scope — Japanese and English Only
+
+## Status
+
+accepted
+
+## Context
+
+NeNe Vault targets Japan SMB operators subject to 電子帳簿保存法. The product's
+domain — received-document search requirements, retention periods, statutory
+vocabulary, and audit posture — is grounded in Japanese law and accounting
+practice. There is no generalised international equivalent.
+
+As cross-border business activity in Japan grows, some operators and staff use
+English as their primary working language. However, extending the UI to additional
+locales (Chinese, Korean, etc.) would ship locale strings and operator guides
+disconnected from Japanese statutory context, creating false confidence in
+regulatory compliance for non-Japan operators without a real operator base for
+those locales.
+
+Repository documentation is English-only per ADR 0008. This ADR governs the
+**product UI and operator-facing materials** only.
+
+Alternatives considered:
+
+1. **Japanese only** — rejected; excludes English-dominant staff at foreign-owned
+   SMBs operating under Japanese law, who are a natural secondary user base.
+2. **Full i18n (any locale)** — rejected; Japanese accounting rules do not
+   generalise across jurisdictions; shipping locale files for non-Japanese
+   jurisdictions implies compliance postures Vault cannot support and would
+   mislead operators.
+3. **Japanese + English only** (chosen) — covers the actual operator base
+   (Japan-registered SMBs including foreign-owned), keeps maintenance scope
+   narrow, and explicitly prevents a non-Japan operator from mistaking Vault for
+   a product that meets their jurisdiction's requirements.
+
+## Decision
+
+NeNe Vault admin UI and operator-facing materials support
+**Japanese (primary) and English (secondary) only**.
+
+- **Admin UI locale catalogs:** `ja` (primary) and `en` (secondary).
+- **Operator install guide and system-overview doc:** ja + en.
+- **OpenAPI descriptions** and **Problem Details** error metadata: English only
+  (ADR 0008 — these are engineering-layer docs, not operator UI).
+- **No other locale files** will be merged into this repository. A PR adding a
+  third locale will be rejected at review with a pointer to this ADR.
+- **Language selector:** toggle ja / en in admin UI; default resolves from
+  browser `Accept-Language` header with `ja` as fallback.
+- **Statutory field labels** (e.g. 取引年月日, 取引金額, 取引先) appear in
+  Japanese in both locales where legally traceable terminology is required.
+
+This restriction applies to the upstream repository only. The MIT licence permits
+operators or forks to add additional locales; the upstream project will not
+maintain them.
+
+## Consequences
+
+**Benefits**
+
+- Covers the real operator base: domestic SMBs and foreign-owned businesses
+  operating under Japanese law.
+- Prevents misleading operators in other jurisdictions (Taiwan, Korea, etc.)
+  into using a Japan-specific compliance product.
+- Keeps locale maintenance narrow, auditable, and honest about product scope.
+- Consistent with the narrow-scope philosophy: one noun, one jurisdiction.
+
+**Costs**
+
+- An English-dominant operator must accept a Japanese-primary UI structure and
+  statutory labels.
+- Future jurisdiction expansion (e.g. a Taiwan edition) would require a fork
+  or a separate product, not an i18n flag in this repository.
+
+## Related
+
+- ADR 0008: English-only repository documentation
+- [`../explanation/received-document-compliance.md`](../explanation/received-document-compliance.md) — compliance posture is Japan-specific
+- [`../explanation/product-vision.md`](../explanation/product-vision.md) — target operators
+- Roadmap Phase 2: Admin UI implementation
+- Supersedes: none
+- Superseded by: none

--- a/docs/adr/0006-multi-tenancy-and-roles.md
+++ b/docs/adr/0006-multi-tenancy-and-roles.md
@@ -6,90 +6,78 @@ accepted
 
 ## Context
 
-The early product docs assumed Phase 1 was single-tenant, with multi-tenancy
-deferred ("`company_settings` singleton per organization (Phase 1 single-tenant;
-multi-tenant adds `organization_id`)"). In practice the product must support, from
-the foundation:
+Early product docs assumed Phase 1 was single-tenant, with multi-tenancy
+deferred. In practice the product must support, from the foundation:
 
 - agencies and hosting operators running **one install for multiple client
-  organizations**, and
-- a **role hierarchy** where a platform operator manages organizations and an
-  organization administrator manages that organization's users.
+  organisations**, and
+- a **role hierarchy** where a platform operator manages organisations and an
+  organisation administrator manages that organisation's users and vault settings.
 
-Sibling product [NeNe Records](https://github.com/hideyukiMORI/nene-records)
-already implements exactly this on NENE2 (per-request organization resolution,
-`Role`/`Capability` enums, `CapabilityMiddleware`, `organization_id` on
-tenant-scoped tables). Retrofitting tenancy later would touch every table,
-repository, and route — far more costly than building tenant-aware from day one.
+Sibling product NeNe Records already implements exactly this on NENE2
+(per-request organisation resolution, `Role`/`Capability` enums,
+`CapabilityMiddleware`, `organization_id` on tenant-scoped tables). Retrofitting
+tenancy later would touch every table, repository, and route — far more costly
+than building tenant-aware from day one.
 
 Alternatives considered:
 
 1. **Single-tenant first, retrofit later** — rejected; a later `organization_id`
-   migration across all document tables plus auth rework is high-risk and
-   re-opens compliance-sensitive code (file storage integrity, audit, retention).
+   migration across all vault, document, and audit tables re-opens
+   compliance-sensitive code (file storage integrity, audit trail, retention).
 2. **Separate install per tenant only** — rejected; does not serve agencies and
    duplicates operations; the data model should still be tenant-aware.
 3. **Multi-tenant foundation, mirroring NeNe Records** (chosen) — tenant-aware
    schema and middleware from the start; a single install may still run as one
-   organization via the `single` resolution mode.
+   organisation via the `single` resolution mode.
 
 ## Decision
 
 NeNe Vault is **multi-tenant from the foundation**, adopting the NeNe Records
-architecture.
+tenancy architecture.
 
 ### Tenancy
 
-> The entity and capability examples below were corrected to NeNe Vault's
-> domain (reconciliation & dunning) per [ADR 0009](./0009-separate-from-nene-invoice.md).
-> The tenancy/role **decision** is unchanged.
-
-- Every tenant-scoped table carries **`organization_id`** (`clear_settings`,
-  `bank_import_batches`, `bank_transactions`, `payment_reconciliations`,
-  `client_credits`, `dunning_notices`, `audit_events`, `users`).
-- The **organization** (`organizations` table) is the tenant. Each organization
-  is an independent **operator** running reconciliation and dunning, with its own
-  `clear_settings` (Invoice upstream API URL/token, registered bank accounts,
-  dunning defaults).
-- Per-request **organization resolution** runs in middleware before authorization
+- Every tenant-scoped table carries **`organization_id`**
+  (`vault_settings`, `vault_documents`, `document_versions`, `document_links`,
+  `audit_events`, `users`).
+- The **organisation** (`organizations` table) is the tenant. Each organisation
+  is an independent operator with its own `vault_settings` (retention years,
+  storage path, optional sibling link configuration).
+- Per-request **organisation resolution** runs in middleware before authorisation
   (mirroring `OrgResolverMiddleware`). Supported modes: **`single`** (default —
-  one organization per install), `path` (`/{org-slug}/…`), `subdomain`, and
-  `custom_domain`. The resolved organization id is held in a request-scoped holder
+  one organisation per install), `path` (`/{org-slug}/…`), `subdomain`, and
+  `custom_domain`. The resolved organisation id is held in a request-scoped holder
   and **every repository query is org-scoped**.
-- Clear issues **no** statutory document numbers (those belong to `nene-invoice`).
-  Import provenance is keyed per organization by `file_hash` + `bank_import_batch_id`.
 
 ### Roles and capabilities
 
 A `Role` enum and a `Capability` enum, resolved per route by a capability
-resolver and enforced by `CapabilityMiddleware` (mirroring NeNe Records):
+resolver and enforced by `CapabilityMiddleware`:
 
 | Role | Scope | Capabilities |
 | --- | --- | --- |
 | **`superadmin`** | Cross-tenant (platform operator) | All, **including `manage_organizations`**. `organization_id` may be `NULL`. |
-| **`admin`** | Single organization | All **except** `manage_organizations` — manages the org's **users**, **Clear settings** (upstream config, bank accounts, dunning defaults), reconciliation, and dunning. |
-| **`member`** | Single organization | Reconciliation operator — import bank CSV, confirm/reverse matches (`manage_reconciliation`), send dunning when granted (`send_dunning`). **Cannot** manage users or settings. |
-| **`viewer`** | Single organization | Read-only (`view_reconciliation`) — matched/unmatched lists, dunning history. Optional; Phase 2+. |
+| **`admin`** | Single organisation | All **except** `manage_organizations` — manages the org's **users**, **vault settings** (retention, storage path, sibling link config), and all document operations. |
+| **`member`** | Single organisation | Upload documents (`upload_document`), edit own metadata (`edit_metadata`). Cannot manage users or settings. |
+| **`viewer`** | Single organisation | Read-only (`view_documents`) — search, download. Optional; Phase 2+. |
 
-Capabilities (reconciliation/dunning-specific; the set differs from NeNe
-Records' content capabilities): `manage_organizations`, `manage_users`,
-`manage_clear_settings`, `manage_reconciliation`, `view_reconciliation`,
-`send_dunning`.
+Capabilities (vault-specific): `manage_organizations`, `manage_users`,
+`manage_vault_settings`, `upload_document`, `edit_metadata`, `void_document`,
+`view_documents`, `export_documents`.
 
-- **Superadmin manages organizations** (`/admin/organizations` — create, list,
-  delete tenants).
-- **Admin manages users** within the organization (`/admin/users`).
+- **Superadmin manages organisations** (`/admin/organizations` — create, list,
+  disable tenants).
+- **Admin manages users** within the organisation (`/admin/users`).
 - Role and capability string values are registered in
   [`../explanation/terminology.md`](../explanation/terminology.md) (binding).
 
 ### Compliance interaction
 
-- Each organization's bank transactions, reconciliation links, client credits,
-  and dunning history are scoped to that organization; cross-tenant reads are
-  prohibited. This does not relax any rule in
-  [`../explanation/accounting-compliance.md`](../explanation/accounting-compliance.md)
-  or [`../explanation/payment-reconciliation-dunning-compliance.md`](../explanation/payment-reconciliation-dunning-compliance.md) —
-  immutability, retention, and audit apply **per organization**.
+Each organisation's documents, versions, links, and audit events are scoped to
+that organisation; cross-tenant reads are prohibited. This does not relax any
+rule in [`../explanation/received-document-compliance.md`](../explanation/received-document-compliance.md)
+— immutability, retention, and audit apply **per organisation**.
 
 ## Consequences
 
@@ -97,29 +85,31 @@ Records' content capabilities): `manage_organizations`, `manage_users`,
 
 - Serves agencies/hosting operators and single SMBs from one codebase; `single`
   mode keeps the simple case simple.
-- Avoids a high-risk tenancy retrofit across compliance-sensitive billing tables.
-- Consistent with the NeNe ecosystem; patterns and reviews transfer.
+- Avoids a high-risk tenancy retrofit across compliance-sensitive document tables.
+- Consistent with the NeNe ecosystem; patterns and reviews transfer from
+  NeNe Records.
 
 **Costs**
 
-- Every repository query must be org-scoped — a standing review item
-  (`docs/review/database.md`, `docs/review/middleware-security.md`).
+- Every repository query must be org-scoped — a standing review item.
 - Auth, org resolution, and RBAC are part of the runtime foundation (Issue #4),
   enlarging it beyond a bare health endpoint.
 
 **Follow-up**
 
-- **PR-B (Issue #4 expanded):** runtime foundation — org resolution + JWT auth +
+- **Issue #4 (expanded):** runtime foundation — org resolution + JWT auth +
   RBAC wiring + `GET /health`.
-- **PR-C+:** organization CRUD (superadmin) and user CRUD (admin).
+- **Issue #4+:** organisation CRUD (superadmin) and user CRUD (admin).
 
 ## Related
 
-- Reference implementation: NeNe Records `src/Organization/`, `src/Auth/` (Role, Capability, CapabilityResolver, CapabilityMiddleware), `src/Organization/Resolution/`
-- Requirements: `docs/explanation/requirements.md`
-- Domain model: `docs/explanation/domain-model.md`
-- Terminology registry: `docs/explanation/terminology.md`
-- Compliance: `docs/explanation/accounting-compliance.md`
-- Issue: `#17`
+- Reference implementation: NeNe Records `src/Organization/`, `src/Auth/`
+  (Role, Capability, CapabilityResolver, CapabilityMiddleware),
+  `src/Organization/Resolution/`
+- Requirements: [`../explanation/requirements.md`](../explanation/requirements.md)
+- Domain model: [`../explanation/domain-model.md`](../explanation/domain-model.md)
+- Terminology: [`../explanation/terminology.md`](../explanation/terminology.md)
+- Compliance: [`../explanation/received-document-compliance.md`](../explanation/received-document-compliance.md)
+- ADR 0009: [`./0009-separate-from-billing-and-reconciliation.md`](./0009-separate-from-billing-and-reconciliation.md)
 - Supersedes: none
 - Superseded by: none

--- a/docs/adr/0014-audit-event-schema.md
+++ b/docs/adr/0014-audit-event-schema.md
@@ -1,0 +1,127 @@
+# ADR 0014: Audit Event Schema — UseCase-Layer Recording with Before/After
+
+## Status
+
+accepted
+
+## Context
+
+`received-document-compliance.md` §3 (真実性の確保 under 電帳法) and §7
+(audit trail) require that every mutating operation on a vault document or vault
+settings record who changed what, including the **before and after state**.
+A tax inspector (税務調査官) or auditor must be able to reconstruct the full
+history of any document.
+
+We need a consistent mechanism that works across all current and future vault
+domains (documents, settings, links) without ad-hoc per-entity logging.
+
+Three implementation layers to consider:
+
+1. **Middleware-level logging** — rejected; middleware sees the HTTP request but
+   not the domain before/after state; cannot name the business action.
+2. **Repository-level logging** — rejected; repositories know the row but not the
+   actor (authentication context) nor the business action name.
+3. **UseCase-level recording via an `AuditRecorder`** (chosen, mirroring NeNe
+   Invoice ADR 0008) — the use case has the actor/tenant context, the
+   before/after entity state, and the business action name. This is the only
+   layer where the mutation is meaningful.
+
+## Decision
+
+A dedicated `audit_events` table records one row per mutating operation.
+
+### Schema
+
+| Column | Type | Meaning |
+| --- | --- | --- |
+| `id` | ULID | Primary key |
+| `organization_id` | UUID | Tenant; NULL only for superadmin system events |
+| `actor_user_id` | UUID nullable | Authenticated user; NULL for system-generated events |
+| `action` | VARCHAR | `{entity}.{verb}` — see §Event types |
+| `entity_type` | VARCHAR | `vault_document` \| `document_version` \| `document_link` \| `vault_settings` |
+| `entity_id` | UUID | ID of the affected entity |
+| `before_json` | JSON nullable | Sanitized snapshot of entity **before** mutation; NULL for create events |
+| `after_json` | JSON nullable | Sanitized snapshot of entity **after** mutation; NULL for delete/void events |
+| `created_at` | TIMESTAMP | When the event was recorded |
+| `source` | VARCHAR | `web_upload` \| `email_inbound` \| `api` \| `scan_upload` \| `system` |
+| `metadata_json` | JSON nullable | Event-specific extra data (e.g. `void_reason`, `export_filter`) |
+
+### Event types (required for MVP)
+
+| Action | entity_type | before_json | after_json | Notes |
+| --- | --- | --- | --- | --- |
+| `document.uploaded` | `vault_document` | NULL | full snapshot | Also records document_version created |
+| `document.metadata_changed` | `vault_document` | snapshot before | snapshot after | Any change to transaction_date, amount_cents, counterparty_name, category, tags |
+| `document.voided` | `vault_document` | active snapshot | voided snapshot | `metadata_json.void_reason` required |
+| `document.restored` | `vault_document` | voided snapshot | restored snapshot | Requires admin capability |
+| `document.version_added` | `document_version` | NULL | version snapshot | Replacement file upload |
+| `document.exported` | `vault_document` | — | — | `metadata_json.export_filter` (date range, counterparty, etc.) |
+| `document.purged` | `vault_document` | final snapshot | NULL | Post-retention; requires §5.4 procedure |
+| `document.link_created` | `document_link` | NULL | link snapshot | Optional Invoice/Clear link added |
+| `document.link_deleted` | `document_link` | link snapshot | NULL | Link removed |
+| `vault_settings.changed` | `vault_settings` | settings before | settings after | Includes retention_years changes |
+
+### Sanitization rules
+
+- `before_json` and `after_json` are produced by the same presenters used for
+  API output — **secrets are never written to the audit log**.
+- File bytes are **never** written to audit events; only metadata and hash.
+- Internal system fields not exposed in the API (DB row IDs used as PKs, etc.)
+  may be included in sanitized snapshots for traceability.
+
+### Recording location
+
+- Recording happens in the **UseCase layer** via `Audit\AuditRecorder`.
+- Use cases receive tenant context and actor from `AuthContext`; they fetch the
+  "before" state before executing the mutation; they pass both to `AuditRecorder`
+  after the mutation commits.
+- Recording is in the **same DB transaction** as the mutation — the audit event
+  row must not be written without the mutation, and vice versa. A transaction
+  boundary wrapping mutation + audit is required from Phase 1.
+
+### Immutability of audit records
+
+- `audit_events` rows **MUST NOT** be updated or deleted by application code
+  after creation.
+- No soft-delete or status column on `audit_events`.
+- Audit records are subject to the same 10-year retention default as the
+  documents they describe (ADR 0004).
+- Database-level permissions: the application user for normal operations has
+  INSERT on `audit_events` but NOT UPDATE or DELETE. Enforcement is at the DB
+  permission layer, not only application code.
+
+## Consequences
+
+**Benefits**
+
+- Satisfies 電帳法 真実性の確保 (訂正削除の履歴方式) and the audit trail
+  requirement from `received-document-compliance.md` §3 and §7.
+- Uniform trail across all vault mutations; auditors and tax inspectors have a
+  single place to check history.
+- Before/after snapshots allow field-level diff without a separate diff table.
+- Transactional consistency: the mutation and its audit record commit together.
+
+**Costs / limitations**
+
+- Every mutating use case gains an `AuditRecorder` dependency and must fetch the
+  "before" state.
+- `audit_events` table grows continuously; no purge until document retention
+  expires (§5.4).
+- Snapshot JSON size grows with entity complexity — avoid embedding large blobs.
+
+**Follow-up**
+
+- Implement `Audit\AuditRecorder` in Phase 1 runtime (Issue #4+).
+- Add `GET /admin/vault/documents/{id}/history` and
+  `GET /admin/audit-events` (admin/superadmin) in Phase 1.
+- Wrap mutation + audit in a single DB transaction from Phase 1 (not a follow-up
+  retrofit — this is a Phase 1 requirement).
+
+## Related
+
+- Compliance: [`../explanation/received-document-compliance.md`](../explanation/received-document-compliance.md) §3, §7
+- Domain model: [`../explanation/domain-model.md`](../explanation/domain-model.md)
+- Requirements: [`../explanation/requirements.md`](../explanation/requirements.md) §4 (history endpoint)
+- Reference: NeNe Invoice ADR 0008 (same pattern)
+- Supersedes: none
+- Superseded by: none

--- a/docs/development/adr.md
+++ b/docs/development/adr.md
@@ -1,0 +1,56 @@
+# ADR Operation Guide
+
+Inherited from [NENE2](https://github.com/hideyukiMORI/NENE2/blob/main/docs/development/adr.md). Use ADRs for decisions that affect architecture, public contracts, compliance, dependency choices, or long-term maintenance.
+
+## When to write an ADR
+
+Write an ADR when:
+
+- A decision affects the **public API contract** (endpoints, schemas, error types)
+- A decision touches **compliance** (電帳法 rules, retention, integrity method)
+- A decision affects **long-term maintenance** (storage adapter, auth method, DB choice)
+- A decision involves a **rejected alternative** worth recording
+- A future developer or AI agent would otherwise wonder "why was this done this way?"
+
+Do **not** write an ADR for:
+
+- Trivial implementation choices that follow existing patterns
+- Decisions already captured in `received-document-compliance.md` or `scope-contract.md`
+- Bugs or minor fixes
+
+## File naming
+
+```text
+docs/adr/NNNN-kebab-title.md
+```
+
+Sequence: next available 4-digit zero-padded number. Current max: 0014.
+
+## Template
+
+Use `docs/adr/0000-template.md`. Required sections:
+
+- **Status:** `proposed` | `accepted` | `rejected` | `superseded`
+- **Context:** problem, constraints, trade-offs
+- **Decision:** the choice, in clear direct language
+- **Consequences:** benefits, costs, follow-up work
+
+Optional: **Related** (links to other ADRs, compliance docs, Issues).
+
+## Compliance ADRs
+
+Any ADR that deviates from `docs/explanation/received-document-compliance.md` requires:
+
+1. Professional sign-off by a licensed 税理士 or 公認会計士, recorded in the ADR.
+2. The sign-off must include the professional's name, credential, and date.
+3. No merge without the sign-off.
+
+## Status lifecycle
+
+```
+proposed → accepted
+         → rejected
+         → superseded (by ADR NNNN)
+```
+
+When superseding an ADR, update the superseded ADR's status to `superseded by: ADR NNNN`.

--- a/docs/development/backend-standards.md
+++ b/docs/development/backend-standards.md
@@ -1,0 +1,156 @@
+# Backend Standards
+
+NeNe Vault backend policy for PHP API code. Adapted from NeNe Invoice backend standards for a **received-document archive** on NENE2.
+
+**Framework baseline:** NENE2 `docs/development/` — deviate only via local ADR.
+
+**Naming and terms:** [`naming-conventions.md`](./naming-conventions.md), [`glossary.md`](../explanation/glossary.md).
+
+**Compliance (binding):** [`../explanation/received-document-compliance.md`](../explanation/received-document-compliance.md) — run [`../review/compliance.md`](../review/compliance.md) for any change in this area.
+
+---
+
+## 1. Project shape
+
+NeNe Vault is a **NENE2 consumer project**:
+
+```
+vendor/hideyukimori/nene2/   ← framework (do not edit)
+src/                         ← product code (NeneVault\)
+tests/                       ← mirrors src/
+docs/openapi/openapi.yaml    ← public contract
+public_html/index.php        ← front controller
+```
+
+Namespace: `NeneVault\`
+
+---
+
+## 2. Module layout (domain-grouped)
+
+Organize by **domain concept**, not technical layer:
+
+```
+src/
+  ApplicationServiceProvider.php
+  Http/                      # PSR-7/15 helpers (thin wrappers if needed)
+  Organization/              # tenants + per-request resolution (Organization/Resolution/)
+  Auth/                      # JWT login, Role / Capability, CapabilityMiddleware
+  User/                      # operator accounts within an organization
+  VaultSettings/             # retention_years, storage_path, sibling link config
+  Document/                  # vault_document CRUD, upload, void/restore, search
+  DocumentVersion/           # file storage, version creation, SHA-256 hash verification
+  DocumentLink/              # optional HTTP reference links to Invoice/Clear
+  Audit/                     # AuditRecorder, audit_events write; history read
+  Export/                    # manifest CSV + ZIP export
+  Integration/
+    SiblingLink/             # optional HTTP clients for Invoice/Clear link validation
+```
+
+**Zero-tolerance placement:** handlers live in their domain folder (`Document/UploadDocumentHandler.php`), not `src/Handlers/`.
+
+---
+
+## 3. Layering rules
+
+```
+Handler → UseCase → RepositoryInterface → PdoRepository
+```
+
+| Layer | May | Must not |
+| --- | --- | --- |
+| **Handler** | Parse HTTP request, build DTO, call UseCase, map JSON response | SQL, business rules, file I/O, direct audit writes |
+| **UseCase** | Business rules, file hash computation, orchestration, call AuditRecorder | `$_SERVER`, PDO, raw HTTP, direct file storage |
+| **Repository** | SQL / persistence; file metadata lookups | HTTP, file I/O (delegate to `DocumentStorageInterface`) |
+| **DocumentStorageInterface** | File I/O, path computation, hash verification | Business rules, audit |
+| **AuditRecorder** | Write `audit_events` in same DB transaction as mutation | Business rules |
+
+Use `final readonly` classes and `declare(strict_types=1);` in every PHP file.
+
+---
+
+## 4. HTTP and OpenAPI
+
+- Every public route appears in `docs/openapi/openapi.yaml` with a stable `operationId`.
+- Success and Problem Details error shapes documented.
+- RFC 9457 Problem Details for errors; base URL `https://nene-vault.dev/problems/`.
+- Admin routes require JWT Bearer auth (Phase 1+).
+- Authenticated file download endpoint — never direct public URL to storage path.
+
+---
+
+## 5. Files, storage, and integrity
+
+> **Compliance is binding (non-negotiable).** All file storage, hash verification,
+> void/version, and retention behavior **MUST** comply with
+> [`../explanation/received-document-compliance.md`](../explanation/received-document-compliance.md).
+> Where compliance conflicts with convenience, compliance wins. Deviations
+> require an ADR with professional sign-off. Run
+> [`../review/compliance.md`](../review/compliance.md) for any change in this area.
+
+- Store files via `DocumentStorageInterface`. The local filesystem adapter is Phase 1–3; S3 adapter is Phase 4+ (ADR 0012).
+- Storage path: `{NENE_VAULT_STORAGE_PATH}/vault/{organization_id}/{document_id}/v{version_number}/{sanitized_filename}` (ADR 0012). Path **MUST NOT** appear in API responses.
+- Compute SHA-256 at upload. Verify SHA-256 on every download. Hash mismatch = P0 defect.
+- MIME allowlist: `application/pdf`, `image/jpeg`, `image/png`. Reject others with `415 Unsupported Media Type`.
+- Max file size: configurable per org via `vault_settings`; default 20 MB.
+- **No byte overwrites** — replacement creates a new `document_version`.
+- Duplicate detection: same `file_sha256` within `organization_id` → warn operator before accepting.
+
+---
+
+## 6. Money and date
+
+- `amount_cents`: **nullable integer** in JPY. `null` = document carries no monetary value. Float/DECIMAL prohibited.
+- `transaction_date` (DATE) is distinct from `uploaded_at` (TIMESTAMP). Do not conflate.
+- `retention_expires_at` = `transaction_date + retention_years` (computed at upload; see ADR 0004).
+- Default `retention_years = 10` (not 7 — see ADR 0004).
+
+---
+
+## 7. Audit trail
+
+> See ADR 0014 for schema and full rules.
+
+- Every mutating UseCase **MUST** call `Audit\AuditRecorder` in the **same DB transaction** as the mutation.
+- Capture "before" state before the mutation; "after" state after.
+- `audit_events` rows: INSERT only — no UPDATE or DELETE in application code.
+- DB user has INSERT on `audit_events`, NOT UPDATE or DELETE.
+
+---
+
+## 8. Multi-tenancy
+
+- Every repository query on a tenant-scoped table **MUST** include `organization_id`.
+- `OrgResolverMiddleware` runs before authorization; resolved org id is in request-scoped context.
+- Cross-tenant reads are prohibited — only superadmin (`organization_id = NULL`) operates cross-tenant.
+- Missing `organization_id` in a query is a P0 security defect.
+
+---
+
+## 9. Database
+
+- Phinx migrations under `database/migrations/`.
+- Schema snapshots under `database/schema/`.
+- Soft delete: `status = 'voided'` + `voided_at` (not `is_deleted`) for `vault_documents`. Full hard delete is prohibited during retention window.
+- `audit_events`: append-only, no soft delete column.
+
+---
+
+## 10. Testing
+
+- UseCase tests: no DB — inject repository fakes or in-memory implementations.
+- Repository tests: real SQL against test database (PDO adapter with SQLite in-memory for speed; MySQL for integration).
+- HTTP/contract tests: assert against OpenAPI shapes.
+- Compliance-critical tests (retention, audit, hash): treat failures as P0 — must never be skipped.
+
+---
+
+## 11. Verification
+
+```bash
+composer check
+composer openapi
+composer mcp
+```
+
+Self-review checklists: [`docs/review/compliance.md`](../review/compliance.md), [`docs/review/backend-api.md`](../review/backend-api.md), [`docs/review/database.md`](../review/database.md).

--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -1,0 +1,115 @@
+# Coding Standards
+
+NeNe Vault inherits the NENE2 coding standards. This document is the local override and extension list for received-document archive specifics.
+
+**Framework baseline:** [NENE2 `docs/development/coding-standards.md`](https://github.com/hideyukiMORI/NENE2/blob/main/docs/development/coding-standards.md). Follow all NENE2 rules unless this document says otherwise.
+
+---
+
+## PHP Baseline (inherited from NENE2)
+
+- Target PHP `>=8.4.1 <9.0`.
+- Every PHP file: `declare(strict_types=1);`
+- Follow PSR-12 unless a narrower project rule says otherwise.
+- No large file-level copyright or project banners.
+- Prefer immutable value objects and `readonly` properties where they clarify intent.
+- Use native types, enums, and small DTOs instead of unstructured arrays at boundaries.
+- Avoid framework magic that hides control flow from tests, static analysis, or AI tools.
+
+## Architecture (inherited from NENE2)
+
+```
+Handler → UseCase → RepositoryInterface → PdoRepository
+```
+
+- Use cases are independent from HTTP, database, templates, and frontend.
+- Depend on interfaces at infrastructure boundaries.
+- Constructor injection for all required dependencies.
+- Typed config objects at runtime — never pass raw arrays through the application.
+- Readonly DTOs or command objects for use case input boundaries.
+- `getenv()`, `$_ENV`, `$_SERVER` only inside the config loading boundary (`src/Config/`).
+- PSR-11 as the container boundary; PSR-3 as the logging boundary.
+- Explicit factories and service providers over autowiring.
+- No container as a service locator inside domain or use-case code.
+- Handlers stay thin: parse input → call use case → return response.
+- Persistence details stay inside repositories.
+
+## HTTP Runtime (inherited from NENE2)
+
+- PSR-7 for request/response, PSR-15 for middleware, PSR-17 for factories.
+- Routing is explicit and readable.
+- Middleware order is explicit and documented.
+- Front controller: `public_html/index.php`.
+- CORS, security headers, request id, and request size limits are API baseline middleware.
+
+## Error Handling (inherited from NENE2)
+
+- RFC 9457 Problem Details for public JSON API errors (`application/problem+json`).
+- Problem Details base URL: `https://nene-vault.dev/problems/`
+- Validation failures: `validation-failed` Problem Details with structured `errors` array.
+- No stack traces, SQL, file paths, secrets, or private identifiers in public error responses.
+- Named domain exceptions for business invariant violations.
+- Map domain exceptions to Problem Details at the HTTP error boundary — not inside use cases.
+
+## NeNe Vault–specific rules
+
+### Compliance is non-negotiable
+
+Any change that touches **document storage, file serving, search, metadata editing, audit logging, retention, void/restore, or export** MUST be reviewed against `docs/explanation/received-document-compliance.md` and `docs/review/compliance.md`. Deviations require an ADR with professional sign-off.
+
+### File integrity
+
+- File bytes **MUST NOT** be overwritten or deleted without the retention-expiry procedure.
+- SHA-256 hash **MUST** be computed at upload and verified at every download.
+- If hash verification fails on download, it is a P0 defect — return `500`, log, alert.
+
+### Money
+
+- `amount_cents`: **nullable integer** in JPY. `null` means the document carries no monetary value.
+- **Float and DECIMAL for money are prohibited** in DB, API JSON, and tests.
+- Do not require `amount_cents` for document creation.
+
+### Audit trail
+
+- Every mutating use case **MUST** call `AuditRecorder` in the **same DB transaction** as the mutation.
+- Before-state **MUST** be captured before the mutation; after-state after.
+- `audit_events` rows are never updated or deleted by application code.
+
+### Organization scoping
+
+- Every repository query on a tenant-scoped table **MUST** include `organization_id` in the WHERE clause.
+- Cross-tenant reads are prohibited — only superadmin operates cross-tenant.
+- Forgetting `organization_id` in a query is a P0 security defect.
+
+### File serving
+
+- File bytes are served via an authenticated download endpoint — never via a direct public URL to the storage path.
+- The storage path layout (`{org_id}/{document_id}/v{version}/…`) **MUST NOT** be exposed in API responses.
+
+## Testing
+
+- Use case tests: no database — inject repository fakes or in-memory implementations.
+- Repository tests: real SQL against test database (PDO SQLite in-memory for unit speed; MySQL for integration).
+- HTTP tests: contract tests against OpenAPI shapes.
+- File integrity tests: verify hash computation, duplicate detection, and hash mismatch detection.
+- Retention tests: verify purge is blocked before `retention_expires_at`.
+- Audit tests: verify every mutating use case produces the expected `audit_event`.
+
+## Static Analysis and Formatting
+
+```bash
+composer check          # test + analyse + cs
+composer test
+composer analyse        # PHPStan level 8
+composer cs             # PHP-CS-Fixer dry run
+composer cs:fix         # PHP-CS-Fixer apply
+```
+
+PHPStan level: **8** minimum.
+
+## AI Readability
+
+- Name files and classes after their role.
+- Keep functions short enough to inspect without jumping through many layers.
+- Explicit return types and simple data shapes.
+- Record architecture decisions in `docs/adr/` when they affect future implementation.

--- a/docs/development/commit-conventions.md
+++ b/docs/development/commit-conventions.md
@@ -1,0 +1,60 @@
+# Commit Message Conventions
+
+Inherited from [NENE2](https://github.com/hideyukiMORI/NENE2/blob/main/docs/development/commit-conventions.md). Uses Conventional Commits.
+
+## Format
+
+```text
+<type>(<optional scope>): <description> (#<issue>)
+
+[optional body]
+
+[optional footer]
+```
+
+## Language
+
+- Keep `type`, `scope`, `BREAKING CHANGE`, and other Conventional Commits keywords in English.
+- Write the description and body in Japanese or English (Japanese preferred for maintainer commits; English for contributions expecting international review).
+- Include the related GitHub Issue number in the subject when practical.
+
+Example:
+
+```text
+docs(governance): NENE2 準拠のコーディング規約を追加する (#3)
+```
+
+## Types
+
+| Type | Use |
+| --- | --- |
+| `feat` | New feature |
+| `fix` | Bug fix |
+| `docs` | Documentation only |
+| `refactor` | Code change without feature or bug fix |
+| `test` | Test additions or changes |
+| `build` | Dependency or build setup |
+| `ci` | CI configuration |
+| `chore` | Maintenance |
+
+## Body
+
+Use the body when the reason is not obvious from the subject. Explain why the change exists, what trade-off was chosen, and whether follow-up work remains.
+
+## Breaking Changes
+
+Use `!` or a `BREAKING CHANGE:` footer when public API, configuration, CLI, or documented behavior changes incompatibly.
+
+## Scope examples (vault-specific)
+
+| Scope | What it covers |
+| --- | --- |
+| `governance` | ADRs, compliance docs, scope-contract |
+| `document` | vault_document domain |
+| `retention` | Retention policy, ADR 0004 |
+| `audit` | audit_event schema, ADR 0014 |
+| `auth` | JWT, roles, capabilities |
+| `storage` | File storage, document_version |
+| `export` | Manifest CSV, ZIP export |
+| `openapi` | OpenAPI contract |
+| `migration` | Database migrations |

--- a/docs/development/frontend-standards.md
+++ b/docs/development/frontend-standards.md
@@ -1,0 +1,39 @@
+# Frontend Standards
+
+**Status: Phase 2 — not yet implemented.**
+
+This document will define the React + TypeScript admin UI standards for NeNe Vault when Phase 2 begins. Until then, this file is a placeholder and no frontend code should be added.
+
+## Framework
+
+- React + TypeScript (strict mode)
+- Vite for local development and production builds
+- npm as the official package manager; Active Node.js LTS
+- ESLint + Prettier for linting and formatting
+
+## Locale
+
+- UI locale: **ja (primary) + en (secondary) only** (ADR 0005)
+- Default language: `ja` (fallback when `Accept-Language` does not match `en`)
+- Language selector in admin UI: toggle ja / en
+- Statutory field labels (取引年月日, 取引金額, 取引先) appear in Japanese in both locales
+
+## Planned Phase 2 content
+
+- Component structure and folder layout
+- API client wrapper (maps snake_case JSON from backend)
+- State management approach
+- Admin route structure
+- PDF inline viewer for received documents
+- File upload wizard with metadata form
+- Search form (date range, amount range, counterparty)
+- Audit history view
+
+## Commands (Phase 2+)
+
+```bash
+npm install --prefix frontend
+npm run dev --prefix frontend
+npm run build --prefix frontend
+npm run check --prefix frontend
+```

--- a/docs/development/naming-conventions.md
+++ b/docs/development/naming-conventions.md
@@ -1,0 +1,258 @@
+# Naming Conventions
+
+Authoritative naming rules for NeNe Vault code, API contracts, database objects, tests, and documentation.
+
+> **Absolute adherence — non-negotiable.** These rules are **MUST**, not
+> suggestions. A name that violates a rule here, or a spelling variant of a
+> registered term, is a defect and **blocks merge**. There is no "close enough."
+> When in doubt, match the registry exactly.
+>
+> The canonical spelling of every term and identifier lives in the **single
+> source of truth**: [`../explanation/terminology.md`](../explanation/terminology.md).
+> This document defines the *patterns*; the registry defines the *exact strings*.
+> Introducing or renaming any identifier **MUST** update the registry in the same PR.
+
+**Terminology registry:** [`docs/explanation/terminology.md`](../explanation/terminology.md)
+**Glossary (meanings):** [`docs/explanation/glossary.md`](../explanation/glossary.md)
+**Framework baseline:** NENE2 [`domain-layer.md`](https://github.com/hideyukiMORI/NENE2/blob/main/docs/development/domain-layer.md) and [`database-migrations.md`](https://github.com/hideyukiMORI/NENE2/blob/main/docs/development/database-migrations.md).
+
+---
+
+## 1. PHP
+
+### Files and namespaces
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| Namespace root | `NeneVault\` | `NeneVault\Document\UploadDocumentHandler` |
+| Domain folder | PascalCase singular domain name | `src/Document/`, `src/Audit/` |
+| File name | Match the primary class | `UploadDocumentHandler.php` |
+| One public class per file | Required | — |
+
+### Classes and interfaces
+
+| Role | Pattern | Example |
+| --- | --- | --- |
+| HTTP handler | `{Verb}{Noun}Handler` | `UploadDocumentHandler`, `SearchDocumentsHandler` |
+| Use case interface | `{Verb}{Noun}UseCaseInterface` | `UploadDocumentUseCaseInterface` |
+| Use case impl | `{Verb}{Noun}UseCase` | `UploadDocumentUseCase` |
+| Use case method | Always `execute` | `execute(UploadDocumentInput $input): UploadDocumentOutput` |
+| Input DTO | `{Verb}{Noun}Input` | `UploadDocumentInput` |
+| Output DTO | `{Verb}{Noun}Output` | `UploadDocumentOutput` |
+| Domain entity | Singular noun, no suffix | `VaultDocument`, `DocumentVersion`, `AuditEvent` |
+| Repository interface | `{Entity}RepositoryInterface` | `VaultDocumentRepositoryInterface` |
+| PDO repository | `Pdo{Entity}Repository` | `PdoVaultDocumentRepository` |
+| Storage adapter | `{Backend}{Purpose}Storage` in `DocumentVersion/` | `LocalFilesystemDocumentStorage` |
+| Storage interface | `DocumentStorageInterface` | — |
+| Audit recorder | `AuditRecorder` in `Audit/` | — |
+| Domain exception | `{Entity}{Reason}Exception` | `VaultDocumentNotFoundException`, `RetentionWindowActiveException` |
+| Service provider | `{Purpose}ServiceProvider` | `RuntimeServiceProvider`, `DocumentServiceProvider` |
+
+All application classes: `final` and `readonly` where applicable. Every PHP file: `declare(strict_types=1);`.
+
+### Modules (`src/`)
+
+Use only domain-grouped top-level folders. Do not add layer folders (`Handlers/`, `Repositories/`, `UseCases/`).
+
+Planned domains: `Organization/`, `Auth/`, `User/`, `VaultSettings/`, `Document/`, `DocumentVersion/`, `DocumentLink/`, `Audit/`, `Export/`, `Integration/SiblingLink/`, `Http/`.
+
+### Methods and properties
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| Methods | camelCase | `findById`, `voidDocument`, `computeRetentionExpiry` |
+| Properties | camelCase | `$vaultDocumentId`, `$auditRecorder` |
+| Constants | UPPER_SNAKE_CASE | `MAX_FILE_SIZE_BYTES`, `SHA256_HEX_LENGTH` |
+
+Repository methods use **domain verbs**: `findById`, `save`, `void`, `search` — not `selectById`, `insertRow`.
+
+---
+
+## 2. HTTP routes and OpenAPI
+
+### URL paths
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| Path segments | lowercase **kebab-case** | `/admin/vault/documents`, `/admin/vault/settings` |
+| Collection paths | plural noun | `/admin/vault/documents` |
+| Single resource | `{id}` path param | `/admin/vault/documents/{id}` |
+| Sub-resources | nested noun | `/admin/vault/documents/{id}/history`, `/admin/vault/documents/{id}/versions` |
+| File download | noun path | `/admin/vault/documents/{id}/versions/{versionId}/download` |
+| Health | `GET /health` | unauthenticated |
+
+Admin mutating routes live under `/admin/…`.
+
+### operationId
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| Case | camelCase | `uploadDocument`, `searchDocuments`, `voidDocument` |
+| Shape | `{verb}{Resource}` or `{verb}{Resource}ById` | `listDocuments`, `getDocumentById` |
+| Stability | Never rename after release; deprecate instead | — |
+
+Must match between `docs/openapi/openapi.yaml`, route registration, and `docs/mcp/tools.json`.
+
+### OpenAPI schema names
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| Response schema | `{Resource}Response` | `VaultDocumentResponse` |
+| List response | `{Resource}ListResponse` | `VaultDocumentListResponse` |
+| Create/upload request | `Upload{Resource}Request` | `UploadDocumentRequest` |
+| Patch request | `Update{Resource}MetadataRequest` | `UpdateDocumentMetadataRequest` |
+| Tag names | PascalCase singular group | `System`, `Admin`, `Document`, `Audit`, `Export` |
+
+Public OpenAPI summaries, descriptions, and examples: **English only**.
+
+---
+
+## 3. JSON (request and response bodies)
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| Property names | **snake_case** | `transaction_date`, `amount_cents`, `counterparty_name` |
+| Money amounts | nullable integer **cents** | `amount_cents` (null if no amount) |
+| Booleans | `is_` / `has_` prefix | `is_metadata_confirmed`, `date_uncertain` |
+| Timestamps | `_at` suffix, ISO 8601 string | `uploaded_at`, `voided_at`, `retention_expires_at` |
+| Dates | `_date` suffix, ISO 8601 date string | `transaction_date` |
+| Foreign keys | `{entity}_id` | `organization_id`, `vault_document_id` |
+| Status enum | `status` field | `"active"`, `"voided"` |
+| Source enum | `source` field | `"web_upload"`, `"email_inbound"`, `"api"`, `"scan_upload"` |
+| List envelope | `items`, `limit`, `offset` | Same as NENE2 list pattern |
+| File hash | `file_sha256` | 64-char hex string |
+
+Do not mix camelCase in public JSON. Do not use floats for money. Do not expose storage paths.
+
+---
+
+## 4. Problem Details and validation errors
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| Base URL | `https://nene-vault.dev/problems/` | — |
+| Type slug | kebab-case | `validation-failed`, `document-not-found`, `retention-window-active` |
+| Validation `errors[].field` | snake_case path | `body.transaction_date`, `body.amount_cents` |
+| Validation `errors[].code` | snake_case | `required`, `invalid_date_format`, `mime_type_not_allowed` |
+
+Problem Details `title` and `detail`: English.
+
+---
+
+## 5. Database
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| Table names | snake_case, **plural** | `vault_documents`, `document_versions`, `document_links`, `audit_events`, `vault_settings` |
+| Column names | snake_case | `transaction_date`, `amount_cents`, `file_sha256` |
+| Money columns | `*_cents` suffix, nullable integer | `amount_cents` |
+| Hash columns | `*_sha256` suffix, `VARCHAR(64)` | `file_sha256` |
+| Primary key | `id` | ULID stored as CHAR(26) or UUID CHAR(36) |
+| Foreign key column | `{singular_entity}_id` | `vault_document_id`, `organization_id` |
+| Status column | `status` ENUM | `'active'`, `'voided'` |
+| Soft void | `voided_at`, `voided_by`, `void_reason` | — |
+| Retention | `retention_years INT`, `retention_expires_at DATE` | — |
+| Index names | `idx_{table}_{columns}` | `idx_vault_documents_org_date` |
+| Unique constraints | `uniq_{table}_{columns}` | `uniq_document_versions_doc_version` |
+| Audit table | `audit_events` | Append-only; no soft delete column |
+
+SQL lives only in `Pdo*Repository` and `LocalFilesystemDocumentStorage` classes.
+
+### Migrations
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| File name | `YYYYMMDDHHMMSS_snake_description.php` | `20260601120000_create_vault_documents_table.php` |
+| Snapshot file | `database/schema/{table}.sql` | `database/schema/vault_documents.sql` |
+
+---
+
+## 6. Environment variables
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| Names | UPPER_SNAKE_CASE | `DB_HOST`, `NENE_VAULT_STORAGE_PATH` |
+| Vault prefix | `NENE_VAULT_` for vault-specific | `NENE_VAULT_STORAGE_PATH`, `NENE_VAULT_PORT` |
+| Secrets | Never commit; document in `.env.example` only | `NENE_VAULT_JWT_SECRET` |
+
+---
+
+## 7. Tests
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| Test class | `{ClassUnderTest}Test` | `UploadDocumentUseCaseTest` |
+| Test method | `test_{behavior}_when_{condition}` | `test_rejects_upload_when_mime_type_not_allowed` |
+| Test namespace | Mirror `src/` under `tests/` | `tests/Document/UploadDocumentUseCaseTest.php` |
+| In-memory repo | `InMemory{Entity}Repository` in `tests/` | `InMemoryVaultDocumentRepository` |
+
+Compliance-critical tests (retention block, hash verification, audit write, org scoping) must never be skipped.
+
+---
+
+## 8. MCP tools
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| Tool `name` | Same as OpenAPI `operationId` | `searchDocuments`, `getDocumentById` |
+| Tool `title` | Short English Title Case | `Search Documents`, `Get Document` |
+| `safety` | `read` or `write` | `read` for search/get; `write` for upload/void |
+
+Catalog: `docs/mcp/tools.json`. Phase 4+ (read tools first per roadmap).
+
+---
+
+## 9. Frontend (Phase 2+)
+
+| Item | Rule |
+| --- | --- |
+| Components | PascalCase file and export |
+| Hooks | camelCase with `use` prefix |
+| API client | Maps snake_case JSON; do not rename API fields in transit |
+| Admin SPA | React + TypeScript strict mode |
+| Locale keys | snake_case; `ja` primary, `en` secondary (ADR 0005) |
+
+Full frontend standards: `docs/development/frontend-standards.md` (Phase 2).
+
+---
+
+## 10. Documentation and commits
+
+| Surface | Language | Naming |
+| --- | --- | --- |
+| Public docs, OpenAPI, API errors | English | Use glossary canonical terms |
+| Issues, PRs, commit bodies | Japanese allowed | Prefer glossary English term on first mention |
+| Commit subject | Conventional Commits + `(#issue)` | See [`commit-conventions.md`](./commit-conventions.md) |
+| ADR file | `NNNN-kebab-title.md` | `0004-retention-period-calculation.md` |
+
+When adding or renaming any identifier, update [`terminology.md`](../explanation/terminology.md) in the same PR; if it is a product concept, also update [`glossary.md`](../explanation/glossary.md).
+
+---
+
+## 11. Prohibited patterns
+
+- **Typos or spelling variants of any term registered in `terminology.md`** — blocks merge
+- **Unregistered identifiers** — using an entity, status, field, slug, or `operationId` not in `terminology.md` without adding it in the same PR
+- Layer-first folders (`src/Handlers/`, `src/Repositories/`, `src/UseCases/`)
+- SQL outside `Pdo*Repository` classes
+- File I/O outside `DocumentStorageInterface` implementations
+- camelCase in public JSON property names
+- Float or DECIMAL for money
+- Exposing storage paths in API responses
+- Renaming shipped `operationId` values
+- Embedding file storage logic in repository classes
+- Hard deleting documents during the retention window
+- Writing audit events outside `AuditRecorder`
+- Skipping org scoping on tenant-scoped queries
+
+---
+
+## Verification
+
+```bash
+composer check
+composer openapi
+composer mcp
+```
+
+Review checklists: [`docs/review/`](../review/).

--- a/docs/development/self-review.md
+++ b/docs/development/self-review.md
@@ -1,0 +1,41 @@
+# Self-Review Checklist Policy
+
+NeNe Vault uses self-review checklists before push or PR, inherited from [NENE2](https://github.com/hideyukiMORI/NENE2/blob/main/docs/development/self-review.md).
+
+## How to use
+
+1. Identify the work type.
+2. Open the matching checklist in `docs/review/`.
+3. Review every applicable item.
+4. Run the narrowest useful verification.
+5. Mention the checklist(s) used in the PR body.
+
+Example:
+
+```text
+Self-review: compliance, backend-api, database
+```
+
+If an item is not applicable, mark it mentally as `N/A`. Do not delete checklist items to pass review.
+
+## Checklist files
+
+| File | Use for |
+| --- | --- |
+| `compliance.md` | **Binding.** Any change touching document storage, file serving, search, metadata, audit, retention, void/restore, or export |
+| `backend-api.md` | Endpoints, handlers, validation, HTTP behavior |
+| `openapi-contract.md` | OpenAPI schemas, examples, contract tests |
+| `database.md` | Migrations, repositories, soft delete, audit_events |
+| `middleware-security.md` | Auth, JWT, CORS, org scoping, rate limits |
+| `docs-policy.md` | Workflow, ADRs, roadmap, Cursor rules |
+| `frontend.md` | **Phase 2 — not in repo yet.** Admin React/TypeScript |
+
+Do **not** use `frontend.md` until Phase 2 creates `frontend/`. Until then, skip that checklist or mark `N/A`.
+
+## AI agents
+
+Pick relevant checklists before finalizing changes. Do not claim an item passed if it was not checked.
+
+The **compliance checklist is binding** — any change in its scope without a compliance review is a P0 defect.
+
+If no checklist matches, use `docs/workflow.md`, `docs/development/coding-standards.md`, and `docs/inheritance-from-nene2.md` directly.

--- a/docs/explanation/domain-model.md
+++ b/docs/explanation/domain-model.md
@@ -1,25 +1,229 @@
 # Domain Model
 
-NeNe Vault entities (MVP). All tenant-scoped tables include `organization_id`.
+NeNe Vault entities and rules — all tenant-scoped. See also:
+[`requirements.md`](./requirements.md), [`terminology.md`](./terminology.md),
+[`received-document-compliance.md`](./received-document-compliance.md).
+
+---
+
+## Entity relationship (MVP)
+
+```
+organization ──────────────────────────────────────── 1
+    │
+    ├─── vault_settings (1 per org)
+    │
+    ├─── users (many)
+    │
+    └─── vault_documents (many)
+             │
+             ├─── document_versions (many; 1..n, immutable)
+             │         ┌────────────────────────────────────┐
+             │         │  version_number monotonic per doc  │
+             │         │  file_sha256, mime_type, path      │
+             │         └────────────────────────────────────┘
+             │
+             ├─── document_links (0..many; optional)
+             │         ┌────────────────────────────────────┐
+             │         │  sibling_product, entity_type,     │
+             │         │  entity_id (HTTP reference only)   │
+             │         └────────────────────────────────────┘
+             │
+             └─── audit_events (many; append-only)
+                       ┌────────────────────────────────────┐
+                       │  action, actor, before_json,       │
+                       │  after_json, created_at            │
+                       └────────────────────────────────────┘
+```
+
+All tenant-scoped tables carry `organization_id`. Cross-tenant reads are
+prohibited; see [ADR 0006](../adr/0006-multi-tenancy-and-roles.md).
+
+---
 
 ## vault_document
 
-Logical document. Points to current `document_version_id`. Metadata fields:
-`transaction_date`, `amount_cents` (nullable), `counterparty_name`, `category`, `tags`.
+Logical document — the stable identity for one received business document
+regardless of how many versions have been uploaded.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `id` | ULID | Primary key |
+| `organization_id` | UUID | Tenant scope |
+| `current_version_id` | UUID | FK → document_version (latest) |
+| `transaction_date` | DATE nullable | 取引年月日 from the received document |
+| `amount_cents` | INT nullable | Amount in integer JPY; null if document carries no amount |
+| `counterparty_name` | VARCHAR | 取引先名; required for search; free text |
+| `category` | ENUM | `invoice_received` \| `contract` \| `receipt` \| `delivery_note` \| `other` |
+| `tags` | JSON | Free-form tag array |
+| `status` | ENUM | `active` \| `voided` — see state machine below |
+| `voided_at` | TIMESTAMP nullable | Set when voided |
+| `voided_by` | UUID nullable | FK → user |
+| `void_reason` | VARCHAR nullable | Required when voided |
+| `void_note` | TEXT nullable | Optional extended context |
+| `date_uncertain` | BOOLEAN | True when transaction_date is null or OCR-unconfirmed |
+| `is_metadata_confirmed` | BOOLEAN | True when operator has confirmed all key metadata fields |
+| `retention_years` | INT | Copied from vault_settings at upload time; immutable after creation |
+| `retention_expires_at` | DATE | Computed: transaction_date (or uploaded_at) + retention_years |
+| `suggested_transaction_date` | DATE nullable | OCR suggestion (Phase 4+); not authoritative until confirmed |
+| `suggested_amount_cents` | INT nullable | OCR suggestion (Phase 4+) |
+| `suggested_counterparty_name` | VARCHAR nullable | OCR suggestion (Phase 4+) |
+| `uploaded_at` | TIMESTAMP | When the first version was created (system receipt) |
+| `uploaded_by` | UUID | FK → user (original uploader) |
+
+### vault_document state machine
+
+```
+                         ┌──────────────────┐
+                         │   (upload)       │
+                         ▼                  │
+                    ┌─────────┐             │ version_added
+                    │ active  │─────────────┘ (new document_version created;
+                    └────┬────┘               current_version_id updated)
+                         │
+                         │ void (reason required)
+                         ▼
+                    ┌─────────┐
+                    │ voided  │◄────────────────────────────────────────┐
+                    └────┬────┘                                         │
+                         │                                              │
+                         │ restore (admin only, audit event required)   │
+                         └─────────────────────────────────────────────┘
+```
+
+**Rules:**
+
+- A document enters `active` immediately upon successful upload.
+- `active` documents are editable for metadata (transaction_date, amount_cents,
+  counterparty_name, category, tags) with an audit trail on every change.
+- `active` documents may receive new file versions (`version_added`); each new
+  version becomes `current_version_id`.
+- Any status → `voided`: requires `void_reason`; records `document.voided` audit
+  event. Void is **not** hard delete. The document remains in the DB.
+- `voided` → `active`: requires `admin` capability; records `document.restored`.
+- There is **no draft state** — an upload IS the document creation. Partial or
+  failed uploads must not create a `vault_document` row.
+- `voided` documents are excluded from default search results but accessible via
+  `include_voided=true` parameter.
+- Purge (`document.purged`) is only valid when `status = voided` AND
+  `retention_expires_at <= now()` AND admin has completed the export procedure
+  (ADR 0004 §5.4).
+
+---
 
 ## document_version
 
-Immutable file storage reference: `file_path`, `file_sha256`, `mime_type`, `original_filename`, `version_number`.
+Immutable file record. One vault_document has 1..n versions. Prior versions
+are permanently accessible.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `id` | ULID | Primary key |
+| `vault_document_id` | UUID | FK → vault_document |
+| `organization_id` | UUID | Denormalized tenant scope |
+| `version_number` | INT | Monotonic per vault_document; starts at 1 |
+| `file_path` | VARCHAR | Relative to storage root; never exposed in API |
+| `file_sha256` | VARCHAR(64) | Hex; verified on every download |
+| `mime_type` | VARCHAR | Validated against allowlist at upload |
+| `original_filename` | VARCHAR | As supplied by upload client |
+| `file_size_bytes` | INT | Stored at upload |
+| `source` | ENUM | `web_upload` \| `email_inbound` \| `api` \| `scan_upload` |
+| `uploaded_at` | TIMESTAMP | When this version was received |
+| `uploaded_by` | UUID | FK → user |
+
+Storage path layout (ADR 0012):
+`{NENE_VAULT_STORAGE_PATH}/vault/{organization_id}/{document_id}/v{version_number}/{sanitized_filename}`
+
+File bytes are **never overwritten** after creation. Replacing a document
+creates `version_number + 1`.
+
+---
 
 ## document_link
 
-Optional reference: `sibling_product` (`nene_invoice` | `nene_clear`), `entity_type`, `entity_id`.
+Optional reference to a sibling product entity. Non-authoritative — Vault is
+never the SSOT for Invoice or Clear data (ADR 0002, ADR 0009).
 
-## audit_event
+| Field | Type | Notes |
+| --- | --- | --- |
+| `id` | ULID | Primary key |
+| `vault_document_id` | UUID | FK → vault_document |
+| `organization_id` | UUID | Tenant scope |
+| `sibling_product` | ENUM | `nene_invoice` \| `nene_clear` |
+| `entity_type` | VARCHAR | e.g. `invoice`, `client`, `bank_transaction` |
+| `entity_id` | VARCHAR | ID as known to the sibling product's API |
+| `created_at` | TIMESTAMP | |
+| `created_by` | UUID | FK → user |
 
-`event_type`: `uploaded`, `metadata_changed`, `voided`, `restored`, `exported`.
+Create and delete are both audited. No amount sync from siblings into Vault
+metadata.
+
+---
+
+## vault_settings
+
+One row per organization. Configures retention and optional sibling integration.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `organization_id` | UUID | PK + FK → organization |
+| `retention_years` | INT | Default 10; minimum 7 (with warning); see ADR 0004 |
+| `storage_path_override` | VARCHAR nullable | Override for NENE_VAULT_STORAGE_PATH per org |
+| `invoice_api_base_url` | VARCHAR nullable | Optional; for link validation only |
+| `invoice_api_token` | VARCHAR nullable | Encrypted; for link validation only |
+| `clear_api_base_url` | VARCHAR nullable | Optional; for link validation only |
+| `clear_api_token` | VARCHAR nullable | Encrypted; for link validation only |
+| `updated_at` | TIMESTAMP | |
+| `updated_by` | UUID | FK → user |
+
+Changes to `vault_settings` are audited via `vault_settings.changed` events.
+
+---
+
+## audit_events
+
+Append-only compliance log. Schema and rules: [ADR 0014](../adr/0014-audit-event-schema.md).
+
+**Immutability:** No UPDATE or DELETE is permitted on this table by application
+code or DB user role. Audit records outlive the documents they describe.
+
+---
+
+## Organization and user
+
+Shared entities (NeNe ecosystem pattern from ADR 0006):
+
+- **organization** — the tenant. `id`, `name`, `slug`, `plan`, `is_active`,
+  `created_at`.
+- **user** — operator account. `id`, `organization_id` (NULL for superadmin),
+  `email`, `password_hash`, `role`, `status` (`active` \| `invited`),
+  `created_at`.
+
+---
+
+## Planned modules (`src/`)
+
+| Module | Responsibility |
+| --- | --- |
+| `Organization/` | Tenants + per-request resolution |
+| `Auth/` | JWT, Role, Capability, middleware |
+| `User/` | Operator accounts within organization |
+| `VaultSettings/` | Retention and sibling link config |
+| `Document/` | vault_document CRUD, upload, void/restore, search |
+| `DocumentVersion/` | File storage, version creation, hash verification |
+| `DocumentLink/` | Optional sibling links |
+| `Audit/` | AuditRecorder, audit_events write; history read |
+| `Export/` | Manifest CSV + ZIP export |
+| `Integration/SiblingLink/` | Optional HTTP clients for Invoice/Clear link validation |
+
+---
 
 ## Related
 
-- [`requirements.md`](./requirements.md)
-- [`terminology.md`](./terminology.md)
+- Requirements: [`requirements.md`](./requirements.md)
+- Compliance (binding): [`received-document-compliance.md`](./received-document-compliance.md)
+- ADR 0004: Retention period calculation
+- ADR 0006: Multi-tenancy and roles
+- ADR 0011: Integrity method
+- ADR 0012: File storage architecture
+- ADR 0014: Audit event schema

--- a/docs/explanation/glossary.md
+++ b/docs/explanation/glossary.md
@@ -1,0 +1,40 @@
+# Glossary
+
+Canonical terms for NeNe Vault public docs, OpenAPI descriptions, and code
+comments.
+
+> This file defines **meaning and context**. The authoritative **spelling** of
+> every identifier (entity names, field names, status values) lives in
+> [`terminology.md`](./terminology.md) — spellings here MUST conform to it.
+
+| Term | Definition | Avoid |
+| --- | --- | --- |
+| **organization** | The tenant — an independent operator (or agency client) with its own users, vault settings, and documents. One install may run as one organization (`single` mode) or multiple (agencies) | "tenant" / "account" / "company" in code identifiers |
+| **superadmin** | Cross-tenant platform role; manages organizations (`manage_organizations`). `organization_id` is NULL | "root", "owner", "platform admin" in code |
+| **admin** | Organization-scoped role; manages the org's users, vault settings, and all document operations | "manager", "org admin" in code identifiers |
+| **member** | Organization-scoped operator; uploads documents and edits own metadata | "user", "staff" in code identifiers |
+| **viewer** | Organization-scoped read-only role (Phase 2+); search and download only | — |
+| **received document** | A PDF or image **received from a third party** (vendor, landlord, service provider) and stored for compliance. The logical container for one business document identity across all its versions | "uploaded file" as the primary concept; "inbound document" |
+| **document version** | An immutable file blob — one physical file upload. The first upload is version 1; each replacement creates a new version with a higher number. All versions remain permanently accessible | "revision" (implies editorial intent); treating version as the primary domain object |
+| **vault document** | The logical identity record pointing to the current version. The stable URL and metadata container | "file" as the primary concept |
+| **void** | Logical deactivation of a document with a mandatory reason, recorded in the audit log. Does not delete file bytes. The statutory-correct alternative to hard delete | "delete", "archive", "remove" in user-facing copy (for the same action) |
+| **transaction date** | 取引年月日 — the date stated on the received document. May differ from the upload date | conflating with `uploaded_at`; using "document date" without clarifying it refers to the transaction |
+| **counterparty** | The vendor, landlord, or service provider named on the received document (`counterparty_name`) | "vendor", "supplier" in API field names; "seller" in statutory search contexts |
+| **retention window** | The period during which a document must be kept. Computed as `transaction_date + retention_years` (ADR 0004). Default 10 years from transaction date | "expiry", "TTL" — implies purge is automatic without confirmation |
+| **audit event** | An append-only record of one mutating operation: who changed what entity, with the before and after state (ADR 0014) | "log entry", "event log" when speaking specifically about compliance trail |
+| **cents** | Integer amount in the smallest currency unit. For JPY (Phase 1–3 only), 1 cent = ¥1, so `amount_cents = 1000` means ¥1,000. The `_cents` suffix is a fixed internal convention | float or DECIMAL money; reading `_cents` as 1/100 yen; using "yen" as the field name |
+| **電子取引** | The legal category of documents received electronically (email PDF, portal download). Subject to mandatory electronic preservation under 電帳法 第7条 since January 1, 2024 | treating paper-printed copies of electronic originals as sufficient preservation |
+| **スキャナ保存** | Scanner preservation — paper documents digitized after receipt. Subject to **different and stricter** requirements than 電子取引; Vault accepts the files but does not manage the additional compliance requirements | treating スキャナ保存 as identical to 電子取引; presenting Vault as certifying スキャナ保存 compliance |
+| **訂正削除の履歴方式** | Correction-history method — Vault's chosen method for 真実性の確保. File bytes are immutable, metadata changes are audited with before/after, and void replaces hard delete | "audit trail method" without specifying this is the statutory method being used |
+| **事務処理規程** | An internal written procedures document that operators must maintain independently if they rely on it as their 真実性 method. Vault does not generate this document; a template outline will ship in Phase 2+ | implying Vault generates or certifies this document |
+| **search requirements (検索要件)** | The statutory requirement to search by 取引年月日, 取引金額, and 取引先 — each individually and in at least two-field combinations (電帳法施行規則 第4条第1項第3号) | treating these as optional convenience features; omitting combination search |
+| **retention default** | 10 years from transaction date (ADR 0004). Covers 法人税法, 消費税法, and 会社法 obligations without requiring fiscal-year configuration | "7 years" as the default — this is less than the statutory minimum for many fiscal calendars |
+| **source** | The upload channel: `web_upload`, `email_inbound`, `api`, or `scan_upload`. `scan_upload` triggers the スキャナ保存 advisory warning | — |
+| **Tier A** | Shared hosting deployment — release ZIP + web installer + MySQL | "rental server tier" in code identifiers |
+| **Tier B** | Docker / VPS deployment — Compose + mounted volume | "cloud tier" |
+| **handler** | HTTP entry point class | "controller" |
+| **use case** | Business logic class with `execute()` | "service" (in the UseCase sense) |
+| **UI locale** | Admin UI language. Bound to **ja (primary) + en (secondary) only** (ADR 0005). Distinct from the English-only repository-docs policy | adding locales beyond ja/en; conflating UI locale with compliance document language |
+
+When adding terms, update this file and [`terminology.md`](./terminology.md)
+in the same PR.

--- a/docs/explanation/received-document-compliance.md
+++ b/docs/explanation/received-document-compliance.md
@@ -1,142 +1,418 @@
 # Received-Document Compliance (binding)
 
-**Status: binding for NeNe Vault engineering.** This document defines how Vault
-meets **電子帳簿保存法** expectations for **received electronic documents**
-(受取電子取引データ).
+**Status: binding for NeNe Vault engineering.** A finance or accounting
+professional reviewing the system must be able to find **zero deviations** from
+the rules below.
 
-> **Not legal advice.** Engineering interpretation for implementers and tax-advisor
-> review. Confirm small-business relaxations and industry-specific rules with a
-> licensed 税理士 before production deployment.
+These are not guidelines. They are **MUST** requirements. Where a rule here
+conflicts with UX, performance, implementation convenience, or any other concern,
+**compliance wins — every time, without exception.**
 
-See also: [`scope-contract.md`](./scope-contract.md), [ADR 0011](../adr/0011-electronic-records-received-documents.md).
+See also: [`scope-contract.md`](./scope-contract.md),
+[`domain-model.md`](./domain-model.md),
+[ADR 0011](../adr/0011-electronic-records-received-documents.md),
+[ADR 0004](../adr/0004-retention-period-calculation.md).
+
+> **Not legal advice.** This document is engineering's binding interpretation of
+> applicable rules. When a requirement is unclear, **stop and consult a 税理士 or
+> 公認会計士** — do not guess. Record the resolved interpretation here with
+> professional attribution and date.
 
 ---
 
-## 1. Scope of this document
+## 0. Governing principle
 
-| In scope | Out of scope |
+1. **Compliance is non-negotiable.** Correct adherence to the law takes
+   precedence over every other product goal.
+2. **No silent deviation.** Any departure from the rules in this document —
+   even temporary, even for a single operator — requires a new **ADR** with
+   **explicit sign-off by a licensed 税理士 or 公認会計士** recorded in that ADR.
+   Code may not merge a deviation without it.
+3. **Engineering is not the legal authority.** This document is engineering's
+   binding interpretation. When a requirement is unclear, **stop and consult a
+   税理士** — do not guess. Record the resolved interpretation here.
+4. **Evidence store, not ledger.** Vault preserves received documents and their
+   metadata; it does not post journal entries, compute tax, or issue documents.
+   Any feature that crosses this boundary violates
+   [`scope-contract.md`](./scope-contract.md) X4, X12.
+
+---
+
+## 1. Statutory basis
+
+NeNe Vault targets the following Japanese rules for **received electronic
+documents**. This table states *what we comply with*; it is not legal advice.
+
+| Area | Rule set |
 | --- | --- |
-| Received PDFs/images from vendors (請求書, 契約書, 領収書 等) | Issued qualified invoices → **NeNe Invoice** |
-| Metadata: date, amount, counterparty, tags | Bank deposit lines → **NeNe Clear** / **NeNe Profile** |
-| Search, retention, correction history | Journal entries, tax returns |
-| Export for advisor review | Expense approval workflows |
+| 電子取引データの保存義務 | 電子帳簿保存法 第7条（平成10年法律第25号、令和3年改正 — 令和4年1月1日施行、猶予期間終了 令和6年1月1日） |
+| 保存要件（真実性・可視性・検索） | 電子帳簿保存法施行規則 第4条第1項（財務省令） |
+| 保存期間（法人） | 法人税法第75条の3、法人税法施行規則第26条の2 — 申告期限の翌日から7年 |
+| 保存期間（個人事業主） | 所得税法施行規則第102条 — 申告期限の翌日から7年 |
+| 保存期間（消費税） | 消費税法第30条第9項、消費税法施行規則第15条の3 — 申告期限の翌日から7年 |
+| 帳簿保存（商法・会社法） | 会社法第432条第2項 — 会計帳簿等は10年 |
+| 繰越欠損金がある法人 | 法人税法第57条 — 最長10年（欠損が発生した事業年度の翌期から） |
+
+When any of these change (statutory amendment, rate changes, new NTA guidance),
+treat it as a compliance defect until the product is updated, and open a P0 Issue.
 
 ---
 
-## 2. Integrity (真実性の確保)
+## 2. Document scope
 
-Vault adopts the **correction-history method** (訂正削除の履歴が残るシステム):
+### 2.1 Primary scope — 電子取引 (Electronic transactions)
 
-1. **File immutability.** Stored file bytes are never overwritten. A correction
-   creates a new `document_version` row; prior version remains addressable.
-2. **Metadata immutability with audit.** Changes to `transaction_date`, `amount_cents`,
-   `counterparty_name`, or `category` append an `audit_event` — prior values
-   remain queryable in history.
-3. **Void, not delete.** Operator may **void** a document (logical delete) with
-   reason and actor; void is reversible only via ADR-gated admin recovery — never
-   silent hard delete in normal operation.
-4. **Provenance.** Each upload records: `file_sha256`, original filename, MIME,
-   `uploaded_at`, `uploaded_by`, optional `source` (`web_upload`, `email_inbound`, `api`).
+Vault's primary compliance target is **電子取引データ** under 電帳法 第7条:
+documents that were **created and transmitted electronically** to the operator.
 
-Duplicate detection: same `file_sha256` within tenant **warns**; operator confirms
-intentional duplicate vs re-upload error.
-
----
-
-## 3. Visibility (可視性の確保)
-
-### 3.1 Legibility (見読可能性)
-
-- Stored files viewable/downloadable in original format (PDF/image).
-- Admin UI renders PDF inline where browser supports; fallback download link.
-- Print-friendly list view with metadata columns.
-
-### 3.2 Search (検索要件)
-
-Vault **MUST** support search on:
-
-| Field | Capability |
+| Typical case | Example formats |
 | --- | --- |
-| **Transaction date (取引年月日)** | Exact, range |
-| **Amount (取引金額)** | Exact, range (integer cents) |
-| **Counterparty (取引先)** | Partial match, normalized |
+| Vendor invoice PDF received by email attachment | `application/pdf` |
+| Receipt downloaded from vendor's web portal | `application/pdf` |
+| Electronic delivery note / 請求書 from EDI or API | `application/pdf` |
+| Payment receipt from a payment service | `application/pdf`, `image/png` |
 
-**Combinations:** at least two-field AND queries (e.g. date range + counterparty).
+For these documents: operators are legally required to preserve the original
+electronic form — **printing and discarding the electronic original is
+prohibited** under 電帳法 第7条 since January 1, 2024. Vault satisfies this
+preservation requirement.
 
-Search is provided **by default** even if operator might qualify for relaxed
-requirements — product strategy targets SMBs who want advisor-ready posture.
+### 2.2 Secondary scope — スキャナ保存 (Scanner preservation, paper → digital)
 
-### 3.3 System overview document
+Vault **accepts** JPEG/PNG uploads that may be scans of paper originals.
+However, スキャナ保存 is governed by **different and stricter rules**
+(電子帳簿保存法施行規則 第2条) than 電子取引. Vault does **not** manage the
+additional スキャナ保存 requirements:
 
-Ship operator guide describing: storage location, backup expectation, search
-workflow, void/version semantics, retention policy.
-
----
-
-## 4. Retention
-
-| Rule | Implementation |
+| スキャナ保存 requirement | Vault's role |
 | --- | --- |
-| Minimum **7 years** from transaction date (or upload date if date unknown — flagged) | Configurable `retention_years` default 7 |
-| **10 years** where operator configures (法人等) | Max cap 10 in Phase 1–3 |
-| No automatic purge before retention expires | Cron job **blocks** purge; manual export only |
-| Post-retention purge | Requires admin confirmation + audit event + ADR if law changes |
+| Accredited timestamp (認定タイムスタンプ) — unless correction-history method applies | **Operator responsibility.** Vault does not acquire TSA timestamps. |
+| Scan quality (200 dpi or higher, color for certain docs) | **Operator responsibility.** Vault stores whatever the operator uploads. |
+| Prompt scanning timeline (速やか or 業務処理サイクル内) | **Operator responsibility.** Vault records `uploaded_at` but does not enforce deadline from paper receipt. |
+| Manager confirmation for receipts under ¥30,000 | **Not implemented.** Separate approval workflow is out of scope (scope-contract X5). |
+
+When an operator uploads a JPEG/PNG with source `scan_upload`, the system
+**MUST** display a warning: "This appears to be a scanned document. スキャナ保存
+requirements differ from 電子取引 rules. Confirm compliance with your 税理士."
+
+### 2.3 Out of scope
+
+| Document type | Owner |
+| --- | --- |
+| 適格請求書 / 請求書 issued by the operator | **NeNe Invoice** (issued billing SSOT) |
+| Bank deposit records | **NeNe Clear** / **NeNe Profile** |
+| Journal entries / 仕訳 | Accounting software |
+| Employee expense receipts requiring approval | Future product (scope-contract X5) |
 
 ---
 
-## 5. Amount and date handling
+## 3. Integrity (真実性の確保)
 
-- Amounts: **integer cents** in JPY; nullable when document has no amount field.
-- Dates: `transaction_date` (取引日) separate from `uploaded_at` (system receipt).
-- When OCR suggests date/amount, store in `suggested_*` fields; **operator confirms**
-  before promoting to authoritative metadata (aligns with "human confirms" philosophy).
+Vault adopts the **訂正削除の履歴が残るシステム方式** (correction-history system
+method) under 電帳法施行規則 第4条第1項第2号ロ. This is one of the four
+recognized methods; the others (タイムスタンプ, 削除不能システム, 事務処理規程)
+are explicitly **not** managed by Vault in MVP.
+
+### 3.1 File immutability
+
+- Stored file bytes **MUST NEVER** be overwritten after upload.
+- Correction creates a new `document_version` row; prior versions remain
+  permanently addressable.
+- Soft-delete (void) is the only removal path; hard delete of file bytes is
+  **prohibited** in normal operation (scope-contract X7, X8).
+- The system **MUST** compute and store `file_sha256` at upload time. On download,
+  the serving layer **MUST** verify the hash matches. Hash mismatch is a P0
+  defect.
+
+### 3.2 Metadata immutability with audit
+
+Changes to any of the following fields **MUST** create an `audit_event` record
+capturing the **old value and new value** before the change is committed:
+
+- `transaction_date`
+- `amount_cents`
+- `counterparty_name`
+- `category`
+- `tags`
+
+Prior values remain permanently queryable via the history endpoint.
+**In-place overwrite of authoritative metadata without audit is prohibited.**
+
+### 3.3 Void, not delete
+
+- Operators MAY void a document by recording `voided_at`, `voided_by`,
+  `void_reason` (mandatory), and optional `void_note`.
+- A voided document remains in the database with status `voided`. It is
+  **excluded from default search** but must be retrievable by history and audit
+  queries.
+- Voided documents **still count toward the retention period**.
+- Un-voiding (restore) requires admin capability and creates a `document.restored`
+  audit event. Mass un-void without audit is prohibited.
+- Hard delete of a voided document is **prohibited** during the retention window.
+  Post-retention purge requires admin confirmation + audit event.
+
+### 3.4 Provenance
+
+Each uploaded version **MUST** record:
+
+| Field | Meaning |
+| --- | --- |
+| `file_sha256` | SHA-256 hex digest of uploaded file bytes |
+| `original_filename` | Filename as supplied by the upload client |
+| `mime_type` | Validated MIME type (allowlist enforced) |
+| `version_number` | Monotonic integer starting at 1 per `vault_document` |
+| `uploaded_at` | System timestamp at receipt |
+| `uploaded_by` | `user.id` of the authenticated operator |
+| `source` | `web_upload` \| `email_inbound` \| `api` \| `scan_upload` |
+
+`source = scan_upload` triggers the スキャナ保存 warning (§2.2).
+
+### 3.5 Duplicate detection
+
+When a new upload's `file_sha256` matches an existing version within the same
+`organization_id`, the system **MUST** warn the operator before accepting the
+upload. Operator confirms intentional duplicate or cancels. Silent auto-accept
+of duplicates is prohibited; silent rejection is also prohibited (operator decides).
 
 ---
 
-## 6. Categories and tags
+## 4. Visibility (可視性の確保)
 
-- Free-form tags + optional preset categories (`invoice_received`, `contract`,
-  `receipt`, `other`) — **not** tax account codes.
-- Vault **must not** map categories to 勘定科目 automatically (X12 in scope contract).
+### 4.1 Legibility (見読可能性) — 規則第4条第1項第1号
+
+- Stored files **MUST** be viewable and downloadable in their original format
+  (PDF, JPEG, PNG) via an authenticated endpoint.
+- The admin UI **MUST** render PDF inline where the browser supports it; fallback
+  to a download link.
+- A print-friendly list view with all required metadata columns (transaction_date,
+  amount_cents, counterparty_name, category, file_sha256, status) **MUST** be
+  available.
+
+### 4.2 Search requirements (検索要件) — 規則第4条第1項第3号
+
+Vault **MUST** support searching on all of the following fields. These are
+**statutory fields** — they are not cosmetic or convenience features. Any
+regression in search capability is a compliance defect.
+
+| Statutory field | Vault field | Capability |
+| --- | --- | --- |
+| 取引年月日 (Transaction date) | `transaction_date` | Exact, range (`from` / `to`) |
+| 取引金額 (Transaction amount) | `amount_cents` | Exact, range (`min_cents` / `max_cents`) |
+| 取引先 (Counterparty) | `counterparty_name` | Partial text match, normalized |
+
+**Combination queries:** at least two-field AND queries (e.g. date range +
+counterparty) **MUST** be supported in a single API call. The three-field AND
+combination **MUST** also be supported. This covers the 電帳法 要件 of
+検索機能の確保 under 規則第4条第1項第3号.
+
+Search is provided **regardless of whether the operator qualifies for relaxed
+requirements** (中小企業の特例) — product strategy targets operators who want
+advisor-ready posture by default.
+
+### 4.3 System overview document
+
+An operator guide describing storage location, backup expectation, search
+workflow, void/version semantics, and retention policy **MUST** ship with the
+product. This is required under 電帳法 for 可視性の確保 (システム概要書). It is
+a Phase 2 deliverable and a gate before the product can be offered for production
+use.
 
 ---
 
-## 7. Export for advisors
+## 5. Retention (保存期間)
 
-Phase 2+ export bundle:
+Retention rules are governed by ADR 0004. The implementation rules follow.
 
-- ZIP of files (or manifest with signed URLs if large)
-- `manifest.csv`: document_id, version, transaction_date, amount_cents, counterparty,
-  category, file_sha256, uploaded_at, voided_at
-- Optional filter by date range
+### 5.1 Retention period
+
+| Operator type | Statutory minimum | Vault default | Configurable up to |
+| --- | --- | --- | --- |
+| All operators (safe default) | 7 years from 申告期限 | **10 years from `transaction_date`** | 10 years |
+| 法人 with 繰越欠損金 | Up to 10 years from filing deadline | 10 years from `transaction_date` | 10 years |
+
+**Why 10 years as default:** The statutory 7-year period runs from the filing
+deadline of the fiscal year containing the transaction — not from the
+transaction date itself. Depending on the operator's fiscal year and filing
+calendar, the filing deadline can be 14–26 months after the transaction. Retaining
+7 years from `transaction_date` may be 3–12 months shorter than required (see
+ADR 0004 for the full calculation). The 10-year default is always sufficient for
+法人税法, 消費税法, and 会社法 requirements without requiring fiscal-year
+configuration.
+
+### 5.2 Retention enforcement
+
+- The system **MUST NOT** auto-purge any document before its `retention_expires_at`
+  date (computed at upload from `transaction_date + retention_years`).
+- Any scheduled or manual purge operation **MUST** verify
+  `retention_expires_at <= now()` and **MUST** require admin capability
+  (`manage_vault_settings`) plus explicit confirmation.
+- A purge attempt on a non-expired document is a P0 defect.
+- Voided documents are subject to the same retention enforcement as active
+  documents — void does not reduce the retention obligation.
+
+### 5.3 Unknown transaction date
+
+When `transaction_date` is null or unknown at upload:
+
+- `retention_expires_at` is anchored to `uploaded_at + retention_years` as a
+  conservative placeholder.
+- The document is **flagged** with `date_uncertain = true` and appears in
+  compliance warnings.
+- The operator is prompted to supply `transaction_date`; upon confirmation,
+  `retention_expires_at` is recalculated and the recalculation is audited.
+
+### 5.4 End-of-retention-period procedure
+
+1. Admin exports a manifest for the expiring cohort.
+2. Admin confirms export was received.
+3. Admin triggers purge for confirmed documents.
+4. System records a `document.purged` audit event per document.
+5. File bytes are deleted; metadata and audit history are retained for a further
+   3-year administrative grace period before permanent removal.
 
 ---
 
-## 8. Email inbound (Phase 3+)
+## 6. Amount and date handling
 
-If implemented:
-
-- Dedicated inbound address per tenant; attachments become upload candidates.
-- Same provenance and immutability rules as web upload.
-- SPF/DKIM verification recommended; document in security ADR when added.
+- Amounts are stored as **integer minimum currency units** (`amount_cents`; for
+  JPY, 1 cent = ¥1). **Float and DECIMAL for money are prohibited** in DB, API
+  JSON, and tests.
+- `amount_cents` is **nullable** — some received documents (delivery notes,
+  contracts with no stated amount) carry no monetary value; Vault **MUST NOT**
+  require an amount to store a document.
+- `transaction_date` (取引年月日) is the date on the received document.
+  `uploaded_at` is the system receipt timestamp. **These are distinct fields
+  and must never be conflated.**
+- If a received document bears no legible date, operator may leave
+  `transaction_date` null. The document is flagged `date_uncertain = true`
+  (§5.3 applies).
+- Phase 1–3 currency is **JPY only**. Multi-currency requires an ADR with
+  professional review.
 
 ---
 
-## 9. Professional review gate
+## 7. Audit trail
 
-Before **Phase 2 admin UI** ships to operators:
+Audit trail is governed by ADR 0014. Summary rules:
 
-- [ ] 税理士 sign-off on §2–§4 posture for received documents
-- [ ] Confirm search fields meet operator's industry pattern
-- [ ] Void/version UX reviewed for audit acceptability
+- **Every mutating operation on a vault document or vault settings** records an
+  `audit_event` row.
+- Reads are not audited; writes are.
+- `audit_event` records **MUST NOT** be updated or deleted after creation.
+  Audit records are subject to the same retention rules as the documents they
+  describe.
+- The `actor_user_id` of every audit event must be the authenticated operator
+  who performed the action. System-generated events (e.g. retention expiry
+  computed) record `actor_user_id = NULL` with `source = system`.
+
+Required event types (minimum set for MVP):
+
+| Event | Trigger |
+| --- | --- |
+| `document.uploaded` | New vault_document + document_version created |
+| `document.metadata_changed` | Any change to transaction_date, amount_cents, counterparty_name, category, tags |
+| `document.voided` | Vault document set to `voided` |
+| `document.restored` | Voided document returned to `active` |
+| `document.version_added` | Replacement file upload (new document_version) |
+| `document.exported` | Manifest CSV or ZIP export covering this document |
+| `document.purged` | Document removed after retention expiry (§5.4) |
+| `document.link_created` | document_link to Invoice/Clear entity added |
+| `document.link_deleted` | document_link removed |
+| `vault_settings.changed` | Any change to organization's retention_years, storage_path, or sibling link config |
+
+---
+
+## 8. OCR policy
+
+OCR assistance is a Phase 4 feature. When implemented:
+
+- OCR output **MUST** be stored in `suggested_transaction_date`,
+  `suggested_amount_cents`, `suggested_counterparty_name` fields.
+- **Operator confirmation is required** before OCR-suggested values are promoted
+  to authoritative fields.
+- Promotion creates a `document.metadata_changed` audit event (from suggested
+  value to confirmed value).
+- The system **MUST NOT** auto-promote OCR suggestions to authoritative fields
+  without an explicit confirmation action (scope-contract X6).
+- Confidence scores and raw OCR source may be stored but are not compliance
+  artifacts; only the operator-confirmed values are authoritative.
+
+---
+
+## 9. スキャナ保存 advisory (summary)
+
+Vault does not certify スキャナ保存 compliance. For scanned documents:
+
+| Rule | Vault's position |
+| --- | --- |
+| Timestamp requirement (認定タイムスタンプ or correction-history) | Correction-history method is satisfied by Vault if the operator's internal procedures document (事務処理規程) is maintained; TSA is operator's responsibility |
+| Resolution / color requirements | Operator responsibility at scan time; Vault stores uploaded bytes as-is |
+| Promptness of scanning / entry | Operator responsibility; Vault records `uploaded_at` only |
+| 事務処理規程 (operational procedures document) | Operator must maintain this separately; Vault does not generate or enforce it |
+
+A Phase 2+ operator guide will include a template 事務処理規程 outline that
+operators can adapt. Until then, operators relying on スキャナ保存 **MUST**
+consult their 税理士.
+
+---
+
+## 10. Tax audit response (税務調査対応)
+
+When a tax inspector (税務調査官) requests records:
+
+1. Admin uses the export feature to produce a manifest CSV + ZIP of requested
+   documents, filtered by date range and optionally by counterparty/amount.
+2. The manifest includes: `document_id`, `version`, `transaction_date`,
+   `amount_cents`, `counterparty_name`, `category`, `file_sha256`,
+   `uploaded_at`, `voided_at` (if applicable).
+3. Document history (all versions, all metadata changes, audit events) is
+   accessible via the history endpoint for any specific document.
+4. The system **MUST** be able to produce this without affecting ongoing
+   operations or modifying any stored data (export is read-only).
+5. Standard practice: 税務調査 notice-to-response is typically 14 days. The
+   export function **MUST** support filtering on all statutory search fields
+   (§4.2).
+
+---
+
+## 11. What Vault does NOT do (compliance scope boundary)
+
+| What a 税理士 might expect of accounting software | Vault's position |
+| --- | --- |
+| Post journal entries (仕訳) | **Prohibited.** Scope-contract X4. |
+| Classify tax account codes (勘定科目) | **Prohibited.** Scope-contract X12. |
+| Compute consumption tax on received invoices | **Prohibited.** Scope-contract X12. Not a USE of information; that belongs to accounting software. |
+| Certify インボイス registration numbers on received documents | **Not implemented.** Vault displays the vendor's stated number; operator verifies via NTA portal. |
+| Issue qualified invoices (適格請求書) | **Prohibited.** Scope-contract X1. |
+| Acquire accredited timestamps (認定タイムスタンプ) | **Not in MVP.** Operator responsibility if TSA method is required. |
+| Generate 事務処理規程 with legal force | **Not in MVP.** Vault provides a template outline in Phase 2+; the legally binding document is the operator's responsibility. |
+| Certify spanner-preservation (スキャナ保存) compliance | **Not implemented.** Vault supports the correction-history method for integrity; スキャナ保存 specific requirements are operator responsibility. |
+| Reconcile bank payments against received invoices | **Prohibited.** Scope-contract X2. NeNe Clear's domain. |
+
+---
+
+## 12. How this applies to every change
+
+Any change that touches **document storage, file serving, metadata editing,
+search, audit logging, retention, void/restore, or export** MUST:
+
+1. Be reviewed against this document and the self-review compliance checklist
+   (`docs/review/compliance.md` when written).
+2. State compliance impact in the PR.
+3. If it deviates from any rule here: carry a new ADR with professional sign-off
+   (§0.2). No exceptions.
+4. If the change is in the grey area: **assume compliance impact and run the
+   review** — do not assume it is safe.
 
 ---
 
 ## Related
 
 - Scope contract: [`scope-contract.md`](./scope-contract.md)
-- ADR 0011: Electronic-records method
-- ADR 0012: Storage architecture
-- Clear bank-data posture (separate domain): `nene-clear` ADR 0012
+- Domain model: [`domain-model.md`](./domain-model.md)
+- ADR 0004: Retention period calculation
+- ADR 0011: Electronic-records integrity method choice
+- ADR 0012: File storage architecture
+- ADR 0014: Audit event schema
 
-Last updated: 2026-05-29
+Last updated: 2026-05-30

--- a/docs/explanation/requirements.md
+++ b/docs/explanation/requirements.md
@@ -84,9 +84,16 @@ Must satisfy [`received-document-compliance.md`](./received-document-compliance.
 
 ## 6. Retention requirements
 
-- [ ] Default `retention_years = 7`; max 10
-- [ ] Documents before retention expiry cannot be purged by cron
-- [ ] Voided documents remain in index with `voided_at` (hidden by default filter)
+See [ADR 0004](../adr/0004-retention-period-calculation.md) for the statutory
+basis and calculation rationale.
+
+- [ ] Default `retention_years = 10` (not 7 — see ADR 0004: "7 years from transaction_date" is systematically shorter than the statutory 7 years from the filing deadline)
+- [ ] Minimum configurable: 7 (with warning: "may not cover statutory minimum — confirm with your 税理士")
+- [ ] Maximum configurable: 99 (permanent retention is a valid policy)
+- [ ] `retention_expires_at` computed at upload time: `transaction_date + retention_years`; if `transaction_date` is null, `uploaded_at + retention_years` with `date_uncertain = true` flag
+- [ ] `retention_years` change in vault_settings does NOT retroactively shorten retention on existing documents — only lengthens
+- [ ] Documents before `retention_expires_at` cannot be purged; system blocks purge
+- [ ] Voided documents remain in index with `voided_at` (excluded from default search filter); same retention enforcement applies
 
 ---
 

--- a/docs/explanation/scope-contract.md
+++ b/docs/explanation/scope-contract.md
@@ -15,6 +15,23 @@ Read first: [ADR 0009](../adr/0009-separate-from-billing-and-reconciliation.md),
 
 ---
 
+## Governing principle
+
+1. **Compliance is non-negotiable.** Correct adherence to the law takes
+   precedence over every other product goal — UX, performance, or convenience.
+2. **No silent deviation.** Any departure from [`received-document-compliance.md`](./received-document-compliance.md)
+   requires an ADR with **explicit sign-off by a licensed 税理士 or 公認会計士**.
+   Code may not merge a deviation without it.
+3. **Engineering is not the legal authority.** When a requirement is unclear,
+   stop and consult a 税理士 — do not guess. Record the resolved interpretation
+   in the compliance doc.
+4. **Evidence store, not ledger.** Vault stores received documents and their
+   metadata. It does not post journal entries, compute tax, or issue documents.
+
+---
+
+---
+
 ## GOAL
 
 > **NeNe Vault lets a Japan SMB store, search, and preserve received business

--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -1,12 +1,122 @@
 # Terminology (binding)
 
-| Term | Definition |
-| --- | --- |
-| **Received document** | PDF/image from a third party (vendor, landlord) — Vault primary corpus |
-| **Issued document** | Quote/invoice PDF from operator — **Invoice SSOT**; Vault may store copy only |
-| **Void** | Logical deactivation with audit; not hard delete |
-| **Document version** | Immutable file blob generation; corrections create new version |
-| **Transaction date** | 取引年月日 on received doc (may differ from upload date) |
-| **Retention window** | Years to retain before eligible purge (default 7) |
+Canonical English and Japanese terms for NeNe Vault. Spellings here govern
+all code identifiers, OpenAPI fields, API responses, and documentation.
 
-Last updated: 2026-05-29
+> This file defines the **binding spelling** of every term. Meaning and context
+> live in [`glossary.md`](./glossary.md). Spellings here take precedence; update
+> both files in the same PR when adding a term.
+
+---
+
+## Core domain terms
+
+| Term | Canonical spelling | Japanese label | Definition |
+| --- | --- | --- | --- |
+| **received document** | `vault_document` (entity) | 受取書類 | A PDF or image received from a third party and stored in Vault |
+| **document version** | `document_version` (entity) | 文書バージョン | An immutable file blob generation; corrections create a new version |
+| **document link** | `document_link` (entity) | 関連書類リンク | Optional non-authoritative HTTP reference to a sibling-product entity |
+| **audit event** | `audit_event` (entity) | 監査ログ | Append-only record of one mutating operation |
+| **void** | `voided` (status) | 無効化 | Logical deactivation with audit trail; not hard delete |
+| **transaction date** | `transaction_date` (field) | 取引年月日 | Date stated on the received document; distinct from `uploaded_at` |
+| **counterparty** | `counterparty_name` (field) | 取引先名 | Name of the vendor, landlord, or service provider on the document |
+| **retention window** | `retention_years` (field), `retention_expires_at` (computed) | 保存期間 | Configured years to retain; see ADR 0004 |
+| **organization** | `organization` (entity) | 組織（テナント） | The tenant; one independent operator or agency client |
+| **vault settings** | `vault_settings` (entity) | 保管設定 | Per-organization retention and sibling link configuration |
+
+---
+
+## Document status values
+
+| Status | Code value | Meaning |
+| --- | --- | --- |
+| Active | `active` | Document is uploaded and accessible |
+| Voided | `voided` | Logically deactivated with reason and audit; excluded from default search |
+
+---
+
+## Document source values
+
+| Source | Code value | Meaning |
+| --- | --- | --- |
+| Web upload | `web_upload` | Uploaded via admin UI |
+| Email inbound | `email_inbound` | Received via inbound email attachment (Phase 3+) |
+| API | `api` | Uploaded via REST or MCP API |
+| Scan upload | `scan_upload` | Uploaded file is identified as a scanned paper document; スキャナ保存 warning applies |
+
+---
+
+## Category values
+
+| Category | Code value | Japanese | Typical document type |
+| --- | --- | --- | --- |
+| Invoice received | `invoice_received` | 受取請求書 | Vendor invoice / 請求書 |
+| Contract | `contract` | 契約書 | Contract or agreement |
+| Receipt | `receipt` | 領収書 | Receipt for payment |
+| Delivery note | `delivery_note` | 納品書 | Delivery confirmation |
+| Other | `other` | その他 | Any other received document |
+
+---
+
+## Role values
+
+| Role | Code value | Scope | Capabilities |
+| --- | --- | --- | --- |
+| Superadmin | `superadmin` | Cross-tenant | All, including `manage_organizations` |
+| Admin | `admin` | Single organization | All except `manage_organizations` |
+| Member | `member` | Single organization | `upload_document`, `edit_metadata` (own uploads) |
+| Viewer | `viewer` | Single organization | `view_documents` (Phase 2+) |
+
+---
+
+## Capability values
+
+| Capability | Code value | Granted to |
+| --- | --- | --- |
+| Manage organizations | `manage_organizations` | superadmin |
+| Manage users | `manage_users` | superadmin, admin |
+| Manage vault settings | `manage_vault_settings` | superadmin, admin |
+| Upload document | `upload_document` | superadmin, admin, member |
+| Edit metadata | `edit_metadata` | superadmin, admin; member for own uploads |
+| Void document | `void_document` | superadmin, admin |
+| View documents | `view_documents` | superadmin, admin, member, viewer |
+| Export documents | `export_documents` | superadmin, admin |
+
+---
+
+## Audit event action values
+
+Canonical form: `{entity}.{verb}`. See [ADR 0014](../adr/0014-audit-event-schema.md).
+
+| Action | entity_type |
+| --- | --- |
+| `document.uploaded` | `vault_document` |
+| `document.metadata_changed` | `vault_document` |
+| `document.voided` | `vault_document` |
+| `document.restored` | `vault_document` |
+| `document.version_added` | `document_version` |
+| `document.exported` | `vault_document` |
+| `document.purged` | `vault_document` |
+| `document.link_created` | `document_link` |
+| `document.link_deleted` | `document_link` |
+| `vault_settings.changed` | `vault_settings` |
+
+---
+
+## Legal terms (appear in docs and UI labels)
+
+| Term | English rendering | Japanese | Usage |
+| --- | --- | --- | --- |
+| Electronic Books and Records Preservation Act | 電子帳簿保存法 (abbreviated 電帳法) | 電子帳簿保存法 | Statutory basis; use full name at first mention, abbreviated thereafter |
+| Electronic transaction | 電子取引 | 電子取引 | Category of received electronic documents under 電帳法 第7条 |
+| Scanner preservation | スキャナ保存 | スキャナ保存 | Scanned-paper preservation; different requirements from 電子取引 |
+| Integrity assurance | 真実性の確保 | 真実性の確保 | Legal requirement; Vault uses correction-history method |
+| Visibility assurance | 可視性の確保 | 可視性の確保 | Legibility + search requirements under 電帳法 規則第4条 |
+| Correction-history method | 訂正削除の履歴方式 | 訂正削除の履歴が残るシステム | Chosen integrity method for Vault (ADR 0011) |
+| Search requirements | 検索要件 | 検索要件 | Date, amount, counterparty — individually and in combination |
+| Retention period | 保存期間 | 保存期間 | Minimum years to retain a document; see ADR 0004 |
+| Filing deadline | 申告期限 | 申告期限 | Tax return due date; the statutory anchor for the 7-year retention period |
+| Operational procedures document | 事務処理規程 | 事務処理規程 | Written internal procedures required for some integrity methods; operator responsibility |
+| Tax audit | 税務調査 | 税務調査 | National Tax Agency inspection; Vault must support export for this purpose |
+
+Last updated: 2026-05-30

--- a/docs/inheritance-from-nene2.md
+++ b/docs/inheritance-from-nene2.md
@@ -1,0 +1,100 @@
+# Inheritance from NENE2
+
+NeNe Vault inherits engineering governance from [NENE2](https://github.com/hideyukiMORI/NENE2). This document is the source of truth for what is inherited, what is adapted, and what is NeNe Vault–specific.
+
+## Relationship
+
+| Layer | Repository | Role |
+| --- | --- | --- |
+| Framework runtime | [NENE2](https://github.com/hideyukiMORI/NENE2) | HTTP runtime, DI, middleware, Problem Details, OpenAPI/MCP patterns |
+| Application platform | **NeNe Vault** (this repo) | Received-document archive — upload, search, retention, audit |
+| Sibling products | [nene-invoice](https://github.com/hideyukiMORI/nene-invoice), [nene-clear](https://github.com/hideyukiMORI/nene-clear), [nene-profile](https://github.com/hideyukiMORI/nene-profile) | Optional HTTP reference links (no shared DB) |
+
+NeNe Vault is a **consumer project**, not a fork of NENE2. Framework code stays in NENE2; product code stays here.
+
+## Inherited by policy (same rules, local copies)
+
+These policies are adopted with the same intent as NENE2 and sibling NeNe products.
+
+| Topic | Local document |
+| --- | --- |
+| Issue-driven workflow | `docs/workflow.md` |
+| Conventional Commits | `docs/development/commit-conventions.md` |
+| Self-review before PR | `docs/development/self-review.md` |
+| ADR operation | `docs/development/adr.md` |
+| AI agent workflow | `docs/integrations/ai-tools.md`, `AGENTS.md` |
+| Cursor summaries | `.cursor/rules/` |
+
+## Inherited by reference (framework behavior)
+
+When implementing HTTP, middleware, validation, or error responses, follow NENE2 upstream docs unless NeNe Vault records an explicit deviation in an ADR.
+
+| Topic | NENE2 upstream |
+| --- | --- |
+| HTTP runtime (PSR-7/15/17) | `docs/development/http-runtime.md` |
+| Middleware order and security | `docs/development/middleware-security.md` |
+| Request validation layers | `docs/development/request-validation.md` |
+| Problem Details errors | `docs/development/api-error-responses.md` |
+| Authentication boundaries | `docs/development/authentication-boundary.md` |
+| JWT middleware (`BearerTokenMiddleware`) | `docs/adr/0008-jwt-authentication.md` |
+| OpenAPI conventions | `docs/integrations/openapi.md` |
+| MCP tool policy | `docs/integrations/mcp-tools.md` |
+| Database adapter boundaries | `docs/development/database-migrations.md` |
+| Domain / use case layering | `docs/development/domain-layer.md` |
+| DI and wiring | `docs/development/dependency-injection.md` |
+| Configuration policy | `docs/development/configuration.md` |
+| Observability / logging | `docs/development/observability.md` |
+| Quality tools (PHPStan, PHP-CS-Fixer) | `docs/development/quality-tools.md` |
+
+Install NENE2 as a Composer dependency and treat `vendor/hideyukimori/nene2/docs/` as the framework reference during development.
+
+## Adapted for NeNe Vault
+
+| Topic | NeNe Vault choice |
+| --- | --- |
+| Product goal | Received-document archive only — not billing, reconciliation, or CSV |
+| Namespace | `NeneVault\` |
+| Public Problem Details base URL | `https://nene-vault.dev/problems/` |
+| Compliance binding | `docs/explanation/received-document-compliance.md` (電帳法 for received docs) |
+| Monetary values | Integer **cents** nullable (`amount_cents`); null when document carries no amount |
+| File integrity | SHA-256 hash verified on every download; no byte overwrites |
+| Audit trail | UseCase-layer `AuditRecorder` with before/after; same DB transaction as mutation (ADR 0014) |
+| Retention | 10-year default from `transaction_date`; no auto-purge (ADR 0004) |
+| Coding standards | `docs/development/coding-standards.md` — NENE2 baseline + vault additions |
+| Backend standards | `docs/development/backend-standards.md` — PHP/API strict policy |
+| Naming conventions | `docs/development/naming-conventions.md` — vault-domain identifiers |
+| Language policy | English for public docs, OpenAPI, API error metadata; Japanese allowed in Issues, PRs, commits, `.cursor/rules/` |
+| Review checklists | `docs/review/` — vault-specific lists |
+
+## NeNe Vault–specific (not inherited)
+
+Record these in ADRs or product docs when they stabilize:
+
+- Received-document domain model (vault_document, document_version, document_link, audit_event)
+- 電子帳簿保存法 compliance posture for received documents (not issued)
+- File storage architecture (local filesystem; S3 adapter Phase 4+)
+- Admin frontend vs public download boundaries
+- MCP read tools (`searchVaultDocuments`, `getVaultDocument`)
+- Optional email inbound (Phase 3+)
+- OCR assist — suggest-only, human confirm (Phase 4+)
+
+## When upstream and local docs conflict
+
+1. Update the **local source-of-truth doc** in this repository first.
+2. If the conflict is about **framework behavior**, prefer NENE2 upstream unless an ADR documents a deliberate deviation.
+3. If the conflict touches compliance behavior, treat it as a P0 issue — do not resolve by guessing.
+4. Keep `.cursor/rules/` as a short summary; do not duplicate full policy text there.
+
+## Verification commands (once runtime is scaffolded)
+
+```bash
+composer check
+composer openapi
+composer mcp
+```
+
+When `frontend/` exists (Phase 2+):
+
+```bash
+npm run check --prefix frontend
+```

--- a/docs/milestones/2026-05-governance-and-foundation.md
+++ b/docs/milestones/2026-05-governance-and-foundation.md
@@ -3,21 +3,22 @@
 Goal: establish NeNe Vault engineering discipline and **binding product definition**
 before runtime code.
 
-**Status: in progress**
+**Status: complete**
 
 ## Acceptance Criteria
 
 - [x] GitHub repository created (`hideyukiMORI/nene-vault`, public since 2026-05-30)
 - [x] Scope contract (GOAL / DO / DON'T) — binding
 - [x] Received-document compliance doc — binding
-- [x] ADR 0001, 0002, 0006–0012, 0009 product boundary
+- [x] ADR 0001, 0002, 0003, 0005, 0006–0013 product boundary and governance
 - [x] Product vision, requirements, scope boundary
 - [x] Sibling integration policy
-- [ ] Issue #1 governance PR merged
-- [ ] `composer check` green on `main` (Issue #4+)
+- [x] Issue #1 governance PR merged (PR #1, 2026-05-30)
+- [x] Issue #2 product vision & requirements PR merged (PR #2, 2026-05-30)
 
 ## Follow-up
 
-Phase 1 — Document upload API + search + storage adapter.
+Phase 1 — Document upload API + search + storage adapter (Issue #4+).
+税理士 review gate before Phase 2 Admin UI.
 
-Last updated: 2026-05-29
+Last updated: 2026-05-30

--- a/docs/review/backend-api.md
+++ b/docs/review/backend-api.md
@@ -1,0 +1,68 @@
+# Backend API Self-Review Checklist
+
+Use for: endpoints, handlers, validation, HTTP behavior, Problem Details errors.
+
+---
+
+## Handler
+
+- [ ] Handler is thin: parses HTTP input, builds DTO, calls UseCase, maps JSON response.
+- [ ] No business logic, SQL, or file I/O in the handler.
+- [ ] No direct repository calls from the handler.
+- [ ] Handler receives UseCase via constructor injection, typed to the interface.
+
+## Input DTO and validation
+
+- [ ] Input is a `final readonly` DTO.
+- [ ] Format validation (type, length, required) happens in the handler before calling the UseCase.
+- [ ] Business invariants are validated in the UseCase, not the handler.
+- [ ] `transaction_date` is validated as a valid ISO 8601 date.
+- [ ] `amount_cents` is validated as a nullable integer (never float).
+- [ ] MIME type and file size are validated at the handler layer before the UseCase.
+
+## UseCase
+
+- [ ] UseCase implements its interface.
+- [ ] Method is always named `execute`.
+- [ ] UseCase has no HTTP, `$_SERVER`, PDO, or raw file I/O knowledge.
+- [ ] AuditRecorder is called in the same DB transaction as the mutation (if applicable).
+
+## Response
+
+- [ ] Response is JSON with `snake_case` property names.
+- [ ] Money amounts are integer cents — never float.
+- [ ] Storage paths are not in the response.
+- [ ] Timestamps use ISO 8601 format.
+- [ ] List responses use `{ items: [...], limit: N, offset: N }` envelope.
+- [ ] `status` 200/201/204 is correct for the operation.
+
+## Problem Details errors
+
+- [ ] Error responses use `application/problem+json`.
+- [ ] `type` is a stable `https://nene-vault.dev/problems/…` URI.
+- [ ] `title` and `detail` are English.
+- [ ] No stack traces, SQL, file paths, or storage paths in error responses.
+- [ ] Validation failures use `validation-failed` with `errors` array.
+- [ ] `errors[].field` uses snake_case path; `errors[].code` uses snake_case.
+
+## Authentication and authorization
+
+- [ ] Mutating routes require JWT Bearer auth.
+- [ ] Required capability is enforced by `CapabilityMiddleware`.
+- [ ] `organization_id` is resolved from middleware context, not from request body.
+- [ ] Superadmin cross-tenant operations are explicitly checked.
+
+## OpenAPI
+
+- [ ] New or changed route has a corresponding entry in `docs/openapi/openapi.yaml`.
+- [ ] `operationId` is stable camelCase matching the handler name convention.
+- [ ] Success and Problem Details schemas are documented.
+
+---
+
+## Verification
+
+```bash
+composer check
+composer openapi
+```

--- a/docs/review/compliance.md
+++ b/docs/review/compliance.md
@@ -1,0 +1,109 @@
+# Compliance Self-Review Checklist
+
+**Binding.** Use this checklist for **any change** that touches:
+
+- Document storage, file serving, or download
+- Metadata creation or editing
+- Search functionality
+- Audit trail / audit_events
+- Retention policy or enforcement
+- Void / restore
+- Export (manifest CSV, ZIP)
+- Retention period configuration
+
+A compliance review is **not optional** for these areas. If any item fails, block the PR until resolved. Deviations from `received-document-compliance.md` require an ADR with professional sign-off.
+
+---
+
+## File integrity (§3.1)
+
+- [ ] File bytes are never overwritten. Replacement creates a new `document_version`.
+- [ ] `file_sha256` is computed at upload and stored in `document_version`.
+- [ ] Hash is verified on every authenticated download. Hash mismatch → 500, logged.
+- [ ] Storage path is never exposed in API responses.
+- [ ] MIME type is validated against the allowlist (`application/pdf`, `image/jpeg`, `image/png`).
+- [ ] File size is validated against the org's configured max.
+
+## Metadata audit trail (§3.2)
+
+- [ ] Changes to `transaction_date`, `amount_cents`, `counterparty_name`, `category`, `tags` each create an `audit_event` with old and new values.
+- [ ] `audit_event` is written in the **same DB transaction** as the metadata mutation.
+- [ ] No in-place overwrite of authoritative metadata without an audit event.
+
+## Void semantics (§3.3)
+
+- [ ] Void records `voided_at`, `voided_by`, `void_reason` (mandatory).
+- [ ] Voided documents remain in the database with `status = 'voided'`.
+- [ ] Voided documents are excluded from default search (but accessible via `include_voided=true`).
+- [ ] Voided documents still enforce the retention period.
+- [ ] Restore (`document.restored`) requires admin capability and creates an audit event.
+- [ ] Hard delete of file bytes during the retention window is not possible.
+
+## Provenance (§3.4)
+
+- [ ] Upload records: `file_sha256`, `original_filename`, `mime_type`, `version_number`, `uploaded_at`, `uploaded_by`, `source`.
+- [ ] `source = scan_upload` triggers a スキャナ保存 advisory warning in the response.
+
+## Duplicate detection (§3.5)
+
+- [ ] Same `file_sha256` within `organization_id` → warn operator; do not silently auto-accept or reject.
+
+## Search requirements (§4.2)
+
+- [ ] Search by `transaction_date` range works correctly.
+- [ ] Search by `amount_cents` range works correctly.
+- [ ] Search by `counterparty_name` partial match works correctly.
+- [ ] Two-field AND combinations work (e.g. date + counterparty).
+- [ ] Three-field AND combination works.
+- [ ] Search is NOT broken by this change. (Run search tests.)
+
+## Retention enforcement (§5)
+
+- [ ] `retention_expires_at` is computed correctly: `transaction_date + retention_years`.
+- [ ] If `transaction_date` is null, `uploaded_at + retention_years` is used and `date_uncertain = true` is set.
+- [ ] No document can be purged before `retention_expires_at <= now()`.
+- [ ] Changing `vault_settings.retention_years` does NOT shorten retention on existing documents.
+- [ ] Default `retention_years = 10` is not changed without ADR 0004 review.
+
+## Audit events (§7 / ADR 0014)
+
+- [ ] Every mutation that requires an audit event has one (see event type table in `terminology.md`).
+- [ ] `audit_events` are written in the same transaction as the mutation.
+- [ ] `audit_events` are never updated or deleted by application code in this change.
+- [ ] Before/after snapshots do not contain secrets (passwords, tokens, storage paths).
+
+## Organization scoping
+
+- [ ] Every query on a tenant-scoped table includes `organization_id`.
+- [ ] Cross-tenant reads are impossible via this change.
+
+## OCR policy (§8)
+
+- [ ] If OCR is involved: suggested values go to `suggested_*` fields only.
+- [ ] No OCR value is auto-promoted to authoritative without explicit operator confirmation.
+
+## Export (§10)
+
+- [ ] Export is read-only — it does not modify any stored data.
+- [ ] Manifest CSV includes: `document_id`, `version`, `transaction_date`, `amount_cents`, `counterparty_name`, `category`, `file_sha256`, `uploaded_at`, `voided_at`.
+
+## Scope (§11 / scope-contract)
+
+- [ ] This change does NOT add: invoice issuance, reconciliation, dunning, CSV mapping, journal entries, tax computation, or expense approval.
+- [ ] If in doubt, check `docs/explanation/scope-contract.md` DON'T list.
+
+---
+
+## Verification command
+
+```bash
+composer check
+```
+
+Run compliance-critical test suite:
+
+```bash
+composer test:compliance
+```
+
+(When defined in Phase 1.)

--- a/docs/review/database.md
+++ b/docs/review/database.md
@@ -1,0 +1,57 @@
+# Database Self-Review Checklist
+
+Use for: migrations, repositories, schema changes, soft delete, audit_events.
+
+---
+
+## Migration
+
+- [ ] Migration file name: `YYYYMMDDHHMMSS_snake_description.php`.
+- [ ] Migration is in `database/migrations/`.
+- [ ] Schema snapshot updated in `database/schema/{table}.sql`.
+- [ ] Migration is reversible (`down()` method is correct).
+- [ ] New tenant-scoped tables include `organization_id NOT NULL`.
+- [ ] Retention-related tables include `retention_expires_at DATE NOT NULL` where applicable.
+- [ ] `audit_events` table has no soft-delete column — append only.
+- [ ] Money columns use `INT` (not DECIMAL or FLOAT) with `*_cents` suffix and allow `NULL` where the value is optional.
+- [ ] Hash columns use `VARCHAR(64)` with `*_sha256` suffix.
+- [ ] Status columns use ENUM matching terminology.md values.
+
+## Repository
+
+- [ ] All SQL is inside `Pdo*Repository` classes only — none in UseCase, Handler, or Domain.
+- [ ] Every query on a tenant-scoped table includes `WHERE organization_id = ?`.
+- [ ] No cross-tenant reads (cross-tenant is superadmin only, enforced by middleware context).
+- [ ] Repository returns domain objects or primitives — not raw PDO result rows.
+- [ ] Row values are cast to typed PHP values on the way out of the repository.
+- [ ] `findById` (and similar) returns `null` for "not found" — does not throw.
+- [ ] `save` / `insert` returns the new ID.
+- [ ] `DatabaseQueryExecutorInterface` from NENE2 is used — not raw PDO.
+
+## Soft delete / void
+
+- [ ] Vault documents use `status = 'voided'` + `voided_at` + `voided_by` + `void_reason` — not `is_deleted`.
+- [ ] Default search queries exclude `status = 'voided'` unless `include_voided = true` is requested.
+- [ ] Voided documents are still subject to retention enforcement.
+
+## Audit events
+
+- [ ] `audit_events` is append-only; no UPDATE or DELETE SQL on this table.
+- [ ] Every `INSERT INTO audit_events` is in the same transaction as the mutation it records.
+- [ ] `before_json` and `after_json` do not contain secrets (passwords, tokens, file paths).
+- [ ] DB user has INSERT on `audit_events`, NOT UPDATE or DELETE (verify in migration or setup doc).
+
+## Indexes
+
+- [ ] Indexes are added on columns used in WHERE clauses (especially `organization_id`, `transaction_date`, `counterparty_name`).
+- [ ] Index names follow `idx_{table}_{columns}` convention.
+- [ ] Unique constraints follow `uniq_{table}_{columns}` convention.
+
+---
+
+## Verification
+
+```bash
+composer check
+composer migrations:migrate
+```

--- a/docs/review/docs-policy.md
+++ b/docs/review/docs-policy.md
@@ -1,0 +1,53 @@
+# Documentation Policy Self-Review Checklist
+
+Use for: workflow changes, ADR additions, roadmap updates, Cursor rules, AGENTS.md, CONTRIBUTING.md.
+
+---
+
+## ADRs
+
+- [ ] ADR file name: `docs/adr/NNNN-kebab-title.md`.
+- [ ] Status is one of: `proposed`, `accepted`, `rejected`, `superseded`.
+- [ ] Context, Decision, and Consequences sections are present.
+- [ ] Related ADRs are linked.
+- [ ] If the ADR deviates from `received-document-compliance.md`: professional sign-off is recorded.
+- [ ] If the ADR supersedes another: the superseded ADR's status is updated.
+
+## Compliance and governance docs
+
+- [ ] Changes to `received-document-compliance.md` have a compliance review sign-off (§0.2).
+- [ ] Changes to `scope-contract.md` have an ADR if they add to the DO or DON'T lists.
+- [ ] `terminology.md` is updated when a new identifier is introduced or renamed.
+- [ ] `glossary.md` is updated for new product concepts in the same PR.
+
+## Roadmap and milestones
+
+- [ ] `docs/roadmap.md` is updated if the change affects phases.
+- [ ] `docs/milestones/` is updated if an acceptance criterion changes.
+- [ ] `docs/todo/current.md` reflects current in-progress and next items.
+
+## Language policy (ADR 0008)
+
+- [ ] Repository docs (`README.md`, `AGENTS.md`, `CLAUDE.md`, `docs/`) are English.
+- [ ] Japanese appears only in: UI locale catalogs, operator guides, or parenthetical statutory labels.
+- [ ] OpenAPI descriptions and Problem Details metadata are English.
+
+## No third-party names (ADR 0013)
+
+- [ ] No named commercial products in repository docs (use "bundled cloud accounting SaaS", etc.).
+
+## Cursor rules
+
+- [ ] `.cursor/rules/` summaries are short and accurate.
+- [ ] No policy text is duplicated between `.cursor/rules/` and `docs/`.
+
+## AGENTS.md / CONTRIBUTING.md
+
+- [ ] New docs added in this PR are linked from `CONTRIBUTING.md` or `AGENTS.md` if appropriate.
+- [ ] No references to non-existent files without a `(Phase N+)` note.
+
+---
+
+## Verification
+
+Read the changed docs against the policies above. No automated command.

--- a/docs/review/middleware-security.md
+++ b/docs/review/middleware-security.md
@@ -1,0 +1,67 @@
+# Middleware and Security Self-Review Checklist
+
+Use for: auth, JWT, org resolution, CORS, rate limits, logging, security headers.
+
+---
+
+## Authentication
+
+- [ ] Mutating routes (`POST`, `PATCH`, `DELETE`) require `Authorization: Bearer <token>`.
+- [ ] `BearerTokenMiddleware` (NENE2) is in the middleware pipeline before routing.
+- [ ] JWT verification uses `TokenVerifierInterface` — no raw library call in handlers.
+- [ ] `401 Unauthorized` uses `application/problem+json` with `WWW-Authenticate: Bearer`.
+- [ ] JWT secret is loaded from `NENE_VAULT_JWT_SECRET` env — never hardcoded.
+
+## Authorization (capabilities)
+
+- [ ] Required capability is enforced by `CapabilityMiddleware` per route.
+- [ ] `403 Forbidden` uses `application/problem+json`.
+- [ ] `manage_vault_settings` is required for retention changes.
+- [ ] `upload_document` is required for uploads.
+- [ ] `void_document` is required for void / restore.
+- [ ] `export_documents` is required for manifest export.
+- [ ] `view_documents` is required for search, download, and history.
+
+## Organization resolution
+
+- [ ] `OrgResolverMiddleware` runs before authorization in the middleware pipeline.
+- [ ] `organization_id` is extracted from the resolved org context, not from request body or path param.
+- [ ] A request with no resolvable org returns 401 or 404 (not a server error).
+- [ ] Superadmin (`organization_id = NULL`) cross-tenant operations are explicitly handled.
+
+## Request scoping
+
+- [ ] Every handler uses the org context from middleware — never the raw JWT claim.
+- [ ] Path `{id}` parameters are always cross-checked against the resolved `organization_id`.
+
+## Security headers
+
+- [ ] `X-Content-Type-Options: nosniff` is set.
+- [ ] `X-Frame-Options: DENY` is set.
+- [ ] No `Server` header revealing implementation details.
+
+## File download security
+
+- [ ] File download endpoint requires authentication.
+- [ ] File is served via application-layer streaming — not by redirecting to the storage path.
+- [ ] Storage path is not visible in the download URL or response headers.
+- [ ] Download validates `organization_id` ownership before serving.
+
+## Logging
+
+- [ ] No secrets, tokens, authorization headers, or file paths are logged.
+- [ ] Logs include `request_id` for correlation.
+- [ ] Failed auth attempts are logged (credential type, failure reason category — not the credential value).
+
+## CORS
+
+- [ ] CORS allowed origins are configured explicitly — not `*` in production.
+- [ ] Pre-flight OPTIONS requests are handled correctly.
+
+---
+
+## Verification
+
+```bash
+composer check
+```

--- a/docs/review/openapi-contract.md
+++ b/docs/review/openapi-contract.md
@@ -1,0 +1,53 @@
+# OpenAPI Contract Self-Review Checklist
+
+Use for: OpenAPI schema changes, new endpoints, examples, contract tests.
+
+---
+
+## Structure
+
+- [ ] `docs/openapi/openapi.yaml` is valid OpenAPI 3.1.
+- [ ] Every public route has a corresponding operation with a stable `operationId`.
+- [ ] `operationId` is camelCase and matches the handler naming convention.
+- [ ] Tags are PascalCase singular group names (`System`, `Admin`, `Document`, `Audit`, `Export`).
+
+## Schemas
+
+- [ ] Request schemas: required fields marked, types correct, `amount_cents` is nullable integer.
+- [ ] Response schemas: snake_case properties, no storage paths.
+- [ ] List responses use `{ items: [...], limit: integer, offset: integer }` envelope.
+- [ ] `file_sha256` is `type: string, pattern: ^[0-9a-f]{64}$`.
+- [ ] Status enum values match `terminology.md`.
+- [ ] Money amounts are `type: integer, nullable: true` — never `number`.
+
+## Problem Details
+
+- [ ] Non-2xx responses reference shared `ProblemDetails` schema (once created).
+- [ ] `type` URIs use `https://nene-vault.dev/problems/` base.
+- [ ] `401`, `403`, `404`, `413`, `415`, `422`, `500` are documented for applicable routes.
+- [ ] Validation errors reference `ValidationProblemDetails` schema (once created).
+
+## Examples
+
+- [ ] `200` example is structurally valid against the response schema.
+- [ ] Examples do not contain real secrets, real user data, or real storage paths.
+- [ ] `file_sha256` in examples is a valid 64-char hex string.
+
+## Security
+
+- [ ] Mutating routes declare `security: [{ bearerAuth: [] }]`.
+- [ ] `GET /health` is explicitly listed as unauthenticated.
+
+## Contract tests
+
+- [ ] `composer openapi` passes (OpenAPI document is valid).
+- [ ] Runtime contract tests pass for documented `200` examples.
+
+---
+
+## Verification
+
+```bash
+composer openapi
+composer check
+```

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -10,7 +10,7 @@ Operators self-host Vault to store and search **received** vendor documents with
 
 ## Phase 0: Governance and Foundation
 
-- Governance docs, ADR 0001/0002/0007–0012/0009 ✅
+- Governance docs, ADR 0001–0006/0008–0014 ✅
 - Product vision, scope contract, compliance doc ✅
 - NENE2 scaffold + `GET /health` 🔲 Issue #4+
 - 税理士 review gate before Phase 2 UI 🔲

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,13 +1,13 @@
 # Current TODO
 
-**Phase 0 — Governance and product design** (2026-05-29 bootstrap)
+**Phase 0 — Governance and product design**
 
-## In progress
+## Done
 
-- [ ] Issue #1: Governance bootstrap → PR → merge
-- [ ] Issue #2: Product vision & requirements review → PR → merge
+- [x] Issue #1: Governance bootstrap — merged (PR #1, 2026-05-30)
+- [x] Issue #2: Product vision & requirements review — merged (PR #2, 2026-05-30)
 
-## Next (Phase 0+)
+## Next (Phase 0 → Phase 1)
 
 - [ ] Issue #4: NENE2 runtime scaffold + `GET /health`
 - [ ] Issue #5: OpenAPI stub (document endpoints)
@@ -22,4 +22,4 @@ None.
 
 Parallel bootstrap with **`nene-profile`**. See publication-strategy decision 0005.
 
-Last updated: 2026-05-29
+Last updated: 2026-05-30

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -23,9 +23,10 @@ See also: `docs/inheritance-from-nene2.md`.
 Use Conventional Commit style as the prefix:
 
 - `docs/1-governance-foundation`
-- `feat/5-bank-csv-import`
-- `fix/12-allocation-overpayment-credit`
-- `test/8-dunning-minimum-interval`
+- `feat/4-nene2-runtime-scaffold`
+- `feat/5-openapi-stub-document-endpoints`
+- `fix/12-document-search-date-range`
+- `test/8-upload-sha256-duplicate-warning`
 
 ## PR Requirements
 


### PR DESCRIPTION
## Summary

- NENE2 の全コーディング規約を nene-vault ドメインに適合させてローカルドキュメントとして整備
- 電帳法コンプライアンスに特化したレビューチェックリストを追加
- Phase 1 ランタイム実装 (Issue #4+) 前にコーディングルールを確定

## 追加ファイル

**`docs/development/`**
- `coding-standards.md` — NENE2 PHP ベースライン + vault 固有ルール（整合性・監査・テナントスコープ）
- `backend-standards.md` — `NeneVault\` 名前空間、モジュールレイアウト、レイヤリングルール
- `naming-conventions.md` — PHP/HTTP/JSON/DB/env/テスト/MCP/フロントエンドの命名規則
- `commit-conventions.md` — Conventional Commits (NENE2 継承)
- `adr.md` — ADR 運用ガイド
- `self-review.md` — セルフレビューチェックリストポリシー
- `frontend-standards.md` — Phase 2 プレースホルダー

**`docs/review/`** (全 6 ファイル新規)
- `compliance.md` — **Binding** 電帳法受取書類コンプライアンスチェックリスト
- `backend-api.md`, `database.md`, `middleware-security.md`, `openapi-contract.md`, `docs-policy.md`

**`docs/`**
- `inheritance-from-nene2.md` — NENE2 継承マップ

**`docs/adr/`** (新規 4 本)
- `0003` Tier A/B デプロイ、`0004` 保存期間起算日、`0005` UI言語スコープ、`0014` 監査ログスキーマ

## 修正ファイル

- `received-document-compliance.md` — §0 支配原則・条文根拠テーブル・スコープ定義追加
- `domain-model.md` — ER図・状態機械・全フィールド定義追加
- `terminology.md`, `scope-contract.md`, `requirements.md`, `adr/0006` — vault ドメインに整合

## Self-review

Self-review: docs-policy, compliance

## Verification

ドキュメントのみ。`composer check` は Issue #4 (NENE2 runtime scaffold) 完了後。

Closes #3