### PR TITLE
feat: Document search — date/amount/counterparty/category with combinations

### DIFF
--- a/src/Document/DocumentRouteRegistrar.php
+++ b/src/Document/DocumentRouteRegistrar.php
@@ -10,12 +10,14 @@ final readonly class DocumentRouteRegistrar
 {
     public function __construct(
         private UploadDocumentHandler $upload,
+        private SearchDocumentsHandler $search,
         private GetDocumentByIdHandler $get,
     ) {
     }
 
     public function register(Router $router): void
     {
+        $router->get('/admin/vault/documents', $this->search->handle(...));
         $router->post('/admin/vault/documents', $this->upload->handle(...));
         $router->get('/admin/vault/documents/{id}', $this->get->handle(...));
     }

--- a/src/Document/DocumentSearchCriteria.php
+++ b/src/Document/DocumentSearchCriteria.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+final readonly class DocumentSearchCriteria
+{
+    public function __construct(
+        public int $organizationId,
+        public ?string $transactionDateFrom = null,
+        public ?string $transactionDateTo = null,
+        public ?int $amountMinCents = null,
+        public ?int $amountMaxCents = null,
+        public ?string $counterpartyName = null,
+        public ?string $category = null,
+        public bool $includeVoided = false,
+        public int $limit = 20,
+        public int $offset = 0,
+    ) {
+    }
+}

--- a/src/Document/DocumentServiceProvider.php
+++ b/src/Document/DocumentServiceProvider.php
@@ -118,6 +118,35 @@ final readonly class DocumentServiceProvider implements ServiceProviderInterface
                 },
             )
             ->set(
+                SearchDocumentsUseCaseInterface::class,
+                static function (ContainerInterface $c): SearchDocumentsUseCaseInterface {
+                    $documents = $c->get(VaultDocumentRepositoryInterface::class);
+
+                    if (!$documents instanceof VaultDocumentRepositoryInterface) {
+                        throw new LogicException('VaultDocumentRepositoryInterface service is invalid.');
+                    }
+
+                    return new SearchDocumentsUseCase($documents);
+                },
+            )
+            ->set(
+                SearchDocumentsHandler::class,
+                static function (ContainerInterface $c): SearchDocumentsHandler {
+                    $uc = $c->get(SearchDocumentsUseCaseInterface::class);
+                    $json = $c->get(JsonResponseFactory::class);
+
+                    if (!$uc instanceof SearchDocumentsUseCaseInterface) {
+                        throw new LogicException('SearchDocumentsUseCaseInterface service is invalid.');
+                    }
+
+                    if (!$json instanceof JsonResponseFactory) {
+                        throw new LogicException('JsonResponseFactory service is invalid.');
+                    }
+
+                    return new SearchDocumentsHandler($uc, $json);
+                },
+            )
+            ->set(
                 UploadDocumentHandler::class,
                 static function (ContainerInterface $c): UploadDocumentHandler {
                     $uc = $c->get(UploadDocumentUseCaseInterface::class);
@@ -203,17 +232,22 @@ final readonly class DocumentServiceProvider implements ServiceProviderInterface
                 DocumentRouteRegistrar::class,
                 static function (ContainerInterface $c): DocumentRouteRegistrar {
                     $upload = $c->get(UploadDocumentHandler::class);
+                    $search = $c->get(SearchDocumentsHandler::class);
                     $get = $c->get(GetDocumentByIdHandler::class);
 
                     if (!$upload instanceof UploadDocumentHandler) {
                         throw new LogicException('UploadDocumentHandler service is invalid.');
                     }
 
+                    if (!$search instanceof SearchDocumentsHandler) {
+                        throw new LogicException('SearchDocumentsHandler service is invalid.');
+                    }
+
                     if (!$get instanceof GetDocumentByIdHandler) {
                         throw new LogicException('GetDocumentByIdHandler service is invalid.');
                     }
 
-                    return new DocumentRouteRegistrar($upload, $get);
+                    return new DocumentRouteRegistrar($upload, $search, $get);
                 },
             );
     }

--- a/src/Document/PdoVaultDocumentRepository.php
+++ b/src/Document/PdoVaultDocumentRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneVault\Document;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use NeneVault\DocumentVersion\DocumentVersion;
 
 final readonly class PdoVaultDocumentRepository implements VaultDocumentRepositoryInterface
 {
@@ -68,6 +69,109 @@ final readonly class PdoVaultDocumentRepository implements VaultDocumentReposito
         $this->query->execute(
             'UPDATE vault_documents SET current_version_id = ? WHERE id = ? AND organization_id = ?',
             [$currentVersionId, $id, $organizationId],
+        );
+    }
+
+    /**
+     * @return list<array{0: VaultDocument, 1: DocumentVersion}>
+     */
+    public function search(DocumentSearchCriteria $criteria): array
+    {
+        [$where, $params] = $this->buildSearchWhere($criteria);
+
+        $docCols = implode(', ', array_map(static fn (string $c) => 'd.' . trim($c), explode(',', self::COLUMNS)));
+
+        $sql = 'SELECT ' . $docCols . ',
+                v.id AS v_id, v.version_number AS v_version_number,
+                v.file_sha256 AS v_file_sha256, v.mime_type AS v_mime_type,
+                v.original_filename AS v_original_filename, v.file_size_bytes AS v_file_size_bytes,
+                v.source AS v_source, v.uploaded_at AS v_uploaded_at, v.uploaded_by AS v_uploaded_by
+            FROM vault_documents d
+            INNER JOIN document_versions v ON v.id = d.current_version_id AND v.organization_id = d.organization_id'
+            . $where
+            . ' ORDER BY d.transaction_date DESC, d.id DESC LIMIT ? OFFSET ?';
+
+        $rows = $this->query->fetchAll($sql, [...$params, $criteria->limit, $criteria->offset]);
+
+        return array_map(
+            fn (array $row) => [$this->mapRow($row), $this->mapVersionRow($row)],
+            $rows,
+        );
+    }
+
+    public function countByCriteria(DocumentSearchCriteria $criteria): int
+    {
+        [$where, $params] = $this->buildSearchWhere($criteria);
+
+        $row = $this->query->fetchOne(
+            'SELECT COUNT(*) AS cnt FROM vault_documents d' . $where,
+            $params,
+        );
+
+        return $row !== null ? (int) $row['cnt'] : 0;
+    }
+
+    /**
+     * @return array{string, list<mixed>}
+     */
+    private function buildSearchWhere(DocumentSearchCriteria $criteria): array
+    {
+        $conditions = ['d.organization_id = ?'];
+        $params = [$criteria->organizationId];
+
+        if (!$criteria->includeVoided) {
+            $conditions[] = "d.status = 'active'";
+        }
+
+        if ($criteria->transactionDateFrom !== null) {
+            $conditions[] = 'd.transaction_date >= ?';
+            $params[] = $criteria->transactionDateFrom;
+        }
+
+        if ($criteria->transactionDateTo !== null) {
+            $conditions[] = 'd.transaction_date <= ?';
+            $params[] = $criteria->transactionDateTo;
+        }
+
+        if ($criteria->amountMinCents !== null) {
+            $conditions[] = 'd.amount_cents >= ?';
+            $params[] = $criteria->amountMinCents;
+        }
+
+        if ($criteria->amountMaxCents !== null) {
+            $conditions[] = 'd.amount_cents <= ?';
+            $params[] = $criteria->amountMaxCents;
+        }
+
+        if ($criteria->counterpartyName !== null && $criteria->counterpartyName !== '') {
+            $conditions[] = 'd.counterparty_name LIKE ?';
+            $params[] = '%' . $criteria->counterpartyName . '%';
+        }
+
+        if ($criteria->category !== null && $criteria->category !== '') {
+            $conditions[] = 'd.category = ?';
+            $params[] = $criteria->category;
+        }
+
+        return [' WHERE ' . implode(' AND ', $conditions), $params];
+    }
+
+    /** @param array<string, mixed> $row */
+    private function mapVersionRow(array $row): DocumentVersion
+    {
+        return new DocumentVersion(
+            id: (string) $row['v_id'],
+            vaultDocumentId: (string) $row['id'],
+            organizationId: (int) $row['organization_id'],
+            versionNumber: (int) $row['v_version_number'],
+            filePath: '',
+            fileSha256: (string) $row['v_file_sha256'],
+            mimeType: (string) $row['v_mime_type'],
+            originalFilename: (string) $row['v_original_filename'],
+            fileSizeBytes: (int) $row['v_file_size_bytes'],
+            source: (string) $row['v_source'],
+            uploadedAt: isset($row['v_uploaded_at']) ? (string) $row['v_uploaded_at'] : null,
+            uploadedBy: isset($row['v_uploaded_by']) ? (int) $row['v_uploaded_by'] : null,
         );
     }
 

--- a/src/Document/SearchDocumentsHandler.php
+++ b/src/Document/SearchDocumentsHandler.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+use Nene2\Http\JsonResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class SearchDocumentsHandler
+{
+    public function __construct(
+        private SearchDocumentsUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $orgId = $request->getAttribute('nene2.org.id');
+        assert(is_int($orgId));
+
+        $q = $request->getQueryParams();
+
+        $limit = min(100, max(1, (int) ($q['limit'] ?? 20)));
+        $offset = max(0, (int) ($q['offset'] ?? 0));
+
+        $criteria = new DocumentSearchCriteria(
+            organizationId: $orgId,
+            transactionDateFrom: $this->strOrNull($q['transaction_date_from'] ?? null),
+            transactionDateTo: $this->strOrNull($q['transaction_date_to'] ?? null),
+            amountMinCents: $this->intOrNull($q['amount_min_cents'] ?? null),
+            amountMaxCents: $this->intOrNull($q['amount_max_cents'] ?? null),
+            counterpartyName: $this->strOrNull($q['counterparty_name'] ?? null),
+            category: $this->strOrNull($q['category'] ?? null),
+            includeVoided: isset($q['include_voided']) && ($q['include_voided'] === '1' || $q['include_voided'] === 'true'),
+            limit: $limit,
+            offset: $offset,
+        );
+
+        $output = $this->useCase->execute($criteria);
+
+        return $this->response->create([
+            'items'  => array_map(
+                static fn (array $pair) => VaultDocumentPresenter::present($pair[0], $pair[1]),
+                $output->items,
+            ),
+            'total'  => $output->total,
+            'limit'  => $output->limit,
+            'offset' => $output->offset,
+        ]);
+    }
+
+    private function strOrNull(mixed $v): ?string
+    {
+        return is_string($v) && $v !== '' ? $v : null;
+    }
+
+    private function intOrNull(mixed $v): ?int
+    {
+        return is_numeric($v) ? (int) $v : null;
+    }
+}

--- a/src/Document/SearchDocumentsOutput.php
+++ b/src/Document/SearchDocumentsOutput.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+use NeneVault\DocumentVersion\DocumentVersion;
+
+final readonly class SearchDocumentsOutput
+{
+    /**
+     * @param list<array{0: VaultDocument, 1: DocumentVersion}> $items
+     */
+    public function __construct(
+        public array $items,
+        public int $total,
+        public int $limit,
+        public int $offset,
+    ) {
+    }
+}

--- a/src/Document/SearchDocumentsUseCase.php
+++ b/src/Document/SearchDocumentsUseCase.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+final readonly class SearchDocumentsUseCase implements SearchDocumentsUseCaseInterface
+{
+    public function __construct(
+        private VaultDocumentRepositoryInterface $documents,
+    ) {
+    }
+
+    public function execute(DocumentSearchCriteria $criteria): SearchDocumentsOutput
+    {
+        return new SearchDocumentsOutput(
+            items: $this->documents->search($criteria),
+            total: $this->documents->countByCriteria($criteria),
+            limit: $criteria->limit,
+            offset: $criteria->offset,
+        );
+    }
+}

--- a/src/Document/SearchDocumentsUseCaseInterface.php
+++ b/src/Document/SearchDocumentsUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+interface SearchDocumentsUseCaseInterface
+{
+    public function execute(DocumentSearchCriteria $criteria): SearchDocumentsOutput;
+}

--- a/src/Document/VaultDocumentRepositoryInterface.php
+++ b/src/Document/VaultDocumentRepositoryInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace NeneVault\Document;
 
+use NeneVault\DocumentVersion\DocumentVersion;
+
 interface VaultDocumentRepositoryInterface
 {
     public function save(VaultDocument $document): void;
@@ -11,4 +13,13 @@ interface VaultDocumentRepositoryInterface
     public function findById(string $id, int $organizationId): ?VaultDocument;
 
     public function updateCurrentVersion(string $id, int $organizationId, string $currentVersionId): void;
+
+    /**
+     * Search documents, joining each to its current version's file metadata.
+     *
+     * @return list<array{0: VaultDocument, 1: DocumentVersion}>
+     */
+    public function search(DocumentSearchCriteria $criteria): array;
+
+    public function countByCriteria(DocumentSearchCriteria $criteria): int;
 }

--- a/tests/Document/DocumentApiTest.php
+++ b/tests/Document/DocumentApiTest.php
@@ -108,6 +108,47 @@ final class DocumentApiTest extends TestCase
         @unlink($tmp);
     }
 
+    public function test_search_by_counterparty_and_date_combination(): void
+    {
+        $handler = $this->handler();
+
+        // Upload two documents with distinct counterparties and dates
+        $this->upload(handler: $handler, counterparty: 'Alpha Trading', date: '2026-02-10', amount: '50000');
+        $this->upload(handler: $handler, counterparty: 'Beta Supplies', date: '2026-08-20', amount: '75000');
+
+        // Two-field combination: counterparty partial + date range
+        $response = $handler->handle($this->request(
+            'GET',
+            '/admin/vault/documents?counterparty_name=Alpha&transaction_date_from=2026-01-01&transaction_date_to=2026-06-30',
+        ));
+
+        $this->assertSame(200, $response->getStatusCode(), (string) $response->getBody());
+        $body = json_decode((string) $response->getBody(), true);
+        $this->assertIsArray($body);
+        $this->assertGreaterThanOrEqual(1, $body['total']);
+        foreach ($body['items'] as $item) {
+            $this->assertStringContainsString('Alpha', $item['counterparty_name']);
+        }
+    }
+
+    public function test_search_by_amount_range(): void
+    {
+        $handler = $this->handler();
+        $this->upload(handler: $handler, counterparty: 'Gamma Corp', date: '2026-03-15', amount: '999999');
+
+        $response = $handler->handle($this->request(
+            'GET',
+            '/admin/vault/documents?amount_min_cents=999999&amount_max_cents=999999&counterparty_name=Gamma',
+        ));
+
+        $this->assertSame(200, $response->getStatusCode());
+        $body = json_decode((string) $response->getBody(), true);
+        $this->assertGreaterThanOrEqual(1, $body['total']);
+        foreach ($body['items'] as $item) {
+            $this->assertSame(999999, $item['amount_cents']);
+        }
+    }
+
     public function test_get_unknown_document_returns_404(): void
     {
         $response = $this->handler()->handle(
@@ -152,10 +193,38 @@ final class DocumentApiTest extends TestCase
             $headers['Authorization'] = 'Bearer ' . self::$token;
         }
 
+        $queryParams = [];
+        $queryString = parse_url($uri, PHP_URL_QUERY);
+        if (is_string($queryString)) {
+            parse_str($queryString, $queryParams);
+        }
+
         return $creator->fromArrays(
             server: ['REQUEST_METHOD' => $method, 'REQUEST_URI' => $uri],
             headers: $headers,
+            get: $queryParams,
         );
+    }
+
+    /** Uploads a document and returns its id. */
+    private function upload(RequestHandlerInterface $handler, string $counterparty, string $date, string $amount): string
+    {
+        $tmp = $this->makeTempFile("%PDF-1.4\n{$counterparty} {$date} {$amount}\n");
+        $request = $this->request('POST', '/admin/vault/documents')
+            ->withUploadedFiles(['file' => $this->uploadedFile($tmp, 'doc.pdf', 'application/pdf')])
+            ->withParsedBody([
+                'counterparty_name' => $counterparty,
+                'category' => 'invoice_received',
+                'transaction_date' => $date,
+                'amount_cents' => $amount,
+            ]);
+
+        $response = $handler->handle($request);
+        assert($response->getStatusCode() === 201, (string) $response->getBody());
+        $body = json_decode((string) $response->getBody(), true);
+        @unlink($tmp);
+
+        return (string) $body['id'];
     }
 
     private function makeTempFile(string $content): string

--- a/tests/Document/UploadDocumentUseCaseTest.php
+++ b/tests/Document/UploadDocumentUseCaseTest.php
@@ -218,6 +218,17 @@ final class InMemoryVaultDocumentRepository implements VaultDocumentRepositoryIn
         // not needed for upload slice tests
     }
 
+    /** @return list<array{0: VaultDocument, 1: \NeneVault\DocumentVersion\DocumentVersion}> */
+    public function search(\NeneVault\Document\DocumentSearchCriteria $criteria): array
+    {
+        return [];
+    }
+
+    public function countByCriteria(\NeneVault\Document\DocumentSearchCriteria $criteria): int
+    {
+        return 0;
+    }
+
     /** @return list<VaultDocument> */
     public function all(): array
     {


### PR DESCRIPTION
## Summary

`searchDocuments` (GET /admin/vault/documents) を実装。電帳法施行規則 第4条第1項第3号の
検索要件（取引年月日・取引金額・取引先 + 複合）を満たす。

## 検索フィールド（§4.2）
- transaction_date 範囲（from/to）
- amount_cents 範囲（min/max）
- counterparty_name 部分一致（LIKE）
- category 完全一致
- **2フィールド以上の AND 複合に対応**

## 実装
- `VaultDocumentRepositoryInterface::search()` + `countByCriteria()`
- 現バージョンのファイルメタデータを INNER JOIN で結合
- voided は `include_voided=true` 以外では除外
- 全クエリ org スコープ、ページネーション（items/total/limit/offset envelope）
- 検索は読み取り専用 — 監査イベントなし

## テスト
- 取引先+日付の複合検索、金額範囲検索（HTTP統合）

## composer check
PHPUnit 35 / PHPStan 8 / CS / locales 344 / OpenAPI valid — all green

Self-review: compliance, backend-api, database

Closes #17