### PR TITLE
feat: Document upload + storage foundation + get detail (vertical slice)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /.php-cs-fixer.cache
 /.phpstan.cache/
 .phpunit.result.cache
+/storage/

--- a/database/migrations/20260530000005_create_vault_documents_table.php
+++ b/database/migrations/20260530000005_create_vault_documents_table.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateVaultDocumentsTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('vault_documents', ['id' => false, 'primary_key' => ['id']])
+            ->addColumn('id', 'char', ['limit' => 26, 'null' => false])
+            ->addColumn('organization_id', 'integer', ['null' => false, 'signed' => false])
+            ->addColumn('current_version_id', 'char', ['limit' => 26, 'null' => false])
+            ->addColumn('status', 'string', ['limit' => 16, 'null' => false, 'default' => 'active'])
+            ->addColumn('transaction_date', 'date', ['null' => true, 'default' => null])
+            ->addColumn('amount_cents', 'integer', ['null' => true, 'default' => null])
+            ->addColumn('counterparty_name', 'string', ['limit' => 255, 'null' => false])
+            ->addColumn('category', 'string', ['limit' => 32, 'null' => false])
+            ->addColumn('tags', 'text', ['null' => true, 'default' => null])
+            ->addColumn('date_uncertain', 'boolean', ['null' => false, 'default' => false])
+            ->addColumn('is_metadata_confirmed', 'boolean', ['null' => false, 'default' => false])
+            ->addColumn('retention_years', 'integer', ['null' => false, 'default' => 10])
+            ->addColumn('retention_expires_at', 'date', ['null' => false])
+            ->addColumn('uploaded_at', 'datetime', ['null' => false])
+            ->addColumn('uploaded_by', 'integer', ['null' => true, 'default' => null, 'signed' => false])
+            ->addColumn('voided_at', 'datetime', ['null' => true, 'default' => null])
+            ->addColumn('voided_by', 'integer', ['null' => true, 'default' => null, 'signed' => false])
+            ->addColumn('void_reason', 'string', ['limit' => 255, 'null' => true, 'default' => null])
+            ->addColumn('void_note', 'text', ['null' => true, 'default' => null])
+            ->addIndex(['organization_id', 'transaction_date'], ['name' => 'idx_vault_documents_org_date'])
+            ->addIndex(['organization_id', 'counterparty_name'], ['name' => 'idx_vault_documents_org_counterparty'])
+            ->addIndex(['organization_id', 'status'], ['name' => 'idx_vault_documents_org_status'])
+            ->addIndex(['organization_id', 'retention_expires_at'], ['name' => 'idx_vault_documents_org_retention'])
+            ->create();
+    }
+}

--- a/database/migrations/20260530000006_create_document_versions_table.php
+++ b/database/migrations/20260530000006_create_document_versions_table.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Immutable document version records. File bytes are never overwritten;
+ * a correction creates a new row with a higher version_number
+ * (received-document-compliance §3.1).
+ */
+final class CreateDocumentVersionsTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('document_versions', ['id' => false, 'primary_key' => ['id']])
+            ->addColumn('id', 'char', ['limit' => 26, 'null' => false])
+            ->addColumn('vault_document_id', 'char', ['limit' => 26, 'null' => false])
+            ->addColumn('organization_id', 'integer', ['null' => false, 'signed' => false])
+            ->addColumn('version_number', 'integer', ['null' => false])
+            ->addColumn('file_path', 'string', ['limit' => 512, 'null' => false])
+            ->addColumn('file_sha256', 'char', ['limit' => 64, 'null' => false])
+            ->addColumn('mime_type', 'string', ['limit' => 64, 'null' => false])
+            ->addColumn('original_filename', 'string', ['limit' => 255, 'null' => false])
+            ->addColumn('file_size_bytes', 'integer', ['null' => false])
+            ->addColumn('source', 'string', ['limit' => 32, 'null' => false, 'default' => 'web_upload'])
+            ->addColumn('uploaded_at', 'datetime', ['null' => false])
+            ->addColumn('uploaded_by', 'integer', ['null' => true, 'default' => null, 'signed' => false])
+            ->addIndex(['vault_document_id', 'version_number'], ['unique' => true, 'name' => 'uniq_document_versions_doc_version'])
+            ->addIndex(['organization_id', 'file_sha256'], ['name' => 'idx_document_versions_org_sha256'])
+            ->create();
+    }
+}

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -13,6 +13,12 @@ use NeneVault\Audit\AuditRouteRegistrar;
 use NeneVault\Audit\AuditServiceProvider;
 use NeneVault\Auth\AuthRouteRegistrar;
 use NeneVault\Auth\InvalidCredentialsExceptionHandler;
+use NeneVault\Document\DocumentRouteRegistrar;
+use NeneVault\Document\DocumentServiceProvider;
+use NeneVault\Document\DuplicateFileExceptionHandler;
+use NeneVault\Document\FileTooLargeExceptionHandler;
+use NeneVault\Document\MimeTypeNotAllowedExceptionHandler;
+use NeneVault\Document\VaultDocumentNotFoundExceptionHandler;
 use NeneVault\Http\HealthHandler;
 use NeneVault\Organization\OrganizationNotFoundExceptionHandler;
 use NeneVault\Organization\OrganizationRouteRegistrar;
@@ -45,7 +51,8 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
         $builder
             ->addProvider(new AuditServiceProvider())
             ->addProvider(new OrganizationServiceProvider())
-            ->addProvider(new VaultSettingsServiceProvider());
+            ->addProvider(new VaultSettingsServiceProvider())
+            ->addProvider(new DocumentServiceProvider());
 
         // Health handler
         $builder->set(
@@ -70,6 +77,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                 $org = $c->get(OrganizationRouteRegistrar::class);
                 $settings = $c->get(VaultSettingsRouteRegistrar::class);
                 $audit = $c->get(AuditRouteRegistrar::class);
+                $document = $c->get(DocumentRouteRegistrar::class);
 
                 if (!$health instanceof HealthHandler) {
                     throw new LogicException('HealthHandler service is invalid.');
@@ -91,12 +99,17 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     throw new LogicException('AuditRouteRegistrar service is invalid.');
                 }
 
+                if (!$document instanceof DocumentRouteRegistrar) {
+                    throw new LogicException('DocumentRouteRegistrar service is invalid.');
+                }
+
                 return [
                     static fn ($router) => $router->get('/health', $health->handle(...)),
                     static fn ($router) => $auth->register($router),
                     static fn ($router) => $org->register($router),
                     static fn ($router) => $settings->register($router),
                     static fn ($router) => $audit->register($router),
+                    static fn ($router) => $document->register($router),
                 ];
             },
         );
@@ -109,6 +122,10 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $c->get(InvalidCredentialsExceptionHandler::class),
                     $c->get(OrganizationNotFoundExceptionHandler::class),
                     $c->get(OrganizationSlugConflictExceptionHandler::class),
+                    $c->get(VaultDocumentNotFoundExceptionHandler::class),
+                    $c->get(DuplicateFileExceptionHandler::class),
+                    $c->get(MimeTypeNotAllowedExceptionHandler::class),
+                    $c->get(FileTooLargeExceptionHandler::class),
                 ];
             },
         );

--- a/src/Document/DocumentRouteRegistrar.php
+++ b/src/Document/DocumentRouteRegistrar.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+use Nene2\Routing\Router;
+
+final readonly class DocumentRouteRegistrar
+{
+    public function __construct(
+        private UploadDocumentHandler $upload,
+        private GetDocumentByIdHandler $get,
+    ) {
+    }
+
+    public function register(Router $router): void
+    {
+        $router->post('/admin/vault/documents', $this->upload->handle(...));
+        $router->get('/admin/vault/documents/{id}', $this->get->handle(...));
+    }
+}

--- a/src/Document/DocumentServiceProvider.php
+++ b/src/Document/DocumentServiceProvider.php
@@ -1,0 +1,220 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use NeneVault\Audit\AuditRecorderInterface;
+use NeneVault\DocumentVersion\DocumentStorageInterface;
+use NeneVault\DocumentVersion\DocumentVersionRepositoryInterface;
+use NeneVault\DocumentVersion\LocalFilesystemDocumentStorage;
+use NeneVault\DocumentVersion\PdoDocumentVersionRepository;
+use NeneVault\VaultSettings\VaultSettingsRepositoryInterface;
+use Psr\Container\ContainerInterface;
+
+final readonly class DocumentServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                DocumentStorageInterface::class,
+                static function (): DocumentStorageInterface {
+                    $root = (string) (getenv('NENE_VAULT_STORAGE_PATH') ?: 'storage/vault');
+
+                    if (!str_starts_with($root, '/')) {
+                        $root = dirname(__DIR__, 2) . '/' . $root;
+                    }
+
+                    return new LocalFilesystemDocumentStorage($root);
+                },
+            )
+            ->set(
+                DocumentVersionRepositoryInterface::class,
+                static function (ContainerInterface $c): DocumentVersionRepositoryInterface {
+                    $query = $c->get(DatabaseQueryExecutorInterface::class);
+
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('DatabaseQueryExecutorInterface service is invalid.');
+                    }
+
+                    return new PdoDocumentVersionRepository($query);
+                },
+            )
+            ->set(
+                VaultDocumentRepositoryInterface::class,
+                static function (ContainerInterface $c): VaultDocumentRepositoryInterface {
+                    $query = $c->get(DatabaseQueryExecutorInterface::class);
+
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('DatabaseQueryExecutorInterface service is invalid.');
+                    }
+
+                    return new PdoVaultDocumentRepository($query);
+                },
+            )
+            ->set(
+                UploadDocumentUseCaseInterface::class,
+                static function (ContainerInterface $c): UploadDocumentUseCaseInterface {
+                    $documents = $c->get(VaultDocumentRepositoryInterface::class);
+                    $versions = $c->get(DocumentVersionRepositoryInterface::class);
+                    $storage = $c->get(DocumentStorageInterface::class);
+                    $settings = $c->get(VaultSettingsRepositoryInterface::class);
+                    $audit = $c->get(AuditRecorderInterface::class);
+
+                    if (!$documents instanceof VaultDocumentRepositoryInterface) {
+                        throw new LogicException('VaultDocumentRepositoryInterface service is invalid.');
+                    }
+
+                    if (!$versions instanceof DocumentVersionRepositoryInterface) {
+                        throw new LogicException('DocumentVersionRepositoryInterface service is invalid.');
+                    }
+
+                    if (!$storage instanceof DocumentStorageInterface) {
+                        throw new LogicException('DocumentStorageInterface service is invalid.');
+                    }
+
+                    if (!$settings instanceof VaultSettingsRepositoryInterface) {
+                        throw new LogicException('VaultSettingsRepositoryInterface service is invalid.');
+                    }
+
+                    if (!$audit instanceof AuditRecorderInterface) {
+                        throw new LogicException('AuditRecorderInterface service is invalid.');
+                    }
+
+                    $maxMb = (int) (getenv('NENE_VAULT_MAX_FILE_SIZE_MB') ?: 20);
+
+                    return new UploadDocumentUseCase(
+                        $documents,
+                        $versions,
+                        $storage,
+                        $settings,
+                        $audit,
+                        $maxMb * 1024 * 1024,
+                    );
+                },
+            )
+            ->set(
+                GetDocumentByIdUseCaseInterface::class,
+                static function (ContainerInterface $c): GetDocumentByIdUseCaseInterface {
+                    $documents = $c->get(VaultDocumentRepositoryInterface::class);
+                    $versions = $c->get(DocumentVersionRepositoryInterface::class);
+
+                    if (!$documents instanceof VaultDocumentRepositoryInterface) {
+                        throw new LogicException('VaultDocumentRepositoryInterface service is invalid.');
+                    }
+
+                    if (!$versions instanceof DocumentVersionRepositoryInterface) {
+                        throw new LogicException('DocumentVersionRepositoryInterface service is invalid.');
+                    }
+
+                    return new GetDocumentByIdUseCase($documents, $versions);
+                },
+            )
+            ->set(
+                UploadDocumentHandler::class,
+                static function (ContainerInterface $c): UploadDocumentHandler {
+                    $uc = $c->get(UploadDocumentUseCaseInterface::class);
+                    $json = $c->get(JsonResponseFactory::class);
+
+                    if (!$uc instanceof UploadDocumentUseCaseInterface) {
+                        throw new LogicException('UploadDocumentUseCaseInterface service is invalid.');
+                    }
+
+                    if (!$json instanceof JsonResponseFactory) {
+                        throw new LogicException('JsonResponseFactory service is invalid.');
+                    }
+
+                    return new UploadDocumentHandler($uc, $json);
+                },
+            )
+            ->set(
+                GetDocumentByIdHandler::class,
+                static function (ContainerInterface $c): GetDocumentByIdHandler {
+                    $uc = $c->get(GetDocumentByIdUseCaseInterface::class);
+                    $json = $c->get(JsonResponseFactory::class);
+
+                    if (!$uc instanceof GetDocumentByIdUseCaseInterface) {
+                        throw new LogicException('GetDocumentByIdUseCaseInterface service is invalid.');
+                    }
+
+                    if (!$json instanceof JsonResponseFactory) {
+                        throw new LogicException('JsonResponseFactory service is invalid.');
+                    }
+
+                    return new GetDocumentByIdHandler($uc, $json);
+                },
+            )
+            ->set(
+                VaultDocumentNotFoundExceptionHandler::class,
+                static function (ContainerInterface $c): VaultDocumentNotFoundExceptionHandler {
+                    $pd = $c->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$pd instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('ProblemDetailsResponseFactory service is invalid.');
+                    }
+
+                    return new VaultDocumentNotFoundExceptionHandler($pd);
+                },
+            )
+            ->set(
+                DuplicateFileExceptionHandler::class,
+                static function (ContainerInterface $c): DuplicateFileExceptionHandler {
+                    $pd = $c->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$pd instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('ProblemDetailsResponseFactory service is invalid.');
+                    }
+
+                    return new DuplicateFileExceptionHandler($pd);
+                },
+            )
+            ->set(
+                MimeTypeNotAllowedExceptionHandler::class,
+                static function (ContainerInterface $c): MimeTypeNotAllowedExceptionHandler {
+                    $pd = $c->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$pd instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('ProblemDetailsResponseFactory service is invalid.');
+                    }
+
+                    return new MimeTypeNotAllowedExceptionHandler($pd);
+                },
+            )
+            ->set(
+                FileTooLargeExceptionHandler::class,
+                static function (ContainerInterface $c): FileTooLargeExceptionHandler {
+                    $pd = $c->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$pd instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('ProblemDetailsResponseFactory service is invalid.');
+                    }
+
+                    return new FileTooLargeExceptionHandler($pd);
+                },
+            )
+            ->set(
+                DocumentRouteRegistrar::class,
+                static function (ContainerInterface $c): DocumentRouteRegistrar {
+                    $upload = $c->get(UploadDocumentHandler::class);
+                    $get = $c->get(GetDocumentByIdHandler::class);
+
+                    if (!$upload instanceof UploadDocumentHandler) {
+                        throw new LogicException('UploadDocumentHandler service is invalid.');
+                    }
+
+                    if (!$get instanceof GetDocumentByIdHandler) {
+                        throw new LogicException('GetDocumentByIdHandler service is invalid.');
+                    }
+
+                    return new DocumentRouteRegistrar($upload, $get);
+                },
+            );
+    }
+}

--- a/src/Document/DuplicateFileException.php
+++ b/src/Document/DuplicateFileException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+use RuntimeException;
+
+/**
+ * Thrown when an upload's SHA-256 already exists in the organization and the
+ * operator has not confirmed the duplicate (received-document-compliance §3.5).
+ */
+final class DuplicateFileException extends RuntimeException
+{
+    public function __construct(string $fileSha256)
+    {
+        parent::__construct("A file with SHA-256 {$fileSha256} already exists in this organization. Set confirm_duplicate to upload anyway.");
+    }
+}

--- a/src/Document/DuplicateFileExceptionHandler.php
+++ b/src/Document/DuplicateFileExceptionHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class DuplicateFileExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $e): bool
+    {
+        return $e instanceof DuplicateFileException;
+    }
+
+    public function handle(Throwable $e, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'duplicate-file', 'Duplicate File', 409, $e->getMessage());
+    }
+}

--- a/src/Document/FileTooLargeException.php
+++ b/src/Document/FileTooLargeException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+use RuntimeException;
+
+final class FileTooLargeException extends RuntimeException
+{
+    public function __construct(int $sizeBytes, int $maxBytes)
+    {
+        parent::__construct("File size {$sizeBytes} bytes exceeds the maximum of {$maxBytes} bytes.");
+    }
+}

--- a/src/Document/FileTooLargeExceptionHandler.php
+++ b/src/Document/FileTooLargeExceptionHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class FileTooLargeExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $e): bool
+    {
+        return $e instanceof FileTooLargeException;
+    }
+
+    public function handle(Throwable $e, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'file-too-large', 'File Too Large', 413, $e->getMessage());
+    }
+}

--- a/src/Document/GetDocumentByIdHandler.php
+++ b/src/Document/GetDocumentByIdHandler.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class GetDocumentByIdHandler
+{
+    public function __construct(
+        private GetDocumentByIdUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $orgId = $request->getAttribute('nene2.org.id');
+        assert(is_int($orgId));
+
+        $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (string) ($params['id'] ?? '');
+
+        [$document, $version] = $this->useCase->execute($id, $orgId);
+
+        return $this->response->create(VaultDocumentPresenter::present($document, $version));
+    }
+}

--- a/src/Document/GetDocumentByIdUseCase.php
+++ b/src/Document/GetDocumentByIdUseCase.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+use NeneVault\DocumentVersion\DocumentVersionRepositoryInterface;
+
+final readonly class GetDocumentByIdUseCase implements GetDocumentByIdUseCaseInterface
+{
+    public function __construct(
+        private VaultDocumentRepositoryInterface $documents,
+        private DocumentVersionRepositoryInterface $versions,
+    ) {
+    }
+
+    /**
+     * @return array{0: VaultDocument, 1: \NeneVault\DocumentVersion\DocumentVersion}
+     */
+    public function execute(string $id, int $organizationId): array
+    {
+        $document = $this->documents->findById($id, $organizationId);
+
+        if ($document === null) {
+            throw new VaultDocumentNotFoundException($id);
+        }
+
+        $version = $this->versions->findById($document->currentVersionId, $organizationId);
+
+        if ($version === null) {
+            // A document must always have its current version; absence is a data integrity error.
+            throw new VaultDocumentNotFoundException($id);
+        }
+
+        return [$document, $version];
+    }
+}

--- a/src/Document/GetDocumentByIdUseCaseInterface.php
+++ b/src/Document/GetDocumentByIdUseCaseInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+use NeneVault\DocumentVersion\DocumentVersion;
+
+interface GetDocumentByIdUseCaseInterface
+{
+    /**
+     * @return array{0: VaultDocument, 1: DocumentVersion}
+     * @throws VaultDocumentNotFoundException
+     */
+    public function execute(string $id, int $organizationId): array;
+}

--- a/src/Document/MimeTypeNotAllowedException.php
+++ b/src/Document/MimeTypeNotAllowedException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+use RuntimeException;
+
+final class MimeTypeNotAllowedException extends RuntimeException
+{
+    public function __construct(string $mimeType)
+    {
+        parent::__construct("File type '{$mimeType}' is not allowed. Only PDF, JPEG, and PNG are accepted.");
+    }
+}

--- a/src/Document/MimeTypeNotAllowedExceptionHandler.php
+++ b/src/Document/MimeTypeNotAllowedExceptionHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class MimeTypeNotAllowedExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $e): bool
+    {
+        return $e instanceof MimeTypeNotAllowedException;
+    }
+
+    public function handle(Throwable $e, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'mime-type-not-allowed', 'MIME Type Not Allowed', 415, $e->getMessage());
+    }
+}

--- a/src/Document/PdoVaultDocumentRepository.php
+++ b/src/Document/PdoVaultDocumentRepository.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final readonly class PdoVaultDocumentRepository implements VaultDocumentRepositoryInterface
+{
+    private const COLUMNS = '
+        id, organization_id, current_version_id, status, transaction_date,
+        amount_cents, counterparty_name, category, tags, date_uncertain,
+        is_metadata_confirmed, retention_years, retention_expires_at,
+        uploaded_at, uploaded_by, voided_at, voided_by, void_reason, void_note
+    ';
+
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function save(VaultDocument $document): void
+    {
+        $this->query->execute(
+            'INSERT INTO vault_documents
+                (id, organization_id, current_version_id, status, transaction_date,
+                 amount_cents, counterparty_name, category, tags, date_uncertain,
+                 is_metadata_confirmed, retention_years, retention_expires_at,
+                 uploaded_at, uploaded_by, voided_at, voided_by, void_reason, void_note)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            [
+                $document->id,
+                $document->organizationId,
+                $document->currentVersionId,
+                $document->status,
+                $document->transactionDate,
+                $document->amountCents,
+                $document->counterpartyName,
+                $document->category,
+                json_encode($document->tags, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR),
+                $document->dateUncertain ? 1 : 0,
+                $document->isMetadataConfirmed ? 1 : 0,
+                $document->retentionYears,
+                $document->retentionExpiresAt,
+                $document->uploadedAt ?? date('Y-m-d H:i:s'),
+                $document->uploadedBy,
+                $document->voidedAt,
+                $document->voidedBy,
+                $document->voidReason,
+                $document->voidNote,
+            ],
+        );
+    }
+
+    public function findById(string $id, int $organizationId): ?VaultDocument
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::COLUMNS . ' FROM vault_documents WHERE id = ? AND organization_id = ?',
+            [$id, $organizationId],
+        );
+
+        return $row !== null ? $this->mapRow($row) : null;
+    }
+
+    public function updateCurrentVersion(string $id, int $organizationId, string $currentVersionId): void
+    {
+        $this->query->execute(
+            'UPDATE vault_documents SET current_version_id = ? WHERE id = ? AND organization_id = ?',
+            [$currentVersionId, $id, $organizationId],
+        );
+    }
+
+    /** @param array<string, mixed> $row */
+    private function mapRow(array $row): VaultDocument
+    {
+        $tags = isset($row['tags']) && is_string($row['tags'])
+            ? json_decode($row['tags'], true, 512, JSON_THROW_ON_ERROR)
+            : [];
+
+        return new VaultDocument(
+            id: (string) $row['id'],
+            organizationId: (int) $row['organization_id'],
+            currentVersionId: (string) $row['current_version_id'],
+            status: (string) $row['status'],
+            transactionDate: isset($row['transaction_date']) ? (string) $row['transaction_date'] : null,
+            amountCents: isset($row['amount_cents']) ? (int) $row['amount_cents'] : null,
+            counterpartyName: (string) $row['counterparty_name'],
+            category: (string) $row['category'],
+            tags: is_array($tags) ? array_values(array_map('strval', $tags)) : [],
+            dateUncertain: (bool) $row['date_uncertain'],
+            isMetadataConfirmed: (bool) $row['is_metadata_confirmed'],
+            retentionYears: (int) $row['retention_years'],
+            retentionExpiresAt: (string) $row['retention_expires_at'],
+            uploadedAt: isset($row['uploaded_at']) ? (string) $row['uploaded_at'] : null,
+            uploadedBy: isset($row['uploaded_by']) ? (int) $row['uploaded_by'] : null,
+            voidedAt: isset($row['voided_at']) ? (string) $row['voided_at'] : null,
+            voidedBy: isset($row['voided_by']) ? (int) $row['voided_by'] : null,
+            voidReason: isset($row['void_reason']) ? (string) $row['void_reason'] : null,
+            voidNote: isset($row['void_note']) ? (string) $row['void_note'] : null,
+        );
+    }
+}

--- a/src/Document/UploadDocumentHandler.php
+++ b/src/Document/UploadDocumentHandler.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use NeneVault\DocumentVersion\DocumentVersion;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UploadedFileInterface;
+
+final readonly class UploadDocumentHandler
+{
+    /** @var list<string> */
+    private const VALID_CATEGORIES = ['invoice_received', 'contract', 'receipt', 'delivery_note', 'other'];
+
+    public function __construct(
+        private UploadDocumentUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $orgId = $request->getAttribute('nene2.org.id');
+        assert(is_int($orgId));
+
+        $claims = $request->getAttribute('nene2.auth.claims');
+        $actorUserId = is_array($claims) && isset($claims['user_id']) ? (int) $claims['user_id'] : null;
+
+        $file = $request->getUploadedFiles()['file'] ?? null;
+        $body = (array) $request->getParsedBody();
+        $errors = [];
+
+        if (!$file instanceof UploadedFileInterface) {
+            $errors[] = new ValidationError('file', 'A file is required.', 'required');
+        } elseif ($file->getError() !== UPLOAD_ERR_OK) {
+            $errors[] = new ValidationError('file', 'File upload failed.', 'upload_error');
+        }
+
+        $counterparty = isset($body['counterparty_name']) && is_string($body['counterparty_name'])
+            ? trim($body['counterparty_name'])
+            : '';
+        if ($counterparty === '') {
+            $errors[] = new ValidationError('counterparty_name', 'This field is required.', 'required');
+        }
+
+        $category = isset($body['category']) && is_string($body['category']) ? $body['category'] : '';
+        if (!in_array($category, self::VALID_CATEGORIES, true)) {
+            $errors[] = new ValidationError('category', 'Invalid category.', 'invalid_format');
+        }
+
+        $transactionDate = isset($body['transaction_date']) && is_string($body['transaction_date']) && $body['transaction_date'] !== ''
+            ? $body['transaction_date']
+            : null;
+        if ($transactionDate !== null && !$this->isValidDate($transactionDate)) {
+            $errors[] = new ValidationError('transaction_date', 'Please enter a valid date (YYYY-MM-DD).', 'invalid_date');
+        }
+
+        $amountCents = null;
+        if (isset($body['amount_cents']) && $body['amount_cents'] !== '') {
+            if (!is_numeric($body['amount_cents']) || (int) $body['amount_cents'] != $body['amount_cents']) {
+                $errors[] = new ValidationError('amount_cents', 'Please enter a valid integer amount.', 'invalid_amount');
+            } else {
+                $amountCents = (int) $body['amount_cents'];
+            }
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        assert($file instanceof UploadedFileInterface);
+
+        $tmpPath = $file->getStream()->getMetadata('uri');
+        if (!is_string($tmpPath)) {
+            throw new ValidationException([new ValidationError('file', 'Could not read uploaded file.', 'upload_error')]);
+        }
+
+        $tags = [];
+        if (isset($body['tags']) && is_string($body['tags']) && $body['tags'] !== '') {
+            $tags = array_values(array_filter(array_map('trim', explode(',', $body['tags'])), static fn (string $t) => $t !== ''));
+        }
+
+        $source = $this->looksLikeScan($file->getClientMediaType() ?? '') ? 'scan_upload' : 'web_upload';
+        $confirmDuplicate = isset($body['confirm_duplicate'])
+            && ($body['confirm_duplicate'] === '1' || $body['confirm_duplicate'] === 'true' || $body['confirm_duplicate'] === true);
+
+        $output = $this->useCase->execute(new UploadDocumentInput(
+            organizationId: $orgId,
+            tmpPath: $tmpPath,
+            originalFilename: $file->getClientFilename() ?? 'upload',
+            mimeType: $file->getClientMediaType() ?? 'application/octet-stream',
+            fileSizeBytes: (int) $file->getSize(),
+            counterpartyName: $counterparty,
+            category: $category,
+            transactionDate: $transactionDate,
+            amountCents: $amountCents,
+            tags: $tags,
+            source: $source,
+            confirmDuplicate: $confirmDuplicate,
+            actorUserId: $actorUserId,
+        ));
+
+        $version = new DocumentVersion(
+            id: $output->document->currentVersionId,
+            vaultDocumentId: $output->document->id,
+            organizationId: $orgId,
+            versionNumber: $output->versionNumber,
+            filePath: '',
+            fileSha256: $output->fileSha256,
+            mimeType: $output->mimeType,
+            originalFilename: $output->originalFilename,
+            fileSizeBytes: $output->fileSizeBytes,
+            source: $source,
+            uploadedAt: $output->document->uploadedAt,
+            uploadedBy: $actorUserId,
+        );
+
+        return $this->response->create(
+            VaultDocumentPresenter::present($output->document, $version),
+            201,
+        );
+    }
+
+    private function isValidDate(string $date): bool
+    {
+        $d = \DateTimeImmutable::createFromFormat('Y-m-d', $date);
+
+        return $d !== false && $d->format('Y-m-d') === $date;
+    }
+
+    private function looksLikeScan(string $mimeType): bool
+    {
+        // JPEG/PNG uploads are likely scans of paper; PDF is treated as electronic.
+        return $mimeType === 'image/jpeg' || $mimeType === 'image/png';
+    }
+}

--- a/src/Document/UploadDocumentInput.php
+++ b/src/Document/UploadDocumentInput.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+final readonly class UploadDocumentInput
+{
+    /**
+     * @param list<string> $tags
+     */
+    public function __construct(
+        public int $organizationId,
+        public string $tmpPath,
+        public string $originalFilename,
+        public string $mimeType,
+        public int $fileSizeBytes,
+        public string $counterpartyName,
+        public string $category,
+        public ?string $transactionDate = null,
+        public ?int $amountCents = null,
+        public array $tags = [],
+        public string $source = 'web_upload',
+        public bool $confirmDuplicate = false,
+        public ?int $actorUserId = null,
+    ) {
+    }
+}

--- a/src/Document/UploadDocumentOutput.php
+++ b/src/Document/UploadDocumentOutput.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+final readonly class UploadDocumentOutput
+{
+    public function __construct(
+        public VaultDocument $document,
+        public string $fileSha256,
+        public string $mimeType,
+        public string $originalFilename,
+        public int $fileSizeBytes,
+        public int $versionNumber,
+    ) {
+    }
+}

--- a/src/Document/UploadDocumentUseCase.php
+++ b/src/Document/UploadDocumentUseCase.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+use NeneVault\Audit\AuditAction;
+use NeneVault\Audit\AuditRecorderInterface;
+use NeneVault\DocumentVersion\DocumentStorageInterface;
+use NeneVault\DocumentVersion\DocumentVersion;
+use NeneVault\DocumentVersion\DocumentVersionRepositoryInterface;
+use NeneVault\Support\Ulid;
+use NeneVault\VaultSettings\VaultSettingsRepositoryInterface;
+
+final readonly class UploadDocumentUseCase implements UploadDocumentUseCaseInterface
+{
+    /** @var list<string> */
+    private const ALLOWED_MIME_TYPES = ['application/pdf', 'image/jpeg', 'image/png'];
+
+    private const DEFAULT_RETENTION_YEARS = 10;
+
+    public function __construct(
+        private VaultDocumentRepositoryInterface $documents,
+        private DocumentVersionRepositoryInterface $versions,
+        private DocumentStorageInterface $storage,
+        private VaultSettingsRepositoryInterface $settings,
+        private AuditRecorderInterface $audit,
+        private int $maxFileSizeBytes,
+    ) {
+    }
+
+    public function execute(UploadDocumentInput $input): UploadDocumentOutput
+    {
+        // 1. MIME allowlist (compliance §2.1, backend-standards §5)
+        if (!in_array($input->mimeType, self::ALLOWED_MIME_TYPES, true)) {
+            throw new MimeTypeNotAllowedException($input->mimeType);
+        }
+
+        // 2. Size limit
+        if ($input->fileSizeBytes > $this->maxFileSizeBytes) {
+            throw new FileTooLargeException($input->fileSizeBytes, $this->maxFileSizeBytes);
+        }
+
+        // 3. SHA-256 (compliance §3.1) + duplicate detection (§3.5)
+        $sha256 = $this->storage->sha256($input->tmpPath);
+
+        if (!$input->confirmDuplicate && $this->versions->existsBySha256($sha256, $input->organizationId)) {
+            throw new DuplicateFileException($sha256);
+        }
+
+        // 4. Retention calculation (ADR 0004)
+        $retentionYears = $this->resolveRetentionYears($input->organizationId);
+        $dateUncertain = $input->transactionDate === null;
+        $anchorDate = $input->transactionDate ?? date('Y-m-d');
+        $retentionExpiresAt = date('Y-m-d', strtotime("{$anchorDate} +{$retentionYears} years") ?: time());
+
+        // 5. Store file (immutable — new path per version)
+        $documentId = Ulid::generate();
+        $versionNumber = 1;
+        $relativePath = $this->storage->store(
+            $input->tmpPath,
+            $input->organizationId,
+            $documentId,
+            $versionNumber,
+            $input->originalFilename,
+        );
+
+        $now = date('Y-m-d H:i:s');
+        $versionId = Ulid::generate();
+
+        $version = new DocumentVersion(
+            id: $versionId,
+            vaultDocumentId: $documentId,
+            organizationId: $input->organizationId,
+            versionNumber: $versionNumber,
+            filePath: $relativePath,
+            fileSha256: $sha256,
+            mimeType: $input->mimeType,
+            originalFilename: $input->originalFilename,
+            fileSizeBytes: $input->fileSizeBytes,
+            source: $input->source,
+            uploadedAt: $now,
+            uploadedBy: $input->actorUserId,
+        );
+
+        $this->versions->save($version);
+
+        $document = new VaultDocument(
+            id: $documentId,
+            organizationId: $input->organizationId,
+            currentVersionId: $versionId,
+            status: 'active',
+            transactionDate: $input->transactionDate,
+            amountCents: $input->amountCents,
+            counterpartyName: $input->counterpartyName,
+            category: $input->category,
+            tags: $input->tags,
+            dateUncertain: $dateUncertain,
+            isMetadataConfirmed: false,
+            retentionYears: $retentionYears,
+            retentionExpiresAt: $retentionExpiresAt,
+            uploadedAt: $now,
+            uploadedBy: $input->actorUserId,
+        );
+
+        $this->documents->save($document);
+
+        // 6. Audit (ADR 0014) — no secrets in snapshot; file_path excluded
+        $this->audit->record(
+            action: AuditAction::DOCUMENT_UPLOADED,
+            entityType: 'vault_document',
+            entityId: $documentId,
+            actorUserId: $input->actorUserId,
+            organizationId: $input->organizationId,
+            beforeJson: null,
+            afterJson: $this->toAuditArray($document, $sha256, $versionNumber),
+            source: $input->source,
+        );
+
+        return new UploadDocumentOutput(
+            document: $document,
+            fileSha256: $sha256,
+            mimeType: $input->mimeType,
+            originalFilename: $input->originalFilename,
+            fileSizeBytes: $input->fileSizeBytes,
+            versionNumber: $versionNumber,
+        );
+    }
+
+    private function resolveRetentionYears(int $organizationId): int
+    {
+        $settings = $this->settings->findByOrganizationId($organizationId);
+
+        return $settings !== null ? $settings->retentionYears : self::DEFAULT_RETENTION_YEARS;
+    }
+
+    /** @return array<string, mixed> */
+    private function toAuditArray(VaultDocument $doc, string $sha256, int $versionNumber): array
+    {
+        return [
+            'id'                => $doc->id,
+            'status'            => $doc->status,
+            'transaction_date'  => $doc->transactionDate,
+            'amount_cents'      => $doc->amountCents,
+            'counterparty_name' => $doc->counterpartyName,
+            'category'          => $doc->category,
+            'tags'              => $doc->tags,
+            'file_sha256'       => $sha256,
+            'version_number'    => $versionNumber,
+            'date_uncertain'    => $doc->dateUncertain,
+            'retention_expires_at' => $doc->retentionExpiresAt,
+        ];
+    }
+}

--- a/src/Document/UploadDocumentUseCaseInterface.php
+++ b/src/Document/UploadDocumentUseCaseInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+interface UploadDocumentUseCaseInterface
+{
+    /**
+     * @throws MimeTypeNotAllowedException
+     * @throws FileTooLargeException
+     * @throws DuplicateFileException
+     */
+    public function execute(UploadDocumentInput $input): UploadDocumentOutput;
+}

--- a/src/Document/VaultDocument.php
+++ b/src/Document/VaultDocument.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+final readonly class VaultDocument
+{
+    /**
+     * @param list<string> $tags
+     */
+    public function __construct(
+        public string $id,
+        public int $organizationId,
+        public string $currentVersionId,
+        public string $status,
+        public ?string $transactionDate,
+        public ?int $amountCents,
+        public string $counterpartyName,
+        public string $category,
+        public array $tags,
+        public bool $dateUncertain,
+        public bool $isMetadataConfirmed,
+        public int $retentionYears,
+        public string $retentionExpiresAt,
+        public ?string $uploadedAt = null,
+        public ?int $uploadedBy = null,
+        public ?string $voidedAt = null,
+        public ?int $voidedBy = null,
+        public ?string $voidReason = null,
+        public ?string $voidNote = null,
+    ) {
+    }
+}

--- a/src/Document/VaultDocumentNotFoundException.php
+++ b/src/Document/VaultDocumentNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+use RuntimeException;
+
+final class VaultDocumentNotFoundException extends RuntimeException
+{
+    public function __construct(string $id)
+    {
+        parent::__construct("Document with id {$id} was not found.");
+    }
+}

--- a/src/Document/VaultDocumentNotFoundExceptionHandler.php
+++ b/src/Document/VaultDocumentNotFoundExceptionHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class VaultDocumentNotFoundExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $e): bool
+    {
+        return $e instanceof VaultDocumentNotFoundException;
+    }
+
+    public function handle(Throwable $e, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'document-not-found', 'Document Not Found', 404, $e->getMessage());
+    }
+}

--- a/src/Document/VaultDocumentPresenter.php
+++ b/src/Document/VaultDocumentPresenter.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+use NeneVault\DocumentVersion\DocumentVersion;
+
+/**
+ * Builds the public VaultDocumentResponse shape (docs/terms.md §17, OpenAPI).
+ *
+ * The storage path is never included. Combines the logical document with its
+ * current version's file metadata.
+ */
+final class VaultDocumentPresenter
+{
+    /** @return array<string, mixed> */
+    public static function present(VaultDocument $doc, DocumentVersion $currentVersion): array
+    {
+        return [
+            'id'                    => $doc->id,
+            'organization_id'       => $doc->organizationId,
+            'status'                => $doc->status,
+            'transaction_date'      => $doc->transactionDate,
+            'amount_cents'          => $doc->amountCents,
+            'counterparty_name'     => $doc->counterpartyName,
+            'category'              => $doc->category,
+            'tags'                  => $doc->tags,
+            'file_sha256'           => $currentVersion->fileSha256,
+            'mime_type'             => $currentVersion->mimeType,
+            'original_filename'     => $currentVersion->originalFilename,
+            'file_size_bytes'       => $currentVersion->fileSizeBytes,
+            'version_number'        => $currentVersion->versionNumber,
+            'source'                => $currentVersion->source,
+            'uploaded_at'           => $doc->uploadedAt,
+            'uploaded_by'           => $doc->uploadedBy,
+            'voided_at'             => $doc->voidedAt,
+            'voided_by'             => $doc->voidedBy,
+            'void_reason'           => $doc->voidReason,
+            'date_uncertain'        => $doc->dateUncertain,
+            'is_metadata_confirmed' => $doc->isMetadataConfirmed,
+            'retention_years'       => $doc->retentionYears,
+            'retention_expires_at'  => $doc->retentionExpiresAt,
+        ];
+    }
+}

--- a/src/Document/VaultDocumentRepositoryInterface.php
+++ b/src/Document/VaultDocumentRepositoryInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+interface VaultDocumentRepositoryInterface
+{
+    public function save(VaultDocument $document): void;
+
+    public function findById(string $id, int $organizationId): ?VaultDocument;
+
+    public function updateCurrentVersion(string $id, int $organizationId, string $currentVersionId): void;
+}

--- a/src/DocumentVersion/DocumentStorageInterface.php
+++ b/src/DocumentVersion/DocumentStorageInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\DocumentVersion;
+
+/**
+ * File storage abstraction for document versions.
+ *
+ * The local filesystem adapter is Phase 1–3; an S3-compatible adapter is Phase 4+
+ * (ADR 0012). Implementations own all file I/O; repositories and use cases never
+ * touch the filesystem directly.
+ */
+interface DocumentStorageInterface
+{
+    /**
+     * Store a file for a document version and return the relative storage path.
+     *
+     * Layout (ADR 0012):
+     * {root}/vault/{organizationId}/{documentId}/v{versionNumber}/{sanitizedFilename}
+     *
+     * File bytes are never overwritten — each version writes to a distinct path.
+     *
+     * @return string Relative path (never exposed in API responses)
+     */
+    public function store(
+        string $sourceTmpPath,
+        int $organizationId,
+        string $documentId,
+        int $versionNumber,
+        string $originalFilename,
+    ): string;
+
+    /** Absolute path for reading a stored file. */
+    public function resolveAbsolutePath(string $relativePath): string;
+
+    /** Compute the SHA-256 hex digest of a file. */
+    public function sha256(string $absolutePath): string;
+}

--- a/src/DocumentVersion/DocumentVersion.php
+++ b/src/DocumentVersion/DocumentVersion.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\DocumentVersion;
+
+final readonly class DocumentVersion
+{
+    public function __construct(
+        public string $id,
+        public string $vaultDocumentId,
+        public int $organizationId,
+        public int $versionNumber,
+        public string $filePath,
+        public string $fileSha256,
+        public string $mimeType,
+        public string $originalFilename,
+        public int $fileSizeBytes,
+        public string $source,
+        public ?string $uploadedAt = null,
+        public ?int $uploadedBy = null,
+    ) {
+    }
+}

--- a/src/DocumentVersion/DocumentVersionRepositoryInterface.php
+++ b/src/DocumentVersion/DocumentVersionRepositoryInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\DocumentVersion;
+
+interface DocumentVersionRepositoryInterface
+{
+    public function save(DocumentVersion $version): void;
+
+    public function findById(string $id, int $organizationId): ?DocumentVersion;
+
+    /** @return list<DocumentVersion> */
+    public function listByDocumentId(string $vaultDocumentId, int $organizationId): array;
+
+    public function existsBySha256(string $fileSha256, int $organizationId): bool;
+
+    public function nextVersionNumber(string $vaultDocumentId, int $organizationId): int;
+}

--- a/src/DocumentVersion/LocalFilesystemDocumentStorage.php
+++ b/src/DocumentVersion/LocalFilesystemDocumentStorage.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\DocumentVersion;
+
+use RuntimeException;
+
+final readonly class LocalFilesystemDocumentStorage implements DocumentStorageInterface
+{
+    public function __construct(
+        private string $storageRoot,
+    ) {
+    }
+
+    public function store(
+        string $sourceTmpPath,
+        int $organizationId,
+        string $documentId,
+        int $versionNumber,
+        string $originalFilename,
+    ): string {
+        $sanitized = $this->sanitizeFilename($originalFilename);
+        $relativeDir = sprintf('vault/%d/%s/v%d', $organizationId, $documentId, $versionNumber);
+        $relativePath = $relativeDir . '/' . $sanitized;
+
+        $absoluteDir = $this->storageRoot . '/' . $relativeDir;
+
+        if (!is_dir($absoluteDir) && !mkdir($absoluteDir, 0755, true) && !is_dir($absoluteDir)) {
+            throw new RuntimeException('Failed to create storage directory: ' . $absoluteDir);
+        }
+
+        $dest = $this->storageRoot . '/' . $relativePath;
+
+        // move_uploaded_file in production; copy fallback for test environments
+        if (!@move_uploaded_file($sourceTmpPath, $dest)) {
+            if (!@copy($sourceTmpPath, $dest)) {
+                throw new RuntimeException('Failed to store uploaded file.');
+            }
+        }
+
+        return $relativePath;
+    }
+
+    public function resolveAbsolutePath(string $relativePath): string
+    {
+        return $this->storageRoot . '/' . $relativePath;
+    }
+
+    public function sha256(string $absolutePath): string
+    {
+        $hash = hash_file('sha256', $absolutePath);
+
+        if ($hash === false) {
+            throw new RuntimeException('Failed to compute SHA-256 for stored file.');
+        }
+
+        return $hash;
+    }
+
+    private function sanitizeFilename(string $filename): string
+    {
+        $base = basename($filename);
+        // Allow safe chars only; collapse everything else to underscore.
+        $safe = preg_replace('/[^A-Za-z0-9._-]/', '_', $base) ?? 'upload';
+        $safe = trim($safe, '.');
+
+        return $safe === '' ? 'upload' : $safe;
+    }
+}

--- a/src/DocumentVersion/PdoDocumentVersionRepository.php
+++ b/src/DocumentVersion/PdoDocumentVersionRepository.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\DocumentVersion;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final readonly class PdoDocumentVersionRepository implements DocumentVersionRepositoryInterface
+{
+    private const COLUMNS = '
+        id, vault_document_id, organization_id, version_number, file_path,
+        file_sha256, mime_type, original_filename, file_size_bytes, source,
+        uploaded_at, uploaded_by
+    ';
+
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function save(DocumentVersion $version): void
+    {
+        $this->query->execute(
+            'INSERT INTO document_versions
+                (id, vault_document_id, organization_id, version_number, file_path,
+                 file_sha256, mime_type, original_filename, file_size_bytes, source,
+                 uploaded_at, uploaded_by)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            [
+                $version->id,
+                $version->vaultDocumentId,
+                $version->organizationId,
+                $version->versionNumber,
+                $version->filePath,
+                $version->fileSha256,
+                $version->mimeType,
+                $version->originalFilename,
+                $version->fileSizeBytes,
+                $version->source,
+                $version->uploadedAt ?? date('Y-m-d H:i:s'),
+                $version->uploadedBy,
+            ],
+        );
+    }
+
+    public function findById(string $id, int $organizationId): ?DocumentVersion
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::COLUMNS . ' FROM document_versions WHERE id = ? AND organization_id = ?',
+            [$id, $organizationId],
+        );
+
+        return $row !== null ? $this->mapRow($row) : null;
+    }
+
+    /** @return list<DocumentVersion> */
+    public function listByDocumentId(string $vaultDocumentId, int $organizationId): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT ' . self::COLUMNS . ' FROM document_versions
+             WHERE vault_document_id = ? AND organization_id = ?
+             ORDER BY version_number ASC',
+            [$vaultDocumentId, $organizationId],
+        );
+
+        return array_map($this->mapRow(...), $rows);
+    }
+
+    public function existsBySha256(string $fileSha256, int $organizationId): bool
+    {
+        $row = $this->query->fetchOne(
+            'SELECT 1 FROM document_versions WHERE file_sha256 = ? AND organization_id = ? LIMIT 1',
+            [$fileSha256, $organizationId],
+        );
+
+        return $row !== null;
+    }
+
+    public function nextVersionNumber(string $vaultDocumentId, int $organizationId): int
+    {
+        $row = $this->query->fetchOne(
+            'SELECT MAX(version_number) AS max_version FROM document_versions
+             WHERE vault_document_id = ? AND organization_id = ?',
+            [$vaultDocumentId, $organizationId],
+        );
+
+        $max = $row !== null && $row['max_version'] !== null ? (int) $row['max_version'] : 0;
+
+        return $max + 1;
+    }
+
+    /** @param array<string, mixed> $row */
+    private function mapRow(array $row): DocumentVersion
+    {
+        return new DocumentVersion(
+            id: (string) $row['id'],
+            vaultDocumentId: (string) $row['vault_document_id'],
+            organizationId: (int) $row['organization_id'],
+            versionNumber: (int) $row['version_number'],
+            filePath: (string) $row['file_path'],
+            fileSha256: (string) $row['file_sha256'],
+            mimeType: (string) $row['mime_type'],
+            originalFilename: (string) $row['original_filename'],
+            fileSizeBytes: (int) $row['file_size_bytes'],
+            source: (string) $row['source'],
+            uploadedAt: isset($row['uploaded_at']) ? (string) $row['uploaded_at'] : null,
+            uploadedBy: isset($row['uploaded_by']) ? (int) $row['uploaded_by'] : null,
+        );
+    }
+}

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -313,6 +313,10 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                         new CapabilityMiddleware($pd),
                     ];
 
+                    // Allow uploads up to the configured max file size plus multipart overhead.
+                    $maxFileMb = (int) (getenv('NENE_VAULT_MAX_FILE_SIZE_MB') ?: 20);
+                    $maxBodyBytes = ($maxFileMb + 5) * 1024 * 1024;
+
                     return new RuntimeApplicationFactory(
                         responseFactory: $rf,
                         streamFactory: $sf,
@@ -323,6 +327,7 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                         routeRegistrars: $routeRegistrars,
                         authMiddleware: $authMiddleware,
                         debug: $config->debug,
+                        requestMaxBodyBytes: $maxBodyBytes,
                     );
                 },
             )

--- a/src/Support/Ulid.php
+++ b/src/Support/Ulid.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Support;
+
+/**
+ * Minimal ULID generator (Crockford base32, 26 chars).
+ *
+ * 48-bit millisecond timestamp + 80-bit randomness. Lexicographically sortable.
+ * Used for vault_document and document_version IDs (see docs/terms.md §7).
+ */
+final class Ulid
+{
+    private const ENCODING = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+
+    public static function generate(): string
+    {
+        $timeMs = (int) (microtime(true) * 1000);
+
+        // 48-bit timestamp → 10 chars
+        $timeChars = '';
+        for ($i = 0; $i < 10; $i++) {
+            $mod = $timeMs % 32;
+            $timeChars = self::ENCODING[$mod] . $timeChars;
+            $timeMs = intdiv($timeMs, 32);
+        }
+
+        // 80-bit randomness → 16 chars
+        $randChars = '';
+        for ($i = 0; $i < 16; $i++) {
+            $randChars .= self::ENCODING[random_int(0, 31)];
+        }
+
+        return $timeChars . $randChars;
+    }
+}

--- a/tests/Document/DocumentApiTest.php
+++ b/tests/Document/DocumentApiTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Tests\Document;
+
+use Nene2\Auth\TokenIssuerInterface;
+use Nene2\Database\DatabaseConnectionFactoryInterface;
+use NeneVault\Http\RuntimeContainerFactory;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Nyholm\Psr7Server\ServerRequestCreator;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class DocumentApiTest extends TestCase
+{
+    private static ?ContainerInterface $container = null;
+    private static int $orgId = 0;
+    private static string $token = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$container = (new RuntimeContainerFactory(dirname(__DIR__, 2)))->create();
+
+        $conn = self::$container->get(DatabaseConnectionFactoryInterface::class);
+        assert($conn instanceof DatabaseConnectionFactoryInterface);
+        $pdo = $conn->create();
+
+        $pdo->exec("INSERT OR IGNORE INTO organizations
+            (name, slug, plan, is_active, created_at, updated_at)
+            VALUES ('Test Org', 'test-org', 'free', 1, datetime('now'), datetime('now'))");
+
+        $stmt = $pdo->query("SELECT id FROM organizations WHERE slug = 'test-org'");
+        assert($stmt !== false);
+        $row = $stmt->fetch();
+        self::$orgId = (int) $row['id'];
+
+        $issuer = self::$container->get(TokenIssuerInterface::class);
+        assert($issuer instanceof TokenIssuerInterface);
+        self::$token = $issuer->issue([
+            'sub' => 'admin@example.com',
+            'user_id' => 1,
+            'role' => 'admin',
+            'org_id' => self::$orgId,
+            'iat' => time(),
+            'exp' => time() + 3600,
+        ]);
+    }
+
+    public function test_upload_then_get_document(): void
+    {
+        $handler = $this->handler();
+
+        $tmp = $this->makeTempFile("%PDF-1.4\nfake pdf content for test\n");
+        $uploadRequest = $this->request('POST', '/admin/vault/documents')
+            ->withUploadedFiles(['file' => $this->uploadedFile($tmp, 'invoice.pdf', 'application/pdf')])
+            ->withParsedBody([
+                'counterparty_name' => 'Sample Inc.',
+                'category' => 'invoice_received',
+                'transaction_date' => '2026-03-31',
+                'amount_cents' => '110000',
+                'tags' => 'q1,important',
+            ]);
+
+        $uploadResponse = $handler->handle($uploadRequest);
+
+        $this->assertSame(201, $uploadResponse->getStatusCode(), (string) $uploadResponse->getBody());
+        $uploaded = json_decode((string) $uploadResponse->getBody(), true);
+        $this->assertIsArray($uploaded);
+        $this->assertSame('active', $uploaded['status']);
+        $this->assertSame('Sample Inc.', $uploaded['counterparty_name']);
+        $this->assertSame('invoice_received', $uploaded['category']);
+        $this->assertSame(110000, $uploaded['amount_cents']);
+        $this->assertSame('2026-03-31', $uploaded['transaction_date']);
+        $this->assertSame(1, $uploaded['version_number']);
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{64}$/', $uploaded['file_sha256']);
+        $this->assertSame('2036-03-31', $uploaded['retention_expires_at']);
+        $this->assertArrayNotHasKey('file_path', $uploaded);
+        $this->assertContains('q1', $uploaded['tags']);
+
+        $documentId = $uploaded['id'];
+        $this->assertIsString($documentId);
+
+        $getResponse = $handler->handle($this->request('GET', '/admin/vault/documents/' . $documentId));
+
+        $this->assertSame(200, $getResponse->getStatusCode(), (string) $getResponse->getBody());
+        $fetched = json_decode((string) $getResponse->getBody(), true);
+        $this->assertSame($documentId, $fetched['id']);
+        $this->assertSame('Sample Inc.', $fetched['counterparty_name']);
+
+        @unlink($tmp);
+    }
+
+    public function test_upload_rejects_disallowed_mime(): void
+    {
+        $handler = $this->handler();
+        $tmp = $this->makeTempFile('plain text');
+
+        $request = $this->request('POST', '/admin/vault/documents')
+            ->withUploadedFiles(['file' => $this->uploadedFile($tmp, 'note.txt', 'text/plain')])
+            ->withParsedBody(['counterparty_name' => 'X', 'category' => 'other']);
+
+        $response = $handler->handle($request);
+
+        $this->assertSame(415, $response->getStatusCode());
+        @unlink($tmp);
+    }
+
+    public function test_get_unknown_document_returns_404(): void
+    {
+        $response = $this->handler()->handle(
+            $this->request('GET', '/admin/vault/documents/00000000000000000000000000'),
+        );
+
+        $this->assertSame(404, $response->getStatusCode());
+    }
+
+    public function test_upload_without_token_returns_401(): void
+    {
+        $response = $this->handler()->handle(
+            $this->request('POST', '/admin/vault/documents', auth: false),
+        );
+
+        $this->assertSame(401, $response->getStatusCode());
+    }
+
+    // ── helpers ──
+
+    private function handler(): RequestHandlerInterface
+    {
+        $container = self::$container;
+        assert($container !== null);
+        $handler = $container->get(RequestHandlerInterface::class);
+        assert($handler instanceof RequestHandlerInterface);
+
+        return $handler;
+    }
+
+    private function request(string $method, string $uri, bool $auth = true): ServerRequestInterface
+    {
+        $container = self::$container;
+        assert($container !== null);
+        $psr17 = $container->get(Psr17Factory::class);
+        assert($psr17 instanceof Psr17Factory);
+
+        $creator = new ServerRequestCreator($psr17, $psr17, $psr17, $psr17);
+
+        $headers = ['Host' => 'localhost'];
+        if ($auth) {
+            $headers['Authorization'] = 'Bearer ' . self::$token;
+        }
+
+        return $creator->fromArrays(
+            server: ['REQUEST_METHOD' => $method, 'REQUEST_URI' => $uri],
+            headers: $headers,
+        );
+    }
+
+    private function makeTempFile(string $content): string
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'vault_test_');
+        assert($tmp !== false);
+        file_put_contents($tmp, $content);
+
+        return $tmp;
+    }
+
+    private function uploadedFile(string $path, string $filename, string $mediaType): \Psr\Http\Message\UploadedFileInterface
+    {
+        $container = self::$container;
+        assert($container !== null);
+        $psr17 = $container->get(Psr17Factory::class);
+        assert($psr17 instanceof Psr17Factory);
+
+        return $psr17->createUploadedFile(
+            $psr17->createStreamFromFile($path),
+            (int) filesize($path),
+            UPLOAD_ERR_OK,
+            $filename,
+            $mediaType,
+        );
+    }
+}

--- a/tests/Document/UploadDocumentUseCaseTest.php
+++ b/tests/Document/UploadDocumentUseCaseTest.php
@@ -1,0 +1,309 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Tests\Document;
+
+use NeneVault\Audit\AuditRecorder;
+use NeneVault\Document\DuplicateFileException;
+use NeneVault\Document\FileTooLargeException;
+use NeneVault\Document\MimeTypeNotAllowedException;
+use NeneVault\Document\UploadDocumentInput;
+use NeneVault\Document\UploadDocumentUseCase;
+use NeneVault\Document\VaultDocument;
+use NeneVault\Document\VaultDocumentRepositoryInterface;
+use NeneVault\DocumentVersion\DocumentStorageInterface;
+use NeneVault\DocumentVersion\DocumentVersion;
+use NeneVault\DocumentVersion\DocumentVersionRepositoryInterface;
+use NeneVault\Tests\Audit\InMemoryAuditEventRepository;
+use NeneVault\VaultSettings\VaultSettings;
+use NeneVault\VaultSettings\VaultSettingsRepositoryInterface;
+use PHPUnit\Framework\TestCase;
+
+final class UploadDocumentUseCaseTest extends TestCase
+{
+    private const MAX_BYTES = 20 * 1024 * 1024;
+
+    public function test_uploads_pdf_and_records_audit(): void
+    {
+        $docs = new InMemoryVaultDocumentRepository();
+        $versions = new InMemoryDocumentVersionRepository();
+        $storage = new FakeDocumentStorage('abc123sha');
+        $settings = new FakeVaultSettingsRepository(retentionYears: 10);
+        $auditRepo = new InMemoryAuditEventRepository();
+        $useCase = new UploadDocumentUseCase($docs, $versions, $storage, $settings, new AuditRecorder($auditRepo), self::MAX_BYTES);
+
+        $output = $useCase->execute($this->input(transactionDate: '2026-03-31', amountCents: 110000));
+
+        $this->assertSame('abc123sha', $output->fileSha256);
+        $this->assertSame(1, $output->versionNumber);
+        $this->assertSame('active', $output->document->status);
+        $this->assertSame(110000, $output->document->amountCents);
+        $this->assertFalse($output->document->dateUncertain);
+        // 10 years from transaction date
+        $this->assertSame('2036-03-31', $output->document->retentionExpiresAt);
+
+        $this->assertCount(1, $docs->all());
+        $this->assertCount(1, $versions->all());
+
+        $events = $auditRepo->all();
+        $this->assertCount(1, $events);
+        $this->assertSame('document.uploaded', $events[0]->action);
+        $this->assertNull($events[0]->beforeJson);
+        $this->assertSame('abc123sha', $events[0]->afterJson['file_sha256'] ?? null);
+        // No storage path in the audit snapshot
+        $this->assertArrayNotHasKey('file_path', $events[0]->afterJson ?? []);
+    }
+
+    public function test_null_transaction_date_sets_date_uncertain(): void
+    {
+        $useCase = $this->makeUseCase();
+        $output = $useCase->execute($this->input(transactionDate: null));
+
+        $this->assertTrue($output->document->dateUncertain);
+        $this->assertNull($output->document->transactionDate);
+    }
+
+    public function test_rejects_disallowed_mime_type(): void
+    {
+        $useCase = $this->makeUseCase();
+
+        $this->expectException(MimeTypeNotAllowedException::class);
+
+        $useCase->execute($this->input(mimeType: 'application/zip'));
+    }
+
+    public function test_rejects_oversized_file(): void
+    {
+        $useCase = $this->makeUseCase();
+
+        $this->expectException(FileTooLargeException::class);
+
+        $useCase->execute($this->input(fileSizeBytes: self::MAX_BYTES + 1));
+    }
+
+    public function test_rejects_duplicate_sha256_unless_confirmed(): void
+    {
+        $versions = new InMemoryDocumentVersionRepository();
+        $versions->markSha('dup-sha');
+        $storage = new FakeDocumentStorage('dup-sha');
+        $useCase = new UploadDocumentUseCase(
+            new InMemoryVaultDocumentRepository(),
+            $versions,
+            $storage,
+            new FakeVaultSettingsRepository(10),
+            new AuditRecorder(new InMemoryAuditEventRepository()),
+            self::MAX_BYTES,
+        );
+
+        $this->expectException(DuplicateFileException::class);
+        $useCase->execute($this->input());
+    }
+
+    public function test_accepts_duplicate_when_confirmed(): void
+    {
+        $versions = new InMemoryDocumentVersionRepository();
+        $versions->markSha('dup-sha');
+        $storage = new FakeDocumentStorage('dup-sha');
+        $useCase = new UploadDocumentUseCase(
+            new InMemoryVaultDocumentRepository(),
+            $versions,
+            $storage,
+            new FakeVaultSettingsRepository(10),
+            new AuditRecorder(new InMemoryAuditEventRepository()),
+            self::MAX_BYTES,
+        );
+
+        $output = $useCase->execute($this->input(confirmDuplicate: true));
+        $this->assertSame('dup-sha', $output->fileSha256);
+    }
+
+    public function test_uses_org_retention_years(): void
+    {
+        $docs = new InMemoryVaultDocumentRepository();
+        $useCase = new UploadDocumentUseCase(
+            $docs,
+            new InMemoryDocumentVersionRepository(),
+            new FakeDocumentStorage('x'),
+            new FakeVaultSettingsRepository(retentionYears: 7),
+            new AuditRecorder(new InMemoryAuditEventRepository()),
+            self::MAX_BYTES,
+        );
+
+        $output = $useCase->execute($this->input(transactionDate: '2026-01-01'));
+        $this->assertSame(7, $output->document->retentionYears);
+        $this->assertSame('2033-01-01', $output->document->retentionExpiresAt);
+    }
+
+    private function makeUseCase(): UploadDocumentUseCase
+    {
+        return new UploadDocumentUseCase(
+            new InMemoryVaultDocumentRepository(),
+            new InMemoryDocumentVersionRepository(),
+            new FakeDocumentStorage('sha'),
+            new FakeVaultSettingsRepository(10),
+            new AuditRecorder(new InMemoryAuditEventRepository()),
+            self::MAX_BYTES,
+        );
+    }
+
+    /** @param list<string> $tags */
+    private function input(
+        string $mimeType = 'application/pdf',
+        int $fileSizeBytes = 1024,
+        ?string $transactionDate = '2026-03-31',
+        ?int $amountCents = null,
+        bool $confirmDuplicate = false,
+        array $tags = [],
+    ): UploadDocumentInput {
+        return new UploadDocumentInput(
+            organizationId: 1,
+            tmpPath: '/tmp/fake-upload',
+            originalFilename: 'invoice.pdf',
+            mimeType: $mimeType,
+            fileSizeBytes: $fileSizeBytes,
+            counterpartyName: 'Sample Inc.',
+            category: 'invoice_received',
+            transactionDate: $transactionDate,
+            amountCents: $amountCents,
+            tags: $tags,
+            source: 'web_upload',
+            confirmDuplicate: $confirmDuplicate,
+            actorUserId: 5,
+        );
+    }
+}
+
+final class FakeDocumentStorage implements DocumentStorageInterface
+{
+    public function __construct(private readonly string $sha)
+    {
+    }
+
+    public function store(string $sourceTmpPath, int $organizationId, string $documentId, int $versionNumber, string $originalFilename): string
+    {
+        return sprintf('vault/%d/%s/v%d/%s', $organizationId, $documentId, $versionNumber, $originalFilename);
+    }
+
+    public function resolveAbsolutePath(string $relativePath): string
+    {
+        return '/tmp/' . $relativePath;
+    }
+
+    public function sha256(string $absolutePath): string
+    {
+        return $this->sha;
+    }
+}
+
+final class InMemoryVaultDocumentRepository implements VaultDocumentRepositoryInterface
+{
+    /** @var array<string, VaultDocument> */
+    private array $docs = [];
+
+    public function save(VaultDocument $document): void
+    {
+        $this->docs[$document->id] = $document;
+    }
+
+    public function findById(string $id, int $organizationId): ?VaultDocument
+    {
+        $d = $this->docs[$id] ?? null;
+
+        return $d !== null && $d->organizationId === $organizationId ? $d : null;
+    }
+
+    public function updateCurrentVersion(string $id, int $organizationId, string $currentVersionId): void
+    {
+        // not needed for upload slice tests
+    }
+
+    /** @return list<VaultDocument> */
+    public function all(): array
+    {
+        return array_values($this->docs);
+    }
+}
+
+final class InMemoryDocumentVersionRepository implements DocumentVersionRepositoryInterface
+{
+    /** @var list<DocumentVersion> */
+    private array $versions = [];
+
+    /** @var array<string, bool> */
+    private array $shas = [];
+
+    public function markSha(string $sha): void
+    {
+        $this->shas[$sha] = true;
+    }
+
+    public function save(DocumentVersion $version): void
+    {
+        $this->versions[] = $version;
+        $this->shas[$version->fileSha256] = true;
+    }
+
+    public function findById(string $id, int $organizationId): ?DocumentVersion
+    {
+        foreach ($this->versions as $v) {
+            if ($v->id === $id && $v->organizationId === $organizationId) {
+                return $v;
+            }
+        }
+
+        return null;
+    }
+
+    /** @return list<DocumentVersion> */
+    public function listByDocumentId(string $vaultDocumentId, int $organizationId): array
+    {
+        return array_values(array_filter(
+            $this->versions,
+            static fn (DocumentVersion $v) => $v->vaultDocumentId === $vaultDocumentId && $v->organizationId === $organizationId,
+        ));
+    }
+
+    public function existsBySha256(string $fileSha256, int $organizationId): bool
+    {
+        return $this->shas[$fileSha256] ?? false;
+    }
+
+    public function nextVersionNumber(string $vaultDocumentId, int $organizationId): int
+    {
+        $max = 0;
+        foreach ($this->versions as $v) {
+            if ($v->vaultDocumentId === $vaultDocumentId) {
+                $max = max($max, $v->versionNumber);
+            }
+        }
+
+        return $max + 1;
+    }
+
+    /** @return list<DocumentVersion> */
+    public function all(): array
+    {
+        return $this->versions;
+    }
+}
+
+final class FakeVaultSettingsRepository implements VaultSettingsRepositoryInterface
+{
+    public function __construct(private readonly int $retentionYears)
+    {
+    }
+
+    public function findByOrganizationId(int $organizationId): VaultSettings
+    {
+        return new VaultSettings(organizationId: $organizationId, retentionYears: $this->retentionYears);
+    }
+
+    public function save(VaultSettings $settings): void
+    {
+    }
+
+    public function update(VaultSettings $settings): void
+    {
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -89,3 +89,41 @@ $pdo->exec('CREATE TABLE IF NOT EXISTS audit_events (
     metadata_json TEXT,
     created_at DATETIME NOT NULL
 )');
+
+$pdo->exec('CREATE TABLE IF NOT EXISTS vault_documents (
+    id CHAR(26) PRIMARY KEY,
+    organization_id INTEGER NOT NULL,
+    current_version_id CHAR(26) NOT NULL,
+    status VARCHAR(16) NOT NULL DEFAULT "active",
+    transaction_date DATE,
+    amount_cents INTEGER,
+    counterparty_name VARCHAR(255) NOT NULL,
+    category VARCHAR(32) NOT NULL,
+    tags TEXT,
+    date_uncertain INTEGER NOT NULL DEFAULT 0,
+    is_metadata_confirmed INTEGER NOT NULL DEFAULT 0,
+    retention_years INTEGER NOT NULL DEFAULT 10,
+    retention_expires_at DATE NOT NULL,
+    uploaded_at DATETIME NOT NULL,
+    uploaded_by INTEGER,
+    voided_at DATETIME,
+    voided_by INTEGER,
+    void_reason VARCHAR(255),
+    void_note TEXT
+)');
+
+$pdo->exec('CREATE TABLE IF NOT EXISTS document_versions (
+    id CHAR(26) PRIMARY KEY,
+    vault_document_id CHAR(26) NOT NULL,
+    organization_id INTEGER NOT NULL,
+    version_number INTEGER NOT NULL,
+    file_path VARCHAR(512) NOT NULL,
+    file_sha256 CHAR(64) NOT NULL,
+    mime_type VARCHAR(64) NOT NULL,
+    original_filename VARCHAR(255) NOT NULL,
+    file_size_bytes INTEGER NOT NULL,
+    source VARCHAR(32) NOT NULL DEFAULT "web_upload",
+    uploaded_at DATETIME NOT NULL,
+    uploaded_by INTEGER,
+    UNIQUE(vault_document_id, version_number)
+)');


### PR DESCRIPTION
## Summary

OpenAPI 契約 (#14) の `uploadDocument` / `getDocumentById` を実装。
Document API の最初の縦切り（アップロード → 保存 → 取得）が動作。

## 実装

**`src/DocumentVersion/`** — ファイルストレージ + 不変バージョン
- `DocumentStorageInterface` + `LocalFilesystemDocumentStorage`（ADR 0012 パスレイアウト）
- `DocumentVersion` エンティティ + PDO リポジトリ

**`src/Document/`** — 論理書類
- `UploadDocumentUseCase` — MIME許可リスト / サイズ上限 / SHA-256 / 重複検出 / 保存期限計算 / 監査
- `GetDocumentByIdUseCase` + `VaultDocumentPresenter`（storage path 非露出）
- 例外 4種 + Problem Details ハンドラ

**`src/Support/Ulid.php`** — ULID ジェネレータ

## コンプライアンス（received-document-compliance）

- SHA-256 をアップロード時に算出・保存（§3.1）
- MIME 許可リスト PDF/JPEG/PNG、それ以外は 415（backend-standards §5）
- 同一org内の重複 SHA-256 → 409、`confirm_duplicate` で許可（§3.5）
- 保存期限 = transaction_date + retention_years、未指定時は uploaded_at 起算 + `date_uncertain`（ADR 0004 §5.3）
- `document.uploaded` 監査イベント、スナップショットに file_path 含めない（ADR 0014）
- 全クエリ org スコープ（ADR 0006）

## テスト（33 tests, 114 assertions）

- `UploadDocumentUseCaseTest` — MIME/サイズ/重複/保存期限/監査
- `DocumentApiTest` — HTTP統合（upload→get、415、404、401）

## composer check
PHPUnit 33 / PHPStan 8 / CS / locales 344 / **OpenAPI valid** — all green

Self-review: compliance, backend-api, database, middleware-security

Closes #15