### PR TITLE
feat: Document version download — authenticated streaming with SHA-256 verification

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -21,9 +21,15 @@ Operators self-host Vault to store and search **received** vendor documents with
 - Audit logging — before/after on all mutations (ADR 0014) ✅ (PR #10)
 - ja/en locale files (ADR 0005) ✅ (PR #12)
 - OpenAPI 3.1 contract — all Phase 1 endpoints ✅ (PR #14)
-- Upload, metadata, search, void, version history 🔲 (in progress)
-- Local filesystem storage (ADR 0012) 🔲
+- Document upload + storage foundation + get detail ✅ (PR #16)
+- Document search — date/amount/counterparty/category ✅ (PR #18)
+- Metadata edit + void/restore + history (audited) ✅ (PR #20)
+- Version download — authenticated, SHA-256 verified ✅ (PR #22)
+- Local filesystem storage (ADR 0012) ✅ (PR #16)
 - PHPUnit + PHPStan 8 ✅ (gate established)
+
+**Phase 1 Document API complete.** Remaining: user CRUD endpoints, manifest export
+(Phase 2), 税理士 review gate before Phase 2 UI.
 
 ## Phase 2: Admin UI + Export
 

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -16,6 +16,7 @@ use NeneVault\Auth\InvalidCredentialsExceptionHandler;
 use NeneVault\Document\DocumentRouteRegistrar;
 use NeneVault\Document\DocumentServiceProvider;
 use NeneVault\Document\DuplicateFileExceptionHandler;
+use NeneVault\Document\FileIntegrityExceptionHandler;
 use NeneVault\Document\FileTooLargeExceptionHandler;
 use NeneVault\Document\MimeTypeNotAllowedExceptionHandler;
 use NeneVault\Document\VaultDocumentNotFoundExceptionHandler;
@@ -126,6 +127,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $c->get(DuplicateFileExceptionHandler::class),
                     $c->get(MimeTypeNotAllowedExceptionHandler::class),
                     $c->get(FileTooLargeExceptionHandler::class),
+                    $c->get(FileIntegrityExceptionHandler::class),
                 ];
             },
         );

--- a/src/Document/DocumentRouteRegistrar.php
+++ b/src/Document/DocumentRouteRegistrar.php
@@ -16,6 +16,7 @@ final readonly class DocumentRouteRegistrar
         private VoidDocumentHandler $void,
         private RestoreDocumentHandler $restore,
         private GetDocumentHistoryHandler $history,
+        private DownloadDocumentVersionHandler $download,
     ) {
     }
 
@@ -28,5 +29,6 @@ final readonly class DocumentRouteRegistrar
         $router->post('/admin/vault/documents/{id}/void', $this->void->handle(...));
         $router->post('/admin/vault/documents/{id}/restore', $this->restore->handle(...));
         $router->get('/admin/vault/documents/{id}/history', $this->history->handle(...));
+        $router->get('/admin/vault/documents/{id}/versions/{versionId}/download', $this->download->handle(...));
     }
 }

--- a/src/Document/DocumentServiceProvider.php
+++ b/src/Document/DocumentServiceProvider.php
@@ -18,6 +18,8 @@ use NeneVault\DocumentVersion\LocalFilesystemDocumentStorage;
 use NeneVault\DocumentVersion\PdoDocumentVersionRepository;
 use NeneVault\VaultSettings\VaultSettingsRepositoryInterface;
 use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
 
 final readonly class DocumentServiceProvider implements ServiceProviderInterface
 {
@@ -177,6 +179,18 @@ final readonly class DocumentServiceProvider implements ServiceProviderInterface
                 },
             )
             ->set(
+                DownloadDocumentVersionUseCaseInterface::class,
+                static function (ContainerInterface $c): DownloadDocumentVersionUseCaseInterface {
+                    $storage = $c->get(DocumentStorageInterface::class);
+
+                    if (!$storage instanceof DocumentStorageInterface) {
+                        throw new LogicException('DocumentStorageInterface service is invalid.');
+                    }
+
+                    return new DownloadDocumentVersionUseCase(self::versionRepo($c), $storage);
+                },
+            )
+            ->set(
                 UpdateDocumentMetadataHandler::class,
                 static function (ContainerInterface $c): UpdateDocumentMetadataHandler {
                     $uc = $c->get(UpdateDocumentMetadataUseCaseInterface::class);
@@ -222,6 +236,40 @@ final readonly class DocumentServiceProvider implements ServiceProviderInterface
                     }
 
                     return new GetDocumentHistoryHandler($uc, self::json($c));
+                },
+            )
+            ->set(
+                DownloadDocumentVersionHandler::class,
+                static function (ContainerInterface $c): DownloadDocumentVersionHandler {
+                    $uc = $c->get(DownloadDocumentVersionUseCaseInterface::class);
+                    $responseFactory = $c->get(ResponseFactoryInterface::class);
+                    $streamFactory = $c->get(StreamFactoryInterface::class);
+
+                    if (!$uc instanceof DownloadDocumentVersionUseCaseInterface) {
+                        throw new LogicException('DownloadDocumentVersionUseCaseInterface service is invalid.');
+                    }
+
+                    if (!$responseFactory instanceof ResponseFactoryInterface) {
+                        throw new LogicException('ResponseFactoryInterface service is invalid.');
+                    }
+
+                    if (!$streamFactory instanceof StreamFactoryInterface) {
+                        throw new LogicException('StreamFactoryInterface service is invalid.');
+                    }
+
+                    return new DownloadDocumentVersionHandler($uc, $responseFactory, $streamFactory);
+                },
+            )
+            ->set(
+                FileIntegrityExceptionHandler::class,
+                static function (ContainerInterface $c): FileIntegrityExceptionHandler {
+                    $pd = $c->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$pd instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('ProblemDetailsResponseFactory service is invalid.');
+                    }
+
+                    return new FileIntegrityExceptionHandler($pd);
                 },
             )
             ->set(
@@ -333,6 +381,7 @@ final readonly class DocumentServiceProvider implements ServiceProviderInterface
                     $void = $c->get(VoidDocumentHandler::class);
                     $restore = $c->get(RestoreDocumentHandler::class);
                     $history = $c->get(GetDocumentHistoryHandler::class);
+                    $download = $c->get(DownloadDocumentVersionHandler::class);
 
                     if (!$upload instanceof UploadDocumentHandler) {
                         throw new LogicException('UploadDocumentHandler service is invalid.');
@@ -362,7 +411,11 @@ final readonly class DocumentServiceProvider implements ServiceProviderInterface
                         throw new LogicException('GetDocumentHistoryHandler service is invalid.');
                     }
 
-                    return new DocumentRouteRegistrar($upload, $search, $get, $updateMetadata, $void, $restore, $history);
+                    if (!$download instanceof DownloadDocumentVersionHandler) {
+                        throw new LogicException('DownloadDocumentVersionHandler service is invalid.');
+                    }
+
+                    return new DocumentRouteRegistrar($upload, $search, $get, $updateMetadata, $void, $restore, $history, $download);
                 },
             );
     }

--- a/src/Document/DownloadDocumentVersionHandler.php
+++ b/src/Document/DownloadDocumentVersionHandler.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+final readonly class DownloadDocumentVersionHandler
+{
+    public function __construct(
+        private DownloadDocumentVersionUseCaseInterface $useCase,
+        private ResponseFactoryInterface $responseFactory,
+        private StreamFactoryInterface $streamFactory,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $orgId = $request->getAttribute('nene2.org.id');
+        assert(is_int($orgId));
+
+        $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $documentId = (string) ($params['id'] ?? '');
+        $versionId = (string) ($params['versionId'] ?? '');
+
+        $result = $this->useCase->execute($documentId, $versionId, $orgId);
+
+        $stream = $this->streamFactory->createStreamFromFile($result['absolute_path'], 'rb');
+
+        return $this->responseFactory->createResponse(200)
+            ->withHeader('Content-Type', $result['mime_type'])
+            ->withHeader('Content-Disposition', 'attachment; filename="' . $this->sanitizeFilename($result['filename']) . '"')
+            ->withHeader('X-Content-Type-Options', 'nosniff')
+            ->withBody($stream);
+    }
+
+    private function sanitizeFilename(string $filename): string
+    {
+        // Strip characters that could break the header; keep it simple and safe.
+        return str_replace(['"', "\r", "\n"], '', $filename);
+    }
+}

--- a/src/Document/DownloadDocumentVersionUseCase.php
+++ b/src/Document/DownloadDocumentVersionUseCase.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+use NeneVault\DocumentVersion\DocumentStorageInterface;
+use NeneVault\DocumentVersion\DocumentVersionRepositoryInterface;
+
+final readonly class DownloadDocumentVersionUseCase implements DownloadDocumentVersionUseCaseInterface
+{
+    public function __construct(
+        private DocumentVersionRepositoryInterface $versions,
+        private DocumentStorageInterface $storage,
+    ) {
+    }
+
+    /**
+     * @return array{absolute_path: string, mime_type: string, filename: string}
+     */
+    public function execute(string $documentId, string $versionId, int $organizationId): array
+    {
+        $version = $this->versions->findById($versionId, $organizationId);
+
+        // Org-scoped + must belong to the named document
+        if ($version === null || $version->vaultDocumentId !== $documentId) {
+            throw new VaultDocumentNotFoundException($documentId);
+        }
+
+        $absolutePath = $this->storage->resolveAbsolutePath($version->filePath);
+
+        if (!is_file($absolutePath)) {
+            throw new VaultDocumentNotFoundException($documentId);
+        }
+
+        // Verify SHA-256 before serving (compliance §3.1) — mismatch is a P0 defect
+        $actualHash = $this->storage->sha256($absolutePath);
+        if (!hash_equals($version->fileSha256, $actualHash)) {
+            throw new FileIntegrityException($versionId);
+        }
+
+        return [
+            'absolute_path' => $absolutePath,
+            'mime_type' => $version->mimeType,
+            'filename' => $version->originalFilename,
+        ];
+    }
+}

--- a/src/Document/DownloadDocumentVersionUseCaseInterface.php
+++ b/src/Document/DownloadDocumentVersionUseCaseInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+interface DownloadDocumentVersionUseCaseInterface
+{
+    /**
+     * @return array{absolute_path: string, mime_type: string, filename: string}
+     * @throws VaultDocumentNotFoundException
+     * @throws FileIntegrityException
+     */
+    public function execute(string $documentId, string $versionId, int $organizationId): array;
+}

--- a/src/Document/FileIntegrityException.php
+++ b/src/Document/FileIntegrityException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+use RuntimeException;
+
+/**
+ * Thrown when a stored file's SHA-256 no longer matches the recorded hash.
+ * This is a P0 integrity defect (received-document-compliance §3.1).
+ */
+final class FileIntegrityException extends RuntimeException
+{
+    public function __construct(string $versionId)
+    {
+        parent::__construct("File integrity check failed for version {$versionId}: stored hash does not match.");
+    }
+}

--- a/src/Document/FileIntegrityExceptionHandler.php
+++ b/src/Document/FileIntegrityExceptionHandler.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class FileIntegrityExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $e): bool
+    {
+        return $e instanceof FileIntegrityException;
+    }
+
+    public function handle(Throwable $e, ServerRequestInterface $request): ResponseInterface
+    {
+        // Do not leak which file or hash; integrity failure is a server-side P0.
+        return $this->problemDetails->create(
+            $request,
+            'internal-server-error',
+            'Internal Server Error',
+            500,
+            'The requested file could not be served due to an integrity check failure.',
+        );
+    }
+}

--- a/tests/Document/DocumentApiTest.php
+++ b/tests/Document/DocumentApiTest.php
@@ -149,6 +149,41 @@ final class DocumentApiTest extends TestCase
         }
     }
 
+    public function test_download_version_returns_file_bytes(): void
+    {
+        $handler = $this->handler();
+        $id = $this->upload(handler: $handler, counterparty: 'Zeta Corp', date: '2026-06-01', amount: '8000');
+
+        // Get the version id from history
+        $history = $handler->handle($this->request('GET', '/admin/vault/documents/' . $id . '/history'));
+        $historyBody = json_decode((string) $history->getBody(), true);
+        $versionId = $historyBody['versions'][0]['id'];
+        $this->assertIsString($versionId);
+
+        $download = $handler->handle($this->request(
+            'GET',
+            '/admin/vault/documents/' . $id . '/versions/' . $versionId . '/download',
+        ));
+
+        $this->assertSame(200, $download->getStatusCode(), (string) $download->getBody());
+        $this->assertSame('application/pdf', $download->getHeaderLine('Content-Type'));
+        $this->assertStringContainsString('attachment', $download->getHeaderLine('Content-Disposition'));
+        $this->assertStringStartsWith('%PDF', (string) $download->getBody());
+    }
+
+    public function test_download_unknown_version_returns_404(): void
+    {
+        $handler = $this->handler();
+        $id = $this->upload(handler: $handler, counterparty: 'Eta Corp', date: '2026-06-02', amount: '9000');
+
+        $response = $handler->handle($this->request(
+            'GET',
+            '/admin/vault/documents/' . $id . '/versions/00000000000000000000000000/download',
+        ));
+
+        $this->assertSame(404, $response->getStatusCode());
+    }
+
     public function test_metadata_edit_then_void_then_restore_with_history(): void
     {
         $handler = $this->handler();


### PR DESCRIPTION
## Summary

`downloadDocumentVersion` を実装。**Phase 1 Document API が全エンドポイント完成。**

## 実装
- `DownloadDocumentVersionUseCase` — org スコープ検証 + 配信前 SHA-256 検証
- `DownloadDocumentVersionHandler` — PSR-17 でファイルストリーム
- `FileIntegrityException` — ハッシュ不一致は P0 として 500（詳細を漏らさない）

## コンプライアンス（backend-standards §5）
- 認証付きダウンロードのみ — storage path への公開 URL なし
- 配信前 SHA-256 検証、不一致は 500
- storage path は URL・レスポンスヘッダーに非露出
- 別 org のバージョンは 404

## テスト
- `test_download_version_returns_file_bytes`: PDFバイト + Content-Type 検証
- `test_download_unknown_version_returns_404`

## Phase 1 Document API 完了
upload / search / get / metadata / void / restore / history / download すべて実装・テスト済み

## composer check
PHPUnit 39 (148 assertions) / PHPStan 8 / CS / locales 344 / OpenAPI valid — all green

Self-review: compliance, backend-api, middleware-security

Closes #21