### PR TITLE
feat: Document metadata edit + void/restore + history (audited lifecycle)

### DIFF
--- a/src/Document/DocumentRouteRegistrar.php
+++ b/src/Document/DocumentRouteRegistrar.php
@@ -12,6 +12,10 @@ final readonly class DocumentRouteRegistrar
         private UploadDocumentHandler $upload,
         private SearchDocumentsHandler $search,
         private GetDocumentByIdHandler $get,
+        private UpdateDocumentMetadataHandler $updateMetadata,
+        private VoidDocumentHandler $void,
+        private RestoreDocumentHandler $restore,
+        private GetDocumentHistoryHandler $history,
     ) {
     }
 
@@ -20,5 +24,9 @@ final readonly class DocumentRouteRegistrar
         $router->get('/admin/vault/documents', $this->search->handle(...));
         $router->post('/admin/vault/documents', $this->upload->handle(...));
         $router->get('/admin/vault/documents/{id}', $this->get->handle(...));
+        $router->patch('/admin/vault/documents/{id}/metadata', $this->updateMetadata->handle(...));
+        $router->post('/admin/vault/documents/{id}/void', $this->void->handle(...));
+        $router->post('/admin/vault/documents/{id}/restore', $this->restore->handle(...));
+        $router->get('/admin/vault/documents/{id}/history', $this->history->handle(...));
     }
 }

--- a/src/Document/DocumentServiceProvider.php
+++ b/src/Document/DocumentServiceProvider.php
@@ -10,6 +10,7 @@ use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
+use NeneVault\Audit\AuditEventRepositoryInterface;
 use NeneVault\Audit\AuditRecorderInterface;
 use NeneVault\DocumentVersion\DocumentStorageInterface;
 use NeneVault\DocumentVersion\DocumentVersionRepositoryInterface;
@@ -130,6 +131,100 @@ final readonly class DocumentServiceProvider implements ServiceProviderInterface
                 },
             )
             ->set(
+                UpdateDocumentMetadataUseCaseInterface::class,
+                static function (ContainerInterface $c): UpdateDocumentMetadataUseCaseInterface {
+                    return new UpdateDocumentMetadataUseCase(
+                        self::repo($c),
+                        self::versionRepo($c),
+                        self::audit($c),
+                    );
+                },
+            )
+            ->set(
+                VoidDocumentUseCaseInterface::class,
+                static function (ContainerInterface $c): VoidDocumentUseCaseInterface {
+                    return new VoidDocumentUseCase(
+                        self::repo($c),
+                        self::versionRepo($c),
+                        self::audit($c),
+                    );
+                },
+            )
+            ->set(
+                RestoreDocumentUseCaseInterface::class,
+                static function (ContainerInterface $c): RestoreDocumentUseCaseInterface {
+                    return new RestoreDocumentUseCase(
+                        self::repo($c),
+                        self::versionRepo($c),
+                        self::audit($c),
+                    );
+                },
+            )
+            ->set(
+                GetDocumentHistoryUseCaseInterface::class,
+                static function (ContainerInterface $c): GetDocumentHistoryUseCaseInterface {
+                    $auditEvents = $c->get(AuditEventRepositoryInterface::class);
+
+                    if (!$auditEvents instanceof AuditEventRepositoryInterface) {
+                        throw new LogicException('AuditEventRepositoryInterface service is invalid.');
+                    }
+
+                    return new GetDocumentHistoryUseCase(
+                        self::repo($c),
+                        self::versionRepo($c),
+                        $auditEvents,
+                    );
+                },
+            )
+            ->set(
+                UpdateDocumentMetadataHandler::class,
+                static function (ContainerInterface $c): UpdateDocumentMetadataHandler {
+                    $uc = $c->get(UpdateDocumentMetadataUseCaseInterface::class);
+
+                    if (!$uc instanceof UpdateDocumentMetadataUseCaseInterface) {
+                        throw new LogicException('UpdateDocumentMetadataUseCaseInterface service is invalid.');
+                    }
+
+                    return new UpdateDocumentMetadataHandler($uc, self::json($c));
+                },
+            )
+            ->set(
+                VoidDocumentHandler::class,
+                static function (ContainerInterface $c): VoidDocumentHandler {
+                    $uc = $c->get(VoidDocumentUseCaseInterface::class);
+
+                    if (!$uc instanceof VoidDocumentUseCaseInterface) {
+                        throw new LogicException('VoidDocumentUseCaseInterface service is invalid.');
+                    }
+
+                    return new VoidDocumentHandler($uc, self::json($c));
+                },
+            )
+            ->set(
+                RestoreDocumentHandler::class,
+                static function (ContainerInterface $c): RestoreDocumentHandler {
+                    $uc = $c->get(RestoreDocumentUseCaseInterface::class);
+
+                    if (!$uc instanceof RestoreDocumentUseCaseInterface) {
+                        throw new LogicException('RestoreDocumentUseCaseInterface service is invalid.');
+                    }
+
+                    return new RestoreDocumentHandler($uc, self::json($c));
+                },
+            )
+            ->set(
+                GetDocumentHistoryHandler::class,
+                static function (ContainerInterface $c): GetDocumentHistoryHandler {
+                    $uc = $c->get(GetDocumentHistoryUseCaseInterface::class);
+
+                    if (!$uc instanceof GetDocumentHistoryUseCaseInterface) {
+                        throw new LogicException('GetDocumentHistoryUseCaseInterface service is invalid.');
+                    }
+
+                    return new GetDocumentHistoryHandler($uc, self::json($c));
+                },
+            )
+            ->set(
                 SearchDocumentsHandler::class,
                 static function (ContainerInterface $c): SearchDocumentsHandler {
                     $uc = $c->get(SearchDocumentsUseCaseInterface::class);
@@ -234,6 +329,10 @@ final readonly class DocumentServiceProvider implements ServiceProviderInterface
                     $upload = $c->get(UploadDocumentHandler::class);
                     $search = $c->get(SearchDocumentsHandler::class);
                     $get = $c->get(GetDocumentByIdHandler::class);
+                    $updateMetadata = $c->get(UpdateDocumentMetadataHandler::class);
+                    $void = $c->get(VoidDocumentHandler::class);
+                    $restore = $c->get(RestoreDocumentHandler::class);
+                    $history = $c->get(GetDocumentHistoryHandler::class);
 
                     if (!$upload instanceof UploadDocumentHandler) {
                         throw new LogicException('UploadDocumentHandler service is invalid.');
@@ -247,8 +346,68 @@ final readonly class DocumentServiceProvider implements ServiceProviderInterface
                         throw new LogicException('GetDocumentByIdHandler service is invalid.');
                     }
 
-                    return new DocumentRouteRegistrar($upload, $search, $get);
+                    if (!$updateMetadata instanceof UpdateDocumentMetadataHandler) {
+                        throw new LogicException('UpdateDocumentMetadataHandler service is invalid.');
+                    }
+
+                    if (!$void instanceof VoidDocumentHandler) {
+                        throw new LogicException('VoidDocumentHandler service is invalid.');
+                    }
+
+                    if (!$restore instanceof RestoreDocumentHandler) {
+                        throw new LogicException('RestoreDocumentHandler service is invalid.');
+                    }
+
+                    if (!$history instanceof GetDocumentHistoryHandler) {
+                        throw new LogicException('GetDocumentHistoryHandler service is invalid.');
+                    }
+
+                    return new DocumentRouteRegistrar($upload, $search, $get, $updateMetadata, $void, $restore, $history);
                 },
             );
+    }
+
+    private static function repo(ContainerInterface $c): VaultDocumentRepositoryInterface
+    {
+        $r = $c->get(VaultDocumentRepositoryInterface::class);
+
+        if (!$r instanceof VaultDocumentRepositoryInterface) {
+            throw new LogicException('VaultDocumentRepositoryInterface service is invalid.');
+        }
+
+        return $r;
+    }
+
+    private static function versionRepo(ContainerInterface $c): DocumentVersionRepositoryInterface
+    {
+        $r = $c->get(DocumentVersionRepositoryInterface::class);
+
+        if (!$r instanceof DocumentVersionRepositoryInterface) {
+            throw new LogicException('DocumentVersionRepositoryInterface service is invalid.');
+        }
+
+        return $r;
+    }
+
+    private static function audit(ContainerInterface $c): AuditRecorderInterface
+    {
+        $a = $c->get(AuditRecorderInterface::class);
+
+        if (!$a instanceof AuditRecorderInterface) {
+            throw new LogicException('AuditRecorderInterface service is invalid.');
+        }
+
+        return $a;
+    }
+
+    private static function json(ContainerInterface $c): JsonResponseFactory
+    {
+        $j = $c->get(JsonResponseFactory::class);
+
+        if (!$j instanceof JsonResponseFactory) {
+            throw new LogicException('JsonResponseFactory service is invalid.');
+        }
+
+        return $j;
     }
 }

--- a/src/Document/GetDocumentHistoryHandler.php
+++ b/src/Document/GetDocumentHistoryHandler.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use NeneVault\Audit\AuditEvent;
+use NeneVault\DocumentVersion\DocumentVersion;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class GetDocumentHistoryHandler
+{
+    public function __construct(
+        private GetDocumentHistoryUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $orgId = $request->getAttribute('nene2.org.id');
+        assert(is_int($orgId));
+
+        $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $documentId = (string) ($params['id'] ?? '');
+
+        $history = $this->useCase->execute($documentId, $orgId);
+
+        return $this->response->create([
+            'versions'     => array_map($this->versionToArray(...), $history['versions']),
+            'audit_events' => array_map($this->auditToArray(...), $history['audit_events']),
+        ]);
+    }
+
+    /** @return array<string, mixed> */
+    private function versionToArray(DocumentVersion $v): array
+    {
+        return [
+            'id'                => $v->id,
+            'version_number'    => $v->versionNumber,
+            'file_sha256'       => $v->fileSha256,
+            'mime_type'         => $v->mimeType,
+            'original_filename' => $v->originalFilename,
+            'file_size_bytes'   => $v->fileSizeBytes,
+            'source'            => $v->source,
+            'uploaded_at'       => $v->uploadedAt,
+            'uploaded_by'       => $v->uploadedBy,
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private function auditToArray(AuditEvent $e): array
+    {
+        return [
+            'id'            => $e->id,
+            'action'        => $e->action,
+            'entity_type'   => $e->entityType,
+            'entity_id'     => $e->entityId,
+            'actor_user_id' => $e->actorUserId,
+            'before_json'   => $e->beforeJson,
+            'after_json'    => $e->afterJson,
+            'metadata_json' => $e->metadataJson,
+            'created_at'    => $e->createdAt,
+        ];
+    }
+}

--- a/src/Document/GetDocumentHistoryUseCase.php
+++ b/src/Document/GetDocumentHistoryUseCase.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+use NeneVault\Audit\AuditEventRepositoryInterface;
+use NeneVault\DocumentVersion\DocumentVersionRepositoryInterface;
+
+final readonly class GetDocumentHistoryUseCase implements GetDocumentHistoryUseCaseInterface
+{
+    private const MAX_EVENTS = 500;
+
+    public function __construct(
+        private VaultDocumentRepositoryInterface $documents,
+        private DocumentVersionRepositoryInterface $versions,
+        private AuditEventRepositoryInterface $auditEvents,
+    ) {
+    }
+
+    /**
+     * @return array{versions: list<\NeneVault\DocumentVersion\DocumentVersion>, audit_events: list<\NeneVault\Audit\AuditEvent>}
+     */
+    public function execute(string $documentId, int $organizationId): array
+    {
+        $document = $this->documents->findById($documentId, $organizationId);
+
+        if ($document === null) {
+            throw new VaultDocumentNotFoundException($documentId);
+        }
+
+        $versions = $this->versions->listByDocumentId($documentId, $organizationId);
+
+        $auditEvents = $this->auditEvents->findByCriteria(
+            [
+                'organization_id' => $organizationId,
+                'entity_type' => 'vault_document',
+                'entity_id' => $documentId,
+            ],
+            self::MAX_EVENTS,
+            0,
+        );
+
+        return ['versions' => $versions, 'audit_events' => $auditEvents];
+    }
+}

--- a/src/Document/GetDocumentHistoryUseCaseInterface.php
+++ b/src/Document/GetDocumentHistoryUseCaseInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+use NeneVault\Audit\AuditEvent;
+use NeneVault\DocumentVersion\DocumentVersion;
+
+interface GetDocumentHistoryUseCaseInterface
+{
+    /**
+     * @return array{versions: list<DocumentVersion>, audit_events: list<AuditEvent>}
+     * @throws VaultDocumentNotFoundException
+     */
+    public function execute(string $documentId, int $organizationId): array;
+}

--- a/src/Document/PdoVaultDocumentRepository.php
+++ b/src/Document/PdoVaultDocumentRepository.php
@@ -72,6 +72,55 @@ final readonly class PdoVaultDocumentRepository implements VaultDocumentReposito
         );
     }
 
+    /** @param list<string> $tags */
+    public function updateMetadata(
+        string $id,
+        int $organizationId,
+        ?string $transactionDate,
+        ?int $amountCents,
+        string $counterpartyName,
+        string $category,
+        array $tags,
+        bool $dateUncertain,
+    ): void {
+        $this->query->execute(
+            'UPDATE vault_documents
+             SET transaction_date = ?, amount_cents = ?, counterparty_name = ?,
+                 category = ?, tags = ?, date_uncertain = ?, is_metadata_confirmed = 1
+             WHERE id = ? AND organization_id = ?',
+            [
+                $transactionDate,
+                $amountCents,
+                $counterpartyName,
+                $category,
+                json_encode($tags, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR),
+                $dateUncertain ? 1 : 0,
+                $id,
+                $organizationId,
+            ],
+        );
+    }
+
+    public function void(string $id, int $organizationId, int $voidedBy, string $voidReason, ?string $voidNote): void
+    {
+        $this->query->execute(
+            "UPDATE vault_documents
+             SET status = 'voided', voided_at = ?, voided_by = ?, void_reason = ?, void_note = ?
+             WHERE id = ? AND organization_id = ?",
+            [date('Y-m-d H:i:s'), $voidedBy, $voidReason, $voidNote, $id, $organizationId],
+        );
+    }
+
+    public function restore(string $id, int $organizationId): void
+    {
+        $this->query->execute(
+            "UPDATE vault_documents
+             SET status = 'active', voided_at = NULL, voided_by = NULL, void_reason = NULL, void_note = NULL
+             WHERE id = ? AND organization_id = ?",
+            [$id, $organizationId],
+        );
+    }
+
     /**
      * @return list<array{0: VaultDocument, 1: DocumentVersion}>
      */

--- a/src/Document/RestoreDocumentHandler.php
+++ b/src/Document/RestoreDocumentHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class RestoreDocumentHandler
+{
+    public function __construct(
+        private RestoreDocumentUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $orgId = $request->getAttribute('nene2.org.id');
+        assert(is_int($orgId));
+
+        $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $documentId = (string) ($params['id'] ?? '');
+
+        $claims = $request->getAttribute('nene2.auth.claims');
+        $actorUserId = is_array($claims) && isset($claims['user_id']) ? (int) $claims['user_id'] : null;
+
+        [$document, $version] = $this->useCase->execute($documentId, $orgId, $actorUserId);
+
+        return $this->response->create(VaultDocumentPresenter::present($document, $version));
+    }
+}

--- a/src/Document/RestoreDocumentUseCase.php
+++ b/src/Document/RestoreDocumentUseCase.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+use NeneVault\Audit\AuditAction;
+use NeneVault\Audit\AuditRecorderInterface;
+use NeneVault\DocumentVersion\DocumentVersionRepositoryInterface;
+
+final readonly class RestoreDocumentUseCase implements RestoreDocumentUseCaseInterface
+{
+    public function __construct(
+        private VaultDocumentRepositoryInterface $documents,
+        private DocumentVersionRepositoryInterface $versions,
+        private AuditRecorderInterface $audit,
+    ) {
+    }
+
+    /**
+     * @return array{0: VaultDocument, 1: \NeneVault\DocumentVersion\DocumentVersion}
+     */
+    public function execute(string $documentId, int $organizationId, ?int $actorUserId): array
+    {
+        $document = $this->documents->findById($documentId, $organizationId);
+
+        if ($document === null) {
+            throw new VaultDocumentNotFoundException($documentId);
+        }
+
+        $beforeJson = ['status' => $document->status];
+
+        $this->documents->restore($documentId, $organizationId);
+
+        $updated = $this->documents->findById($documentId, $organizationId);
+        assert($updated !== null);
+
+        $version = $this->versions->findById($updated->currentVersionId, $organizationId);
+        assert($version !== null);
+
+        $this->audit->record(
+            action: AuditAction::DOCUMENT_RESTORED,
+            entityType: 'vault_document',
+            entityId: $documentId,
+            actorUserId: $actorUserId,
+            organizationId: $organizationId,
+            beforeJson: $beforeJson,
+            afterJson: ['status' => $updated->status],
+        );
+
+        return [$updated, $version];
+    }
+}

--- a/src/Document/RestoreDocumentUseCaseInterface.php
+++ b/src/Document/RestoreDocumentUseCaseInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+use NeneVault\DocumentVersion\DocumentVersion;
+
+interface RestoreDocumentUseCaseInterface
+{
+    /**
+     * @return array{0: VaultDocument, 1: DocumentVersion}
+     * @throws VaultDocumentNotFoundException
+     */
+    public function execute(string $documentId, int $organizationId, ?int $actorUserId): array;
+}

--- a/src/Document/UpdateDocumentMetadataHandler.php
+++ b/src/Document/UpdateDocumentMetadataHandler.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class UpdateDocumentMetadataHandler
+{
+    /** @var list<string> */
+    private const VALID_CATEGORIES = ['invoice_received', 'contract', 'receipt', 'delivery_note', 'other'];
+
+    public function __construct(
+        private UpdateDocumentMetadataUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $orgId = $request->getAttribute('nene2.org.id');
+        assert(is_int($orgId));
+
+        $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $documentId = (string) ($params['id'] ?? '');
+
+        $claims = $request->getAttribute('nene2.auth.claims');
+        $actorUserId = is_array($claims) && isset($claims['user_id']) ? (int) $claims['user_id'] : null;
+
+        $body = JsonRequestBodyParser::parse($request);
+        $errors = [];
+
+        $counterparty = isset($body['counterparty_name']) && is_string($body['counterparty_name'])
+            ? trim($body['counterparty_name'])
+            : '';
+        if ($counterparty === '') {
+            $errors[] = new ValidationError('counterparty_name', 'This field is required.', 'required');
+        }
+
+        $category = isset($body['category']) && is_string($body['category']) ? $body['category'] : '';
+        if (!in_array($category, self::VALID_CATEGORIES, true)) {
+            $errors[] = new ValidationError('category', 'Invalid category.', 'invalid_format');
+        }
+
+        $transactionDate = isset($body['transaction_date']) && is_string($body['transaction_date']) && $body['transaction_date'] !== ''
+            ? $body['transaction_date']
+            : null;
+        if ($transactionDate !== null && !$this->isValidDate($transactionDate)) {
+            $errors[] = new ValidationError('transaction_date', 'Please enter a valid date (YYYY-MM-DD).', 'invalid_date');
+        }
+
+        $amountCents = null;
+        if (isset($body['amount_cents']) && $body['amount_cents'] !== '') {
+            if (!is_numeric($body['amount_cents']) || (int) $body['amount_cents'] != $body['amount_cents']) {
+                $errors[] = new ValidationError('amount_cents', 'Please enter a valid integer amount.', 'invalid_amount');
+            } else {
+                $amountCents = (int) $body['amount_cents'];
+            }
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        $tags = [];
+        if (isset($body['tags']) && is_array($body['tags'])) {
+            $tags = array_values(array_map('strval', $body['tags']));
+        }
+
+        [$document, $version] = $this->useCase->execute(new UpdateDocumentMetadataInput(
+            documentId: $documentId,
+            organizationId: $orgId,
+            transactionDate: $transactionDate,
+            amountCents: $amountCents,
+            counterpartyName: $counterparty,
+            category: $category,
+            tags: $tags,
+            actorUserId: $actorUserId,
+        ));
+
+        return $this->response->create(VaultDocumentPresenter::present($document, $version));
+    }
+
+    private function isValidDate(string $date): bool
+    {
+        $d = \DateTimeImmutable::createFromFormat('Y-m-d', $date);
+
+        return $d !== false && $d->format('Y-m-d') === $date;
+    }
+}

--- a/src/Document/UpdateDocumentMetadataInput.php
+++ b/src/Document/UpdateDocumentMetadataInput.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+final readonly class UpdateDocumentMetadataInput
+{
+    /**
+     * @param list<string> $tags
+     */
+    public function __construct(
+        public string $documentId,
+        public int $organizationId,
+        public ?string $transactionDate,
+        public ?int $amountCents,
+        public string $counterpartyName,
+        public string $category,
+        public array $tags,
+        public ?int $actorUserId = null,
+    ) {
+    }
+}

--- a/src/Document/UpdateDocumentMetadataUseCase.php
+++ b/src/Document/UpdateDocumentMetadataUseCase.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+use NeneVault\Audit\AuditAction;
+use NeneVault\Audit\AuditRecorderInterface;
+use NeneVault\DocumentVersion\DocumentVersionRepositoryInterface;
+
+final readonly class UpdateDocumentMetadataUseCase implements UpdateDocumentMetadataUseCaseInterface
+{
+    public function __construct(
+        private VaultDocumentRepositoryInterface $documents,
+        private DocumentVersionRepositoryInterface $versions,
+        private AuditRecorderInterface $audit,
+    ) {
+    }
+
+    /**
+     * @return array{0: VaultDocument, 1: \NeneVault\DocumentVersion\DocumentVersion}
+     */
+    public function execute(UpdateDocumentMetadataInput $input): array
+    {
+        $document = $this->documents->findById($input->documentId, $input->organizationId);
+
+        if ($document === null) {
+            throw new VaultDocumentNotFoundException($input->documentId);
+        }
+
+        // Capture before-state metadata for audit (§3.2)
+        $beforeJson = $this->metadataSnapshot($document);
+
+        $dateUncertain = $input->transactionDate === null;
+
+        $this->documents->updateMetadata(
+            $input->documentId,
+            $input->organizationId,
+            $input->transactionDate,
+            $input->amountCents,
+            $input->counterpartyName,
+            $input->category,
+            $input->tags,
+            $dateUncertain,
+        );
+
+        $updated = $this->documents->findById($input->documentId, $input->organizationId);
+        assert($updated !== null);
+
+        $version = $this->versions->findById($updated->currentVersionId, $input->organizationId);
+        assert($version !== null);
+
+        $this->audit->record(
+            action: AuditAction::DOCUMENT_METADATA_CHANGED,
+            entityType: 'vault_document',
+            entityId: $input->documentId,
+            actorUserId: $input->actorUserId,
+            organizationId: $input->organizationId,
+            beforeJson: $beforeJson,
+            afterJson: $this->metadataSnapshot($updated),
+        );
+
+        return [$updated, $version];
+    }
+
+    /** @return array<string, mixed> */
+    private function metadataSnapshot(VaultDocument $doc): array
+    {
+        return [
+            'transaction_date'  => $doc->transactionDate,
+            'amount_cents'      => $doc->amountCents,
+            'counterparty_name' => $doc->counterpartyName,
+            'category'          => $doc->category,
+            'tags'              => $doc->tags,
+            'date_uncertain'    => $doc->dateUncertain,
+        ];
+    }
+}

--- a/src/Document/UpdateDocumentMetadataUseCaseInterface.php
+++ b/src/Document/UpdateDocumentMetadataUseCaseInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+use NeneVault\DocumentVersion\DocumentVersion;
+
+interface UpdateDocumentMetadataUseCaseInterface
+{
+    /**
+     * @return array{0: VaultDocument, 1: DocumentVersion}
+     * @throws VaultDocumentNotFoundException
+     */
+    public function execute(UpdateDocumentMetadataInput $input): array;
+}

--- a/src/Document/VaultDocumentRepositoryInterface.php
+++ b/src/Document/VaultDocumentRepositoryInterface.php
@@ -15,6 +15,26 @@ interface VaultDocumentRepositoryInterface
     public function updateCurrentVersion(string $id, int $organizationId, string $currentVersionId): void;
 
     /**
+     * Update editable metadata fields. File bytes are never touched.
+     *
+     * @param list<string> $tags
+     */
+    public function updateMetadata(
+        string $id,
+        int $organizationId,
+        ?string $transactionDate,
+        ?int $amountCents,
+        string $counterpartyName,
+        string $category,
+        array $tags,
+        bool $dateUncertain,
+    ): void;
+
+    public function void(string $id, int $organizationId, int $voidedBy, string $voidReason, ?string $voidNote): void;
+
+    public function restore(string $id, int $organizationId): void;
+
+    /**
      * Search documents, joining each to its current version's file metadata.
      *
      * @return list<array{0: VaultDocument, 1: DocumentVersion}>

--- a/src/Document/VoidDocumentHandler.php
+++ b/src/Document/VoidDocumentHandler.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class VoidDocumentHandler
+{
+    public function __construct(
+        private VoidDocumentUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $orgId = $request->getAttribute('nene2.org.id');
+        assert(is_int($orgId));
+
+        $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $documentId = (string) ($params['id'] ?? '');
+
+        $claims = $request->getAttribute('nene2.auth.claims');
+        $actorUserId = is_array($claims) && isset($claims['user_id']) ? (int) $claims['user_id'] : null;
+
+        $body = JsonRequestBodyParser::parse($request);
+
+        $voidReason = isset($body['void_reason']) && is_string($body['void_reason']) ? trim($body['void_reason']) : '';
+        if ($voidReason === '') {
+            throw new ValidationException([
+                new ValidationError('void_reason', 'A reason is required to void a document.', 'required'),
+            ]);
+        }
+
+        $voidNote = isset($body['void_note']) && is_string($body['void_note']) && $body['void_note'] !== ''
+            ? $body['void_note']
+            : null;
+
+        [$document, $version] = $this->useCase->execute($documentId, $orgId, $voidReason, $voidNote, $actorUserId);
+
+        return $this->response->create(VaultDocumentPresenter::present($document, $version));
+    }
+}

--- a/src/Document/VoidDocumentUseCase.php
+++ b/src/Document/VoidDocumentUseCase.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+use NeneVault\Audit\AuditAction;
+use NeneVault\Audit\AuditRecorderInterface;
+use NeneVault\DocumentVersion\DocumentVersionRepositoryInterface;
+
+final readonly class VoidDocumentUseCase implements VoidDocumentUseCaseInterface
+{
+    public function __construct(
+        private VaultDocumentRepositoryInterface $documents,
+        private DocumentVersionRepositoryInterface $versions,
+        private AuditRecorderInterface $audit,
+    ) {
+    }
+
+    /**
+     * @return array{0: VaultDocument, 1: \NeneVault\DocumentVersion\DocumentVersion}
+     */
+    public function execute(
+        string $documentId,
+        int $organizationId,
+        string $voidReason,
+        ?string $voidNote,
+        ?int $actorUserId,
+    ): array {
+        $document = $this->documents->findById($documentId, $organizationId);
+
+        if ($document === null) {
+            throw new VaultDocumentNotFoundException($documentId);
+        }
+
+        $beforeJson = ['status' => $document->status];
+
+        $this->documents->void($documentId, $organizationId, $actorUserId ?? 0, $voidReason, $voidNote);
+
+        $updated = $this->documents->findById($documentId, $organizationId);
+        assert($updated !== null);
+
+        $version = $this->versions->findById($updated->currentVersionId, $organizationId);
+        assert($version !== null);
+
+        $this->audit->record(
+            action: AuditAction::DOCUMENT_VOIDED,
+            entityType: 'vault_document',
+            entityId: $documentId,
+            actorUserId: $actorUserId,
+            organizationId: $organizationId,
+            beforeJson: $beforeJson,
+            afterJson: ['status' => $updated->status],
+            metadataJson: ['void_reason' => $voidReason, 'void_note' => $voidNote],
+        );
+
+        return [$updated, $version];
+    }
+}

--- a/src/Document/VoidDocumentUseCaseInterface.php
+++ b/src/Document/VoidDocumentUseCaseInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+use NeneVault\DocumentVersion\DocumentVersion;
+
+interface VoidDocumentUseCaseInterface
+{
+    /**
+     * @return array{0: VaultDocument, 1: DocumentVersion}
+     * @throws VaultDocumentNotFoundException
+     */
+    public function execute(
+        string $documentId,
+        int $organizationId,
+        string $voidReason,
+        ?string $voidNote,
+        ?int $actorUserId,
+    ): array;
+}

--- a/tests/Document/DocumentApiTest.php
+++ b/tests/Document/DocumentApiTest.php
@@ -149,6 +149,85 @@ final class DocumentApiTest extends TestCase
         }
     }
 
+    public function test_metadata_edit_then_void_then_restore_with_history(): void
+    {
+        $handler = $this->handler();
+        $id = $this->upload(handler: $handler, counterparty: 'Delta Ltd', date: '2026-04-01', amount: '12345');
+
+        // 1. Edit metadata — counterparty + amount change
+        $patch = $this->request('PATCH', '/admin/vault/documents/' . $id . '/metadata', json: [
+            'counterparty_name' => 'Delta Limited',
+            'category' => 'invoice_received',
+            'transaction_date' => '2026-04-02',
+            'amount_cents' => '54321',
+        ]);
+        $patchResponse = $handler->handle($patch);
+        $this->assertSame(200, $patchResponse->getStatusCode(), (string) $patchResponse->getBody());
+        $patched = json_decode((string) $patchResponse->getBody(), true);
+        $this->assertSame('Delta Limited', $patched['counterparty_name']);
+        $this->assertSame(54321, $patched['amount_cents']);
+        $this->assertTrue($patched['is_metadata_confirmed']);
+
+        // 2. Void with reason
+        $void = $this->request('POST', '/admin/vault/documents/' . $id . '/void', json: ['void_reason' => 'Duplicate entry']);
+        $voidResponse = $handler->handle($void);
+        $this->assertSame(200, $voidResponse->getStatusCode(), (string) $voidResponse->getBody());
+        $voided = json_decode((string) $voidResponse->getBody(), true);
+        $this->assertSame('voided', $voided['status']);
+        $this->assertSame('Duplicate entry', $voided['void_reason']);
+
+        // 3. Voided excluded from default search
+        $search = $handler->handle($this->request('GET', '/admin/vault/documents?counterparty_name=Delta+Limited'));
+        $searchBody = json_decode((string) $search->getBody(), true);
+        foreach ($searchBody['items'] as $item) {
+            $this->assertNotSame($id, $item['id'], 'Voided document must not appear in default search');
+        }
+
+        // 4. Voided included when include_voided=true
+        $searchVoided = $handler->handle($this->request('GET', '/admin/vault/documents?counterparty_name=Delta+Limited&include_voided=true'));
+        $searchVoidedBody = json_decode((string) $searchVoided->getBody(), true);
+        $ids = array_column($searchVoidedBody['items'], 'id');
+        $this->assertContains($id, $ids);
+
+        // 5. Restore
+        $restore = $handler->handle($this->request('POST', '/admin/vault/documents/' . $id . '/restore'));
+        $this->assertSame(200, $restore->getStatusCode());
+        $restored = json_decode((string) $restore->getBody(), true);
+        $this->assertSame('active', $restored['status']);
+
+        // 6. History contains version + audit events (uploaded, metadata_changed, voided, restored)
+        $history = $handler->handle($this->request('GET', '/admin/vault/documents/' . $id . '/history'));
+        $this->assertSame(200, $history->getStatusCode());
+        $historyBody = json_decode((string) $history->getBody(), true);
+        $this->assertCount(1, $historyBody['versions']);
+        $actions = array_column($historyBody['audit_events'], 'action');
+        $this->assertContains('document.uploaded', $actions);
+        $this->assertContains('document.metadata_changed', $actions);
+        $this->assertContains('document.voided', $actions);
+        $this->assertContains('document.restored', $actions);
+
+        // metadata_changed event must carry before/after
+        foreach ($historyBody['audit_events'] as $event) {
+            if ($event['action'] === 'document.metadata_changed') {
+                $this->assertSame('Delta Ltd', $event['before_json']['counterparty_name']);
+                $this->assertSame('Delta Limited', $event['after_json']['counterparty_name']);
+            }
+        }
+    }
+
+    public function test_void_requires_reason(): void
+    {
+        $handler = $this->handler();
+        $id = $this->upload(handler: $handler, counterparty: 'Epsilon', date: '2026-05-01', amount: '100');
+
+        // Send a JSON object without void_reason → validation 422
+        $response = $handler->handle(
+            $this->request('POST', '/admin/vault/documents/' . $id . '/void', json: ['void_note' => 'no reason given']),
+        );
+
+        $this->assertSame(422, $response->getStatusCode());
+    }
+
     public function test_get_unknown_document_returns_404(): void
     {
         $response = $this->handler()->handle(
@@ -179,7 +258,8 @@ final class DocumentApiTest extends TestCase
         return $handler;
     }
 
-    private function request(string $method, string $uri, bool $auth = true): ServerRequestInterface
+    /** @param array<string, mixed>|null $json */
+    private function request(string $method, string $uri, bool $auth = true, ?array $json = null): ServerRequestInterface
     {
         $container = self::$container;
         assert($container !== null);
@@ -199,10 +279,18 @@ final class DocumentApiTest extends TestCase
             parse_str($queryString, $queryParams);
         }
 
+        $body = null;
+        if ($json !== null) {
+            $headers['Content-Type'] = 'application/json';
+            $encoded = json_encode($json, JSON_THROW_ON_ERROR);
+            $body = $psr17->createStream($encoded);
+        }
+
         return $creator->fromArrays(
             server: ['REQUEST_METHOD' => $method, 'REQUEST_URI' => $uri],
             headers: $headers,
             get: $queryParams,
+            body: $body,
         );
     }
 

--- a/tests/Document/UploadDocumentUseCaseTest.php
+++ b/tests/Document/UploadDocumentUseCaseTest.php
@@ -218,6 +218,30 @@ final class InMemoryVaultDocumentRepository implements VaultDocumentRepositoryIn
         // not needed for upload slice tests
     }
 
+    /** @param list<string> $tags */
+    public function updateMetadata(
+        string $id,
+        int $organizationId,
+        ?string $transactionDate,
+        ?int $amountCents,
+        string $counterpartyName,
+        string $category,
+        array $tags,
+        bool $dateUncertain,
+    ): void {
+        // not needed for upload slice tests
+    }
+
+    public function void(string $id, int $organizationId, int $voidedBy, string $voidReason, ?string $voidNote): void
+    {
+        // not needed for upload slice tests
+    }
+
+    public function restore(string $id, int $organizationId): void
+    {
+        // not needed for upload slice tests
+    }
+
     /** @return list<array{0: VaultDocument, 1: \NeneVault\DocumentVersion\DocumentVersion}> */
     public function search(\NeneVault\Document\DocumentSearchCriteria $criteria): array
     {


### PR DESCRIPTION
## Summary

監査付きの変更ライフサイクルを実装。各操作は**前後の監査イベント**を記録（ADR 0014）。
ファイルバイトには一切触れない。

## 実装

| 操作 | エンドポイント | 監査アクション |
|---|---|---|
| メタデータ編集 | PATCH .../metadata | document.metadata_changed（before/after §3.2） |
| 無効化 | POST .../void | document.voided（void_reason 必須 §3.3） |
| 復元 | POST .../restore | document.restored |
| 履歴 | GET .../history | バージョン + 全監査イベント |

## コンプライアンス
- メタデータ変更は旧値+新値を監査に追記（§3.2）
- void は voided_at/by + reason 記録、DB に残存、デフォルト検索から除外（§3.3）
- voided も保存期間にカウント、ファイル削除なし
- restore は監査記録

## テスト
- `test_metadata_edit_then_void_then_restore_with_history`:
  編集 → void → 検索除外確認 → include_voided 確認 → restore → history 検証
  metadata_changed の before/after を検証（Delta Ltd → Delta Limited）
- `test_void_requires_reason`: 理由なしは 422

## composer check
PHPUnit 37 (142 assertions) / PHPStan 8 / CS / locales 344 / OpenAPI valid — all green

Self-review: compliance, backend-api, database

Closes #19