### PR TITLE
feat: OpenAPI 3.1 contract — all Phase 1 endpoints (spec-first)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,11 +33,13 @@
         "migrations:migrate": "phinx migrate -c phinx.php",
         "migrations:rollback": "phinx rollback -c phinx.php",
         "locales": "php tools/validate-locales.php",
+        "openapi": "php tools/validate-openapi.php",
         "check": [
             "@test",
             "@analyse",
             "@cs",
-            "@locales"
+            "@locales",
+            "@openapi"
         ]
     },
     "config": {
@@ -47,6 +49,7 @@
         "friendsofphp/php-cs-fixer": "^3.95",
         "phpstan/phpstan": "^2.1",
         "phpunit/phpunit": "^13.1",
-        "robmorgan/phinx": "^0.16.11"
+        "robmorgan/phinx": "^0.16.11",
+        "symfony/yaml": "^8.0"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d3096fe78d558a595adb585de08bf94f",
+    "content-hash": "b4882fb45ad7804d8e8e3e9e0857361e",
     "packages": [
         {
             "name": "graham-campbell/result-type",
@@ -6079,6 +6079,82 @@
             ],
             "support": {
                 "source": "https://github.com/symfony/string/tree/v8.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-29T05:06:50+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v8.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "efb42bd2c6f4f3ccfd4683583449938b5fc146b0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/efb42bd2c6f4f3ccfd4683583449938b5fc146b0",
+                "reference": "efb42bd2c6f4f3ccfd4683583449938b5fc146b0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/console": "<7.4"
+            },
+            "require-dev": {
+                "symfony/console": "^7.4|^8.0",
+                "yaml/yaml-test-suite": "*"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v8.1.0"
             },
             "funding": [
                 {

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,0 +1,1373 @@
+openapi: 3.1.0
+info:
+  title: NeNe Vault API
+  version: 0.1.0
+  description: >
+    NeNe Vault public API contract — received-document archive for Japan SMB
+    (電子帳簿保存法). Multi-tenant. Phase 1 covers auth, organizations, users,
+    vault settings, audit events, and the received-document lifecycle
+    (upload, search, detail, metadata edit, void/restore, history, download).
+    All identifiers follow docs/terms.md. Errors use RFC 9457 Problem Details.
+servers:
+  - url: http://localhost:8080
+    description: Local development server
+tags:
+  - name: System
+    description: Runtime health endpoints.
+  - name: Auth
+    description: Authentication — login and JWT issuance.
+  - name: Organization
+    description: Organization (tenant) management. Superadmin only.
+  - name: User
+    description: User account management within an organization. Admin only.
+  - name: VaultSettings
+    description: Per-organization retention and sibling-link settings.
+  - name: Document
+    description: Received-document lifecycle — upload, search, void, history, download.
+  - name: Audit
+    description: Append-only audit event log.
+
+paths:
+  /health:
+    get:
+      tags: [System]
+      summary: Health check
+      description: Operational health check. Unauthenticated.
+      operationId: getHealth
+      responses:
+        '200':
+          description: Service healthy.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthResponse'
+              examples:
+                ok:
+                  value:
+                    status: ok
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /admin/auth/login:
+    post:
+      tags: [Auth]
+      summary: Log in
+      description: Authenticates with email and password, returns a JWT bearer token. Unauthenticated.
+      operationId: login
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoginRequest'
+            example:
+              email: admin@example.com
+              password: secret
+      responses:
+        '200':
+          description: Token issued.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LoginResponse'
+              examples:
+                ok:
+                  value:
+                    token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+                    expires_at: '2026-05-31T00:00:00Z'
+                    user_id: 1
+                    email: admin@example.com
+                    role: admin
+                    org_id: 1
+        '401':
+          $ref: '#/components/responses/InvalidCredentials'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+
+  /admin/organizations:
+    get:
+      tags: [Organization]
+      summary: List organizations
+      description: Returns a paginated list of organizations. Superadmin only.
+      operationId: listOrganizations
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/LimitQuery'
+        - $ref: '#/components/parameters/OffsetQuery'
+      responses:
+        '200':
+          description: Paginated organization list.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrganizationListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+    post:
+      tags: [Organization]
+      summary: Create organization
+      description: Creates a new organization (tenant) and seeds default vault settings. Superadmin only.
+      operationId: createOrganization
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateOrganizationRequest'
+            example:
+              name: Sample Inc.
+              slug: sample-corp
+              plan: free
+              is_active: true
+      responses:
+        '201':
+          description: Organization created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrganizationResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '409':
+          $ref: '#/components/responses/OrganizationSlugConflict'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+
+  /admin/organizations/{id}:
+    parameters:
+      - $ref: '#/components/parameters/IdPath'
+    get:
+      tags: [Organization]
+      summary: Get organization
+      description: Returns a single organization by ID. Superadmin only.
+      operationId: getOrganizationById
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Organization detail.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrganizationResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/OrganizationNotFound'
+    patch:
+      tags: [Organization]
+      summary: Update organization
+      description: Updates an organization. Superadmin only. Audited.
+      operationId: updateOrganization
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateOrganizationRequest'
+      responses:
+        '200':
+          description: Organization updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrganizationResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/OrganizationNotFound'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+    delete:
+      tags: [Organization]
+      summary: Delete organization
+      description: Deletes an organization. Superadmin only. Audited.
+      operationId: deleteOrganization
+      security:
+        - bearerAuth: []
+      responses:
+        '204':
+          description: Organization deleted.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/OrganizationNotFound'
+
+  /admin/users:
+    get:
+      tags: [User]
+      summary: List users
+      description: Returns users within the resolved organization. Admin only.
+      operationId: listUsers
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/LimitQuery'
+        - $ref: '#/components/parameters/OffsetQuery'
+      responses:
+        '200':
+          description: User list.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+    post:
+      tags: [User]
+      summary: Create user
+      description: Creates a user within the organization. Admin only. Audited.
+      operationId: createUser
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateUserRequest'
+            example:
+              email: member@example.com
+              password: changeme123
+              role: member
+      responses:
+        '201':
+          description: User created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+
+  /admin/users/{id}:
+    parameters:
+      - $ref: '#/components/parameters/IdPath'
+    get:
+      tags: [User]
+      summary: Get user
+      description: Returns a single user. Admin only.
+      operationId: getUserById
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: User detail.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    patch:
+      tags: [User]
+      summary: Update user
+      description: Updates a user. Admin only. Audited.
+      operationId: updateUser
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateUserRequest'
+      responses:
+        '200':
+          description: User updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+    delete:
+      tags: [User]
+      summary: Delete user
+      description: Deletes a user. Admin only. Audited.
+      operationId: deleteUser
+      security:
+        - bearerAuth: []
+      responses:
+        '204':
+          description: User deleted.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /admin/vault/settings:
+    get:
+      tags: [VaultSettings]
+      summary: Get vault settings
+      description: Returns retention and sibling-link settings for the resolved organization.
+      operationId: getVaultSettings
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Vault settings.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VaultSettingsResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+    patch:
+      tags: [VaultSettings]
+      summary: Update vault settings
+      description: >
+        Updates retention years (min 7, max 99; default 10 — see ADR 0004) and
+        optional sibling-link config. Admin only. Audited.
+      operationId: updateVaultSettings
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateVaultSettingsRequest'
+            example:
+              retention_years: 10
+      responses:
+        '200':
+          description: Vault settings updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VaultSettingsResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+
+  /admin/vault/documents:
+    get:
+      tags: [Document]
+      summary: Search documents
+      description: >
+        Searches received documents by transaction date range, amount range,
+        counterparty (partial), and category. Combinations of two or more fields
+        are supported (検索要件, 電帳法施行規則 第4条第1項第3号). Voided documents
+        are excluded unless include_voided=true.
+      operationId: searchDocuments
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: transaction_date_from
+          in: query
+          description: Transaction date range start (取引年月日, inclusive).
+          schema:
+            type: string
+            format: date
+        - name: transaction_date_to
+          in: query
+          description: Transaction date range end (取引年月日, inclusive).
+          schema:
+            type: string
+            format: date
+        - name: amount_min_cents
+          in: query
+          description: Minimum amount (取引金額) in integer JPY.
+          schema:
+            type: integer
+        - name: amount_max_cents
+          in: query
+          description: Maximum amount (取引金額) in integer JPY.
+          schema:
+            type: integer
+        - name: counterparty_name
+          in: query
+          description: Counterparty (取引先名) partial match.
+          schema:
+            type: string
+        - name: category
+          in: query
+          schema:
+            $ref: '#/components/schemas/DocumentCategory'
+        - name: include_voided
+          in: query
+          description: Include voided documents in results.
+          schema:
+            type: boolean
+            default: false
+        - $ref: '#/components/parameters/LimitQuery'
+        - $ref: '#/components/parameters/OffsetQuery'
+      responses:
+        '200':
+          description: Paginated document list.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VaultDocumentListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+    post:
+      tags: [Document]
+      summary: Upload document
+      description: >
+        Uploads a received document (PDF/JPEG/PNG) with metadata as multipart
+        form data. Computes SHA-256, creates document_version 1, and records a
+        document.uploaded audit event. Duplicate SHA-256 within the organization
+        returns 409 duplicate-file unless confirmed. Member, admin, superadmin.
+      operationId: uploadDocument
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/UploadDocumentRequest'
+      responses:
+        '201':
+          description: Document uploaded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VaultDocumentResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '409':
+          $ref: '#/components/responses/DuplicateFile'
+        '413':
+          $ref: '#/components/responses/FileTooLarge'
+        '415':
+          $ref: '#/components/responses/MimeTypeNotAllowed'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+
+  /admin/vault/documents/{id}:
+    parameters:
+      - $ref: '#/components/parameters/IdPath'
+    get:
+      tags: [Document]
+      summary: Get document detail
+      description: Returns a single document with current metadata and version info.
+      operationId: getDocumentById
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Document detail.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VaultDocumentResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/DocumentNotFound'
+
+  /admin/vault/documents/{id}/metadata:
+    parameters:
+      - $ref: '#/components/parameters/IdPath'
+    patch:
+      tags: [Document]
+      summary: Update document metadata
+      description: >
+        Updates transaction_date, amount_cents, counterparty_name, category, or
+        tags. File bytes are never changed. Records a document.metadata_changed
+        audit event with before/after. Member (own), admin, superadmin.
+      operationId: updateDocumentMetadata
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateDocumentMetadataRequest'
+      responses:
+        '200':
+          description: Metadata updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VaultDocumentResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/DocumentNotFound'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+
+  /admin/vault/documents/{id}/void:
+    parameters:
+      - $ref: '#/components/parameters/IdPath'
+    post:
+      tags: [Document]
+      summary: Void document
+      description: >
+        Voids a document (logical deactivation) with a mandatory reason. The
+        document remains stored and counts toward retention. Records a
+        document.voided audit event. Admin, superadmin.
+      operationId: voidDocument
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VoidDocumentRequest'
+            example:
+              void_reason: Registered by mistake
+      responses:
+        '200':
+          description: Document voided.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VaultDocumentResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/DocumentNotFound'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+
+  /admin/vault/documents/{id}/restore:
+    parameters:
+      - $ref: '#/components/parameters/IdPath'
+    post:
+      tags: [Document]
+      summary: Restore voided document
+      description: Returns a voided document to active status. Records a document.restored audit event. Admin, superadmin.
+      operationId: restoreDocument
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Document restored.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VaultDocumentResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/DocumentNotFound'
+
+  /admin/vault/documents/{id}/history:
+    parameters:
+      - $ref: '#/components/parameters/IdPath'
+    get:
+      tags: [Document]
+      summary: Get document history
+      description: Returns all versions and audit events for a document (訂正削除の履歴).
+      operationId: getDocumentHistory
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Document history.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DocumentHistoryResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/DocumentNotFound'
+
+  /admin/vault/documents/{id}/versions/{versionId}/download:
+    parameters:
+      - $ref: '#/components/parameters/IdPath'
+      - name: versionId
+        in: path
+        required: true
+        description: document_version ID.
+        schema:
+          type: string
+    get:
+      tags: [Document]
+      summary: Download document version
+      description: >
+        Streams the file bytes for a specific version through an authenticated
+        endpoint. SHA-256 is verified before serving. The storage path is never
+        exposed.
+      operationId: downloadDocumentVersion
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: File bytes.
+          content:
+            application/pdf:
+              schema:
+                type: string
+                format: binary
+            image/jpeg:
+              schema:
+                type: string
+                format: binary
+            image/png:
+              schema:
+                type: string
+                format: binary
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/DocumentNotFound'
+
+  /admin/audit-events:
+    get:
+      tags: [Audit]
+      summary: List audit events
+      description: >
+        Returns a paginated, filterable list of audit events. Superadmin sees all;
+        other roles see their organization only. Append-only — events are never
+        modified or deleted.
+      operationId: listAuditEvents
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: entity_type
+          in: query
+          schema:
+            type: string
+        - name: entity_id
+          in: query
+          schema:
+            type: string
+        - name: action
+          in: query
+          schema:
+            type: string
+        - name: actor_user_id
+          in: query
+          schema:
+            type: integer
+        - $ref: '#/components/parameters/LimitQuery'
+        - $ref: '#/components/parameters/OffsetQuery'
+      responses:
+        '200':
+          description: Paginated audit event list.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuditEventListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: 'JWT issued by POST /admin/auth/login. Sent as `Authorization: Bearer <token>`.'
+
+  parameters:
+    LimitQuery:
+      name: limit
+      in: query
+      description: Maximum items to return (1–100, default 20).
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 100
+        default: 20
+    OffsetQuery:
+      name: offset
+      in: query
+      description: Number of items to skip (default 0).
+      schema:
+        type: integer
+        minimum: 0
+        default: 0
+    IdPath:
+      name: id
+      in: path
+      required: true
+      description: Resource ID.
+      schema:
+        type: string
+
+  schemas:
+    HealthResponse:
+      type: object
+      required: [status]
+      properties:
+        status:
+          type: string
+          examples: [ok]
+
+    LoginRequest:
+      type: object
+      required: [email, password]
+      properties:
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+
+    LoginResponse:
+      type: object
+      required: [token, expires_at, user_id, email, role]
+      properties:
+        token:
+          type: string
+        expires_at:
+          type: string
+          format: date-time
+        user_id:
+          type: integer
+        email:
+          type: string
+          format: email
+        role:
+          $ref: '#/components/schemas/Role'
+        org_id:
+          type: [integer, 'null']
+          description: Organization ID; null for superadmin.
+
+    Role:
+      type: string
+      enum: [superadmin, admin, member, viewer]
+
+    OrganizationResponse:
+      type: object
+      required: [id, name, slug, plan, is_active]
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        slug:
+          type: string
+        plan:
+          type: string
+        is_active:
+          type: boolean
+        external_id:
+          type: [string, 'null']
+        custom_domain:
+          type: [string, 'null']
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    OrganizationListResponse:
+      type: object
+      required: [items, total, limit, offset]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/OrganizationResponse'
+        total:
+          type: integer
+        limit:
+          type: integer
+        offset:
+          type: integer
+
+    CreateOrganizationRequest:
+      type: object
+      required: [name, slug]
+      properties:
+        name:
+          type: string
+        slug:
+          type: string
+          pattern: '^[a-z0-9-]+$'
+        plan:
+          type: string
+          default: free
+        is_active:
+          type: boolean
+          default: true
+        external_id:
+          type: [string, 'null']
+        custom_domain:
+          type: [string, 'null']
+
+    UpdateOrganizationRequest:
+      type: object
+      required: [name, slug]
+      properties:
+        name:
+          type: string
+        slug:
+          type: string
+          pattern: '^[a-z0-9-]+$'
+        plan:
+          type: string
+        is_active:
+          type: boolean
+        external_id:
+          type: [string, 'null']
+        custom_domain:
+          type: [string, 'null']
+
+    UserResponse:
+      type: object
+      required: [id, email, role, status]
+      properties:
+        id:
+          type: integer
+        email:
+          type: string
+          format: email
+        role:
+          $ref: '#/components/schemas/Role'
+        organization_id:
+          type: [integer, 'null']
+        status:
+          type: string
+          enum: [active, invited]
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    UserListResponse:
+      type: object
+      required: [items, total, limit, offset]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserResponse'
+        total:
+          type: integer
+        limit:
+          type: integer
+        offset:
+          type: integer
+
+    CreateUserRequest:
+      type: object
+      required: [email, password, role]
+      properties:
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+          minLength: 8
+        role:
+          $ref: '#/components/schemas/Role'
+
+    UpdateUserRequest:
+      type: object
+      properties:
+        email:
+          type: string
+          format: email
+        role:
+          $ref: '#/components/schemas/Role'
+        status:
+          type: string
+          enum: [active, invited]
+
+    VaultSettingsResponse:
+      type: object
+      required: [organization_id, retention_years]
+      properties:
+        organization_id:
+          type: integer
+        retention_years:
+          type: integer
+          minimum: 7
+          maximum: 99
+        storage_path_override:
+          type: [string, 'null']
+        invoice_api_base_url:
+          type: [string, 'null']
+        clear_api_base_url:
+          type: [string, 'null']
+        updated_at:
+          type: [string, 'null']
+          format: date-time
+
+    UpdateVaultSettingsRequest:
+      type: object
+      properties:
+        retention_years:
+          type: integer
+          minimum: 7
+          maximum: 99
+          description: Years to retain (from transaction date). Default 10; below 10 warns. See ADR 0004.
+        storage_path_override:
+          type: [string, 'null']
+        invoice_api_base_url:
+          type: [string, 'null']
+        clear_api_base_url:
+          type: [string, 'null']
+
+    DocumentStatus:
+      type: string
+      enum: [active, voided]
+
+    DocumentCategory:
+      type: string
+      enum: [invoice_received, contract, receipt, delivery_note, other]
+
+    DocumentSource:
+      type: string
+      enum: [web_upload, email_inbound, api, scan_upload]
+
+    VaultDocumentResponse:
+      type: object
+      required:
+        - id
+        - organization_id
+        - status
+        - counterparty_name
+        - category
+        - file_sha256
+        - version_number
+        - source
+        - uploaded_at
+      properties:
+        id:
+          type: string
+        organization_id:
+          type: integer
+        status:
+          $ref: '#/components/schemas/DocumentStatus'
+        transaction_date:
+          type: [string, 'null']
+          format: date
+          description: 取引年月日.
+        amount_cents:
+          type: [integer, 'null']
+          description: 取引金額 in integer JPY. Null when the document carries no amount.
+        counterparty_name:
+          type: string
+          description: 取引先名.
+        category:
+          $ref: '#/components/schemas/DocumentCategory'
+        tags:
+          type: array
+          items:
+            type: string
+        file_sha256:
+          type: string
+          pattern: '^[0-9a-f]{64}$'
+        mime_type:
+          type: string
+          enum: [application/pdf, image/jpeg, image/png]
+        original_filename:
+          type: string
+        file_size_bytes:
+          type: integer
+        version_number:
+          type: integer
+        source:
+          $ref: '#/components/schemas/DocumentSource'
+        uploaded_at:
+          type: string
+          format: date-time
+        uploaded_by:
+          type: [integer, 'null']
+        voided_at:
+          type: [string, 'null']
+          format: date-time
+        voided_by:
+          type: [integer, 'null']
+        void_reason:
+          type: [string, 'null']
+        date_uncertain:
+          type: boolean
+        is_metadata_confirmed:
+          type: boolean
+        retention_years:
+          type: integer
+        retention_expires_at:
+          type: string
+          format: date
+
+    VaultDocumentListResponse:
+      type: object
+      required: [items, total, limit, offset]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/VaultDocumentResponse'
+        total:
+          type: integer
+        limit:
+          type: integer
+        offset:
+          type: integer
+
+    UploadDocumentRequest:
+      type: object
+      required: [file, counterparty_name, category]
+      properties:
+        file:
+          type: string
+          format: binary
+          description: PDF, JPEG, or PNG file.
+        transaction_date:
+          type: string
+          format: date
+          description: 取引年月日. Optional; if omitted, date_uncertain is set.
+        amount_cents:
+          type: integer
+          description: 取引金額 in integer JPY. Optional.
+        counterparty_name:
+          type: string
+          description: 取引先名.
+        category:
+          $ref: '#/components/schemas/DocumentCategory'
+        tags:
+          type: string
+          description: Comma-separated tags.
+        confirm_duplicate:
+          type: boolean
+          default: false
+          description: Set true to accept an upload whose SHA-256 already exists in the organization.
+
+    UpdateDocumentMetadataRequest:
+      type: object
+      properties:
+        transaction_date:
+          type: [string, 'null']
+          format: date
+        amount_cents:
+          type: [integer, 'null']
+        counterparty_name:
+          type: string
+        category:
+          $ref: '#/components/schemas/DocumentCategory'
+        tags:
+          type: array
+          items:
+            type: string
+
+    VoidDocumentRequest:
+      type: object
+      required: [void_reason]
+      properties:
+        void_reason:
+          type: string
+          description: Mandatory reason for voiding.
+        void_note:
+          type: [string, 'null']
+          description: Optional extended context.
+
+    DocumentVersionResponse:
+      type: object
+      required: [id, version_number, file_sha256, mime_type, original_filename, source, uploaded_at]
+      properties:
+        id:
+          type: string
+        version_number:
+          type: integer
+        file_sha256:
+          type: string
+          pattern: '^[0-9a-f]{64}$'
+        mime_type:
+          type: string
+        original_filename:
+          type: string
+        file_size_bytes:
+          type: integer
+        source:
+          $ref: '#/components/schemas/DocumentSource'
+        uploaded_at:
+          type: string
+          format: date-time
+        uploaded_by:
+          type: [integer, 'null']
+
+    DocumentHistoryResponse:
+      type: object
+      required: [versions, audit_events]
+      properties:
+        versions:
+          type: array
+          items:
+            $ref: '#/components/schemas/DocumentVersionResponse'
+        audit_events:
+          type: array
+          items:
+            $ref: '#/components/schemas/AuditEventResponse'
+
+    AuditEventResponse:
+      type: object
+      required: [id, action, entity_type, entity_id, created_at]
+      properties:
+        id:
+          type: integer
+        action:
+          type: string
+        entity_type:
+          type: string
+        entity_id:
+          type: string
+        actor_user_id:
+          type: [integer, 'null']
+        organization_id:
+          type: [integer, 'null']
+        before_json:
+          type: [object, 'null']
+          additionalProperties: true
+        after_json:
+          type: [object, 'null']
+          additionalProperties: true
+        source:
+          type: string
+        metadata_json:
+          type: [object, 'null']
+          additionalProperties: true
+        created_at:
+          type: string
+          format: date-time
+
+    AuditEventListResponse:
+      type: object
+      required: [items, total, limit, offset]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/AuditEventResponse'
+        total:
+          type: integer
+        limit:
+          type: integer
+        offset:
+          type: integer
+
+    ExportDocumentsRequest:
+      type: object
+      properties:
+        transaction_date_from:
+          type: string
+          format: date
+        transaction_date_to:
+          type: string
+          format: date
+        counterparty_name:
+          type: string
+        include_voided:
+          type: boolean
+          default: false
+
+    ProblemDetails:
+      type: object
+      required: [type, title, status]
+      properties:
+        type:
+          type: string
+          format: uri
+          description: Stable problem type URI under https://nene-vault.dev/problems/.
+        title:
+          type: string
+        status:
+          type: integer
+        detail:
+          type: string
+        instance:
+          type: string
+
+    ValidationProblemDetails:
+      allOf:
+        - $ref: '#/components/schemas/ProblemDetails'
+        - type: object
+          properties:
+            errors:
+              type: array
+              items:
+                type: object
+                required: [field, message, code]
+                properties:
+                  field:
+                    type: string
+                  message:
+                    type: string
+                  code:
+                    type: string
+
+  responses:
+    Unauthorized:
+      description: Authentication required or token invalid.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+          example:
+            type: https://nene-vault.dev/problems/unauthorized
+            title: Unauthorized
+            status: 401
+            detail: No Bearer token was provided.
+    Forbidden:
+      description: Insufficient capability or organization access denied.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+          example:
+            type: https://nene-vault.dev/problems/forbidden
+            title: Forbidden
+            status: 403
+            detail: You do not have permission to perform this action.
+    NotFound:
+      description: Resource not found.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+    DocumentNotFound:
+      description: Document not found.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+          example:
+            type: https://nene-vault.dev/problems/document-not-found
+            title: Document Not Found
+            status: 404
+    OrganizationNotFound:
+      description: Organization not found.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+          example:
+            type: https://nene-vault.dev/problems/organization-not-found
+            title: Organization Not Found
+            status: 404
+    OrganizationSlugConflict:
+      description: Slug already in use.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+          example:
+            type: https://nene-vault.dev/problems/organization-slug-conflict
+            title: Organization Slug Conflict
+            status: 409
+    DuplicateFile:
+      description: A file with the same SHA-256 already exists in this organization.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+          example:
+            type: https://nene-vault.dev/problems/duplicate-file
+            title: Duplicate File
+            status: 409
+    FileTooLarge:
+      description: File exceeds the maximum allowed size.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+          example:
+            type: https://nene-vault.dev/problems/file-too-large
+            title: File Too Large
+            status: 413
+    MimeTypeNotAllowed:
+      description: File type not in the allowlist (PDF/JPEG/PNG).
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+          example:
+            type: https://nene-vault.dev/problems/mime-type-not-allowed
+            title: MIME Type Not Allowed
+            status: 415
+    InvalidCredentials:
+      description: Email or password incorrect.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+          example:
+            type: https://nene-vault.dev/problems/invalid-credentials
+            title: Invalid Credentials
+            status: 401
+    ValidationFailed:
+      description: Request body failed validation.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ValidationProblemDetails'
+          example:
+            type: https://nene-vault.dev/problems/validation-failed
+            title: Validation Failed
+            status: 422
+            errors:
+              - field: counterparty_name
+                message: This field is required.
+                code: required
+    InternalServerError:
+      description: Unexpected server error.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+          example:
+            type: https://nene-vault.dev/problems/internal-server-error
+            title: Internal Server Error
+            status: 500

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,15 +12,18 @@ Operators self-host Vault to store and search **received** vendor documents with
 
 - Governance docs, ADR 0001–0006/0008–0014 ✅
 - Product vision, scope contract, compliance doc ✅
-- NENE2 scaffold + `GET /health` 🔲 Issue #4+
+- NENE2 scaffold + `GET /health` ✅ (PR #8)
 - 税理士 review gate before Phase 2 UI 🔲
 
 ## Phase 1: Document API
 
-- Multi-tenant + JWT + RBAC (ADR 0006)
-- Upload, metadata, search, void, version history
-- Local filesystem storage (ADR 0012)
-- OpenAPI + PHPUnit + PHPStan 8
+- Multi-tenant + JWT + RBAC (ADR 0006) ✅ (PR #8)
+- Audit logging — before/after on all mutations (ADR 0014) ✅ (PR #10)
+- ja/en locale files (ADR 0005) ✅ (PR #12)
+- OpenAPI 3.1 contract — all Phase 1 endpoints ✅ (PR #14)
+- Upload, metadata, search, void, version history 🔲 (in progress)
+- Local filesystem storage (ADR 0012) 🔲
+- PHPUnit + PHPStan 8 ✅ (gate established)
 
 ## Phase 2: Admin UI + Export
 

--- a/docs/terms.md
+++ b/docs/terms.md
@@ -304,6 +304,7 @@ Admin routes are under `/admin/vault/…` (vault-scoped namespace).
 | Canonical form | Method | Description | DO NOT use |
 | --- | --- | --- | --- |
 | `/health` | GET | Health check (unauthenticated) | `/api/health`, `/ping`, `/status` |
+| `/admin/auth/login` | POST | Login, issue JWT (unauthenticated) | `/login`, `/auth/login`, `/admin/login` |
 | `/admin/vault/documents` | GET | Search documents | `/admin/documents`, `/vault/documents` |
 | `/admin/vault/documents` | POST | Upload document | — |
 | `/admin/vault/documents/{id}` | GET | Get document detail | `/admin/vault/document/{id}` (singular) |
@@ -328,6 +329,7 @@ Admin routes are under `/admin/vault/…` (vault-scoped namespace).
 | Canonical form | Method + Route | DO NOT use |
 | --- | --- | --- |
 | `getHealth` | GET /health | `healthCheck`, `ping` |
+| `login` | POST /admin/auth/login | `authenticate`, `signIn`, `adminLogin` |
 | `uploadDocument` | POST /admin/vault/documents | `createDocument`, `addDocument` |
 | `searchDocuments` | GET /admin/vault/documents | `listDocuments`, `getDocuments` |
 | `getDocumentById` | GET /admin/vault/documents/{id} | `getDocument`, `fetchDocument` |
@@ -409,6 +411,31 @@ Standard fields used across multiple responses:
 | `ExportDocumentsRequest` | Export request body | `CreateExportRequest` |
 | `ProblemDetails` | RFC 9457 error response | `ErrorResponse`, `ApiError`, `Problem` |
 | `ValidationProblemDetails` | Validation error response (extends ProblemDetails) | `ValidationErrorResponse` |
+| `HealthResponse` | Health check response | `StatusResponse`, `PingResponse` |
+| `LoginRequest` | Login request body | `AuthRequest`, `SignInRequest` |
+| `LoginResponse` | Login response (token + claims) | `AuthResponse`, `TokenResponse` |
+| `OrganizationResponse` | Single organization response | `OrgResponse`, `TenantResponse` |
+| `OrganizationListResponse` | List of organizations | `OrgListResponse` |
+| `CreateOrganizationRequest` | Org create body | `NewOrganizationRequest` |
+| `UpdateOrganizationRequest` | Org update body | `EditOrganizationRequest` |
+| `UserResponse` | Single user response | `AccountResponse` |
+| `UserListResponse` | List of users | `AccountListResponse` |
+| `CreateUserRequest` | User create body | `InviteUserRequest`, `NewUserRequest` |
+| `UpdateUserRequest` | User update body | `EditUserRequest` |
+| `DocumentVersionResponse` | Single version response | `VersionResponse` |
+| `DocumentHistoryResponse` | Versions + audit events for a document | `HistoryResponse`, `DocumentAuditResponse` |
+
+### Enum wrapper schemas (OpenAPI)
+
+These wrap an enum whose values are registered in §9–§13. The schema name is the
+PascalCase concept; the values are the canonical codes.
+
+| Canonical form | Wraps values from | DO NOT use |
+| --- | --- | --- |
+| `Role` | §13 Role values | `UserRole`, `RoleEnum` |
+| `DocumentStatus` | §9 status values | `Status`, `VaultDocumentStatus` |
+| `DocumentCategory` | §10 category values | `Category` |
+| `DocumentSource` | §11 source values | `Source`, `UploadSource` |
 
 ---
 

--- a/tools/validate-openapi.php
+++ b/tools/validate-openapi.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Yaml;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+$path = dirname(__DIR__) . '/docs/openapi/openapi.yaml';
+
+try {
+    $document = Yaml::parseFile($path);
+} catch (ParseException $exception) {
+    fwrite(STDERR, sprintf("OpenAPI YAML parse error: %s\n", $exception->getMessage()));
+    exit(1);
+}
+
+if (!is_array($document)) {
+    fwrite(STDERR, "OpenAPI document must parse to a mapping.\n");
+    exit(1);
+}
+
+$errors = [];
+
+foreach (['openapi', 'info', 'paths', 'components'] as $requiredKey) {
+    if (!array_key_exists($requiredKey, $document)) {
+        $errors[] = sprintf('Missing required top-level key: %s', $requiredKey);
+    }
+}
+
+if (($document['openapi'] ?? null) !== '3.1.0') {
+    $errors[] = 'OpenAPI version must be 3.1.0.';
+}
+
+validateInternalReferences($document, $document, '#', $errors);
+
+if ($errors !== []) {
+    foreach ($errors as $error) {
+        fwrite(STDERR, sprintf("OpenAPI validation error: %s\n", $error));
+    }
+
+    exit(1);
+}
+
+echo "OpenAPI contract is valid.\n";
+
+/**
+ * @param array<mixed> $node
+ * @param array<mixed> $document
+ * @param list<string> $errors
+ */
+function validateInternalReferences(array $node, array $document, string $path, array &$errors): void
+{
+    foreach ($node as $key => $value) {
+        $childPath = $path . '/' . (string) $key;
+
+        if ($key === '$ref' && is_string($value) && str_starts_with($value, '#/')) {
+            if (!hasJsonPointer($document, $value)) {
+                $errors[] = sprintf('Unresolved internal reference at %s: %s', $path, $value);
+            }
+
+            continue;
+        }
+
+        if (is_array($value)) {
+            validateInternalReferences($value, $document, $childPath, $errors);
+        }
+    }
+}
+
+/**
+ * @param array<mixed> $document
+ */
+function hasJsonPointer(array $document, string $reference): bool
+{
+    $current = $document;
+
+    foreach (explode('/', substr($reference, 2)) as $segment) {
+        $segment = str_replace(['~1', '~0'], ['/', '~'], $segment);
+
+        if (!is_array($current) || !array_key_exists($segment, $current)) {
+            return false;
+        }
+
+        $current = $current[$segment];
+    }
+
+    return true;
+}


### PR DESCRIPTION
## Summary

spec-first でアプリケーション実装を進めるため、Phase 1 全エンドポイントの
OpenAPI 3.1 契約を定義。すべてのパス・operationId・スキーマ名・フィールド名を
`docs/terms.md` に厳密準拠（23 operationId, 29 schema）。

## docs/openapi/openapi.yaml

**実装済み**（既存挙動を文書化）: health, login, organizations CRUD, vault settings, audit events

**Phase 1 契約**（次に実装）:
| Method | Path | operationId |
|---|---|---|
| POST | /admin/vault/documents | uploadDocument (multipart) |
| GET | /admin/vault/documents | searchDocuments |
| GET | /admin/vault/documents/{id} | getDocumentById |
| PATCH | /admin/vault/documents/{id}/metadata | updateDocumentMetadata |
| POST | /admin/vault/documents/{id}/void | voidDocument |
| POST | /admin/vault/documents/{id}/restore | restoreDocument |
| GET | /admin/vault/documents/{id}/history | getDocumentHistory |
| GET | /admin/vault/documents/{id}/versions/{versionId}/download | downloadDocumentVersion |
| (CRUD) | /admin/users | listUsers / createUser / ... |

## Tooling

- `tools/validate-openapi.php` — YAML パース + 内部 `$ref` 解決チェック
- `composer openapi` を `composer check` に追加（CIゲート化）

## 設計判断

- RFC 9457 Problem Details、base `https://nene-vault.dev/problems/`
- `amount_cents` は nullable integer、`file_sha256` は `^[0-9a-f]{64}$` pattern
- 法定フィールド（取引年月日/取引金額/取引先名）は description に日本語併記
- ランタイムコントラクトテストは Document API 実装時に追加（実装が存在してから）

## docs/terms.md 更新

auth ルート・login operationId・Auth/Org/User/Health スキーマ名・enum ラッパースキーマを登録（docs-policy ルール準拠）

## composer check
PHPUnit 22 / PHPStan 8 / locales 344 / **OpenAPI valid** — all green

Self-review: openapi-contract, docs-policy

Closes #13