### PR TITLE
feat: User CRUD endpoints — admin-managed org users (audited)

### DIFF
--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -25,6 +25,12 @@ use NeneVault\Organization\OrganizationNotFoundExceptionHandler;
 use NeneVault\Organization\OrganizationRouteRegistrar;
 use NeneVault\Organization\OrganizationServiceProvider;
 use NeneVault\Organization\OrganizationSlugConflictExceptionHandler;
+use NeneVault\User\CannotDeleteSelfExceptionHandler;
+use NeneVault\User\InvalidUserRoleExceptionHandler;
+use NeneVault\User\UserEmailConflictExceptionHandler;
+use NeneVault\User\UserNotFoundExceptionHandler;
+use NeneVault\User\UserRouteRegistrar;
+use NeneVault\User\UserServiceProvider;
 use NeneVault\VaultSettings\VaultSettingsRouteRegistrar;
 use NeneVault\VaultSettings\VaultSettingsServiceProvider;
 use Psr\Container\ContainerInterface;
@@ -53,7 +59,8 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
             ->addProvider(new AuditServiceProvider())
             ->addProvider(new OrganizationServiceProvider())
             ->addProvider(new VaultSettingsServiceProvider())
-            ->addProvider(new DocumentServiceProvider());
+            ->addProvider(new DocumentServiceProvider())
+            ->addProvider(new UserServiceProvider());
 
         // Health handler
         $builder->set(
@@ -79,6 +86,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                 $settings = $c->get(VaultSettingsRouteRegistrar::class);
                 $audit = $c->get(AuditRouteRegistrar::class);
                 $document = $c->get(DocumentRouteRegistrar::class);
+                $user = $c->get(UserRouteRegistrar::class);
 
                 if (!$health instanceof HealthHandler) {
                     throw new LogicException('HealthHandler service is invalid.');
@@ -104,6 +112,10 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     throw new LogicException('DocumentRouteRegistrar service is invalid.');
                 }
 
+                if (!$user instanceof UserRouteRegistrar) {
+                    throw new LogicException('UserRouteRegistrar service is invalid.');
+                }
+
                 return [
                     static fn ($router) => $router->get('/health', $health->handle(...)),
                     static fn ($router) => $auth->register($router),
@@ -111,6 +123,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     static fn ($router) => $settings->register($router),
                     static fn ($router) => $audit->register($router),
                     static fn ($router) => $document->register($router),
+                    static fn ($router) => $user->register($router),
                 ];
             },
         );
@@ -128,6 +141,10 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $c->get(MimeTypeNotAllowedExceptionHandler::class),
                     $c->get(FileTooLargeExceptionHandler::class),
                     $c->get(FileIntegrityExceptionHandler::class),
+                    $c->get(UserNotFoundExceptionHandler::class),
+                    $c->get(UserEmailConflictExceptionHandler::class),
+                    $c->get(InvalidUserRoleExceptionHandler::class),
+                    $c->get(CannotDeleteSelfExceptionHandler::class),
                 ];
             },
         );

--- a/src/Auth/PdoUserRepository.php
+++ b/src/Auth/PdoUserRepository.php
@@ -74,16 +74,32 @@ final readonly class PdoUserRepository implements UserRepositoryInterface
     public function updatePassword(int $id, string $passwordHash): void
     {
         $this->query->execute(
-            'UPDATE users SET password_hash = ?, updated_at = NOW() WHERE id = ?',
-            [$passwordHash, $id],
+            'UPDATE users SET password_hash = ?, updated_at = ? WHERE id = ?',
+            [$passwordHash, date('Y-m-d H:i:s'), $id],
         );
     }
 
     public function updateStatus(int $id, string $status): void
     {
         $this->query->execute(
-            'UPDATE users SET status = ?, updated_at = NOW() WHERE id = ?',
-            [$status, $id],
+            'UPDATE users SET status = ?, updated_at = ? WHERE id = ?',
+            [$status, date('Y-m-d H:i:s'), $id],
+        );
+    }
+
+    public function updateRole(int $id, string $role): void
+    {
+        $this->query->execute(
+            'UPDATE users SET role = ?, updated_at = ? WHERE id = ?',
+            [$role, date('Y-m-d H:i:s'), $id],
+        );
+    }
+
+    public function updateEmail(int $id, string $email): void
+    {
+        $this->query->execute(
+            'UPDATE users SET email = ?, updated_at = ? WHERE id = ?',
+            [$email, date('Y-m-d H:i:s'), $id],
         );
     }
 

--- a/src/Auth/UserRepositoryInterface.php
+++ b/src/Auth/UserRepositoryInterface.php
@@ -19,6 +19,10 @@ interface UserRepositoryInterface
 
     public function updateStatus(int $id, string $status): void;
 
+    public function updateRole(int $id, string $role): void;
+
+    public function updateEmail(int $id, string $email): void;
+
     public function storeInviteToken(int $id, string $tokenHash, int $expiresAt): void;
 
     public function findByInviteToken(string $tokenHash): ?User;

--- a/src/User/CannotDeleteSelfException.php
+++ b/src/User/CannotDeleteSelfException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\User;
+
+use RuntimeException;
+
+final class CannotDeleteSelfException extends RuntimeException
+{
+    public function __construct()
+    {
+        parent::__construct('You cannot delete your own account.');
+    }
+}

--- a/src/User/CannotDeleteSelfExceptionHandler.php
+++ b/src/User/CannotDeleteSelfExceptionHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\User;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class CannotDeleteSelfExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $e): bool
+    {
+        return $e instanceof CannotDeleteSelfException;
+    }
+
+    public function handle(Throwable $e, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'cannot-delete-self', 'Cannot Delete Self', 409, $e->getMessage());
+    }
+}

--- a/src/User/CreateUserHandler.php
+++ b/src/User/CreateUserHandler.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\User;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class CreateUserHandler
+{
+    public function __construct(
+        private CreateUserUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $orgId = $request->getAttribute('nene2.org.id');
+        assert(is_int($orgId));
+
+        $claims = $request->getAttribute('nene2.auth.claims');
+        $actorUserId = is_array($claims) && isset($claims['user_id']) ? (int) $claims['user_id'] : null;
+
+        $body = JsonRequestBodyParser::parse($request);
+        $errors = [];
+
+        $email = isset($body['email']) && is_string($body['email']) ? trim($body['email']) : '';
+        $password = isset($body['password']) && is_string($body['password']) ? $body['password'] : '';
+        $role = isset($body['role']) && is_string($body['role']) ? $body['role'] : '';
+
+        if ($email === '' || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            $errors[] = new ValidationError('email', 'A valid email is required.', 'invalid_email');
+        }
+
+        if (strlen($password) < 8) {
+            $errors[] = new ValidationError('password', 'Password must be at least 8 characters.', 'too_small');
+        }
+
+        if ($role === '') {
+            $errors[] = new ValidationError('role', 'Role is required.', 'required');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        $user = $this->useCase->execute($email, $password, $role, $orgId, $actorUserId);
+
+        return $this->response->create(UserPresenter::present($user), 201);
+    }
+}

--- a/src/User/CreateUserUseCase.php
+++ b/src/User/CreateUserUseCase.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\User;
+
+use NeneVault\Audit\AuditAction;
+use NeneVault\Audit\AuditRecorderInterface;
+use NeneVault\Auth\Role;
+use NeneVault\Auth\User;
+use NeneVault\Auth\UserRepositoryInterface;
+
+final readonly class CreateUserUseCase implements CreateUserUseCaseInterface
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+        private AuditRecorderInterface $audit,
+    ) {
+    }
+
+    public function execute(
+        string $email,
+        string $password,
+        string $role,
+        int $organizationId,
+        ?int $actorUserId,
+    ): User {
+        $roleEnum = Role::tryFrom($role);
+
+        // superadmin cannot be created via the org user API (platform-level only)
+        if ($roleEnum === null || $roleEnum === Role::Superadmin) {
+            throw new InvalidUserRoleException($role);
+        }
+
+        if ($this->users->findByEmail($email) !== null) {
+            throw new UserEmailConflictException($email);
+        }
+
+        $passwordHash = password_hash($password, PASSWORD_BCRYPT);
+        $user = $this->users->create($email, $passwordHash, $role, $organizationId);
+
+        $this->audit->record(
+            action: AuditAction::USER_CREATED,
+            entityType: 'user',
+            entityId: (string) $user->id,
+            actorUserId: $actorUserId,
+            organizationId: $organizationId,
+            beforeJson: null,
+            afterJson: UserPresenter::present($user),
+        );
+
+        return $user;
+    }
+}

--- a/src/User/CreateUserUseCaseInterface.php
+++ b/src/User/CreateUserUseCaseInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\User;
+
+use NeneVault\Auth\User;
+
+interface CreateUserUseCaseInterface
+{
+    /**
+     * @throws InvalidUserRoleException
+     * @throws UserEmailConflictException
+     */
+    public function execute(
+        string $email,
+        string $password,
+        string $role,
+        int $organizationId,
+        ?int $actorUserId,
+    ): User;
+}

--- a/src/User/DeleteUserHandler.php
+++ b/src/User/DeleteUserHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\User;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class DeleteUserHandler
+{
+    public function __construct(
+        private DeleteUserUseCaseInterface $useCase,
+        private ResponseFactoryInterface $responseFactory,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $orgId = $request->getAttribute('nene2.org.id');
+        assert(is_int($orgId));
+
+        $claims = $request->getAttribute('nene2.auth.claims');
+        $actorUserId = is_array($claims) && isset($claims['user_id']) ? (int) $claims['user_id'] : null;
+
+        $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($params['id'] ?? 0);
+
+        $this->useCase->execute($id, $orgId, $actorUserId);
+
+        return $this->responseFactory->createResponse(204);
+    }
+}

--- a/src/User/DeleteUserUseCase.php
+++ b/src/User/DeleteUserUseCase.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\User;
+
+use NeneVault\Audit\AuditAction;
+use NeneVault\Audit\AuditRecorderInterface;
+use NeneVault\Auth\UserRepositoryInterface;
+
+final readonly class DeleteUserUseCase implements DeleteUserUseCaseInterface
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+        private AuditRecorderInterface $audit,
+    ) {
+    }
+
+    public function execute(int $id, int $organizationId, ?int $actorUserId): void
+    {
+        if ($actorUserId !== null && $actorUserId === $id) {
+            throw new CannotDeleteSelfException();
+        }
+
+        $user = $this->users->findById($id);
+
+        if ($user === null || $user->organizationId !== $organizationId) {
+            throw new UserNotFoundException($id);
+        }
+
+        $before = UserPresenter::present($user);
+
+        $this->users->delete($id);
+
+        $this->audit->record(
+            action: AuditAction::USER_DELETED,
+            entityType: 'user',
+            entityId: (string) $id,
+            actorUserId: $actorUserId,
+            organizationId: $organizationId,
+            beforeJson: $before,
+            afterJson: null,
+        );
+    }
+}

--- a/src/User/DeleteUserUseCaseInterface.php
+++ b/src/User/DeleteUserUseCaseInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\User;
+
+interface DeleteUserUseCaseInterface
+{
+    /**
+     * @throws UserNotFoundException
+     * @throws CannotDeleteSelfException
+     */
+    public function execute(int $id, int $organizationId, ?int $actorUserId): void;
+}

--- a/src/User/GetUserByIdHandler.php
+++ b/src/User/GetUserByIdHandler.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\User;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use NeneVault\Auth\UserRepositoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class GetUserByIdHandler
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $orgId = $request->getAttribute('nene2.org.id');
+        assert(is_int($orgId));
+
+        $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($params['id'] ?? 0);
+
+        $user = $this->users->findById($id);
+
+        if ($user === null || $user->organizationId !== $orgId) {
+            throw new UserNotFoundException($id);
+        }
+
+        return $this->response->create(UserPresenter::present($user));
+    }
+}

--- a/src/User/InvalidUserRoleException.php
+++ b/src/User/InvalidUserRoleException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\User;
+
+use RuntimeException;
+
+final class InvalidUserRoleException extends RuntimeException
+{
+    public function __construct(string $role)
+    {
+        parent::__construct("Role '{$role}' cannot be assigned via the organization user API.");
+    }
+}

--- a/src/User/InvalidUserRoleExceptionHandler.php
+++ b/src/User/InvalidUserRoleExceptionHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\User;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class InvalidUserRoleExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $e): bool
+    {
+        return $e instanceof InvalidUserRoleException;
+    }
+
+    public function handle(Throwable $e, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'invalid-user-role', 'Invalid User Role', 422, $e->getMessage());
+    }
+}

--- a/src/User/ListUsersHandler.php
+++ b/src/User/ListUsersHandler.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\User;
+
+use Nene2\Http\JsonResponseFactory;
+use NeneVault\Auth\User;
+use NeneVault\Auth\UserRepositoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ListUsersHandler
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $orgId = $request->getAttribute('nene2.org.id');
+        assert(is_int($orgId));
+
+        $params = $request->getQueryParams();
+        $limit = min(100, max(1, (int) ($params['limit'] ?? 20)));
+        $offset = max(0, (int) ($params['offset'] ?? 0));
+
+        $all = $this->users->listByOrganizationId($orgId);
+        $total = count($all);
+        $page = array_slice($all, $offset, $limit);
+
+        return $this->response->create([
+            'items'  => array_map(static fn (User $u) => UserPresenter::present($u), $page),
+            'total'  => $total,
+            'limit'  => $limit,
+            'offset' => $offset,
+        ]);
+    }
+}

--- a/src/User/UpdateUserHandler.php
+++ b/src/User/UpdateUserHandler.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\User;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class UpdateUserHandler
+{
+    /** @var list<string> */
+    private const VALID_STATUSES = ['active', 'invited'];
+
+    public function __construct(
+        private UpdateUserUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $orgId = $request->getAttribute('nene2.org.id');
+        assert(is_int($orgId));
+
+        $claims = $request->getAttribute('nene2.auth.claims');
+        $actorUserId = is_array($claims) && isset($claims['user_id']) ? (int) $claims['user_id'] : null;
+
+        $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($params['id'] ?? 0);
+
+        $body = JsonRequestBodyParser::parse($request);
+
+        $email = isset($body['email']) && is_string($body['email']) && $body['email'] !== '' ? trim($body['email']) : null;
+        if ($email !== null && !filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            throw new ValidationException([new ValidationError('email', 'A valid email is required.', 'invalid_email')]);
+        }
+
+        $role = isset($body['role']) && is_string($body['role']) && $body['role'] !== '' ? $body['role'] : null;
+
+        $status = isset($body['status']) && is_string($body['status']) && $body['status'] !== '' ? $body['status'] : null;
+        if ($status !== null && !in_array($status, self::VALID_STATUSES, true)) {
+            throw new ValidationException([new ValidationError('status', 'Invalid status.', 'invalid_format')]);
+        }
+
+        $user = $this->useCase->execute($id, $orgId, $email, $role, $status, $actorUserId);
+
+        return $this->response->create(UserPresenter::present($user));
+    }
+}

--- a/src/User/UpdateUserUseCase.php
+++ b/src/User/UpdateUserUseCase.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\User;
+
+use NeneVault\Audit\AuditAction;
+use NeneVault\Audit\AuditRecorderInterface;
+use NeneVault\Auth\Role;
+use NeneVault\Auth\User;
+use NeneVault\Auth\UserRepositoryInterface;
+
+final readonly class UpdateUserUseCase implements UpdateUserUseCaseInterface
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+        private AuditRecorderInterface $audit,
+    ) {
+    }
+
+    public function execute(
+        int $id,
+        int $organizationId,
+        ?string $email,
+        ?string $role,
+        ?string $status,
+        ?int $actorUserId,
+    ): User {
+        $user = $this->users->findById($id);
+
+        // Org-scoped: only users in the resolved organization are visible
+        if ($user === null || $user->organizationId !== $organizationId) {
+            throw new UserNotFoundException($id);
+        }
+
+        $before = UserPresenter::present($user);
+
+        if ($role !== null) {
+            $roleEnum = Role::tryFrom($role);
+
+            if ($roleEnum === null || $roleEnum === Role::Superadmin) {
+                throw new InvalidUserRoleException($role);
+            }
+
+            $this->users->updateRole($id, $role);
+        }
+
+        if ($email !== null && $email !== $user->email) {
+            $existing = $this->users->findByEmail($email);
+
+            if ($existing !== null && $existing->id !== $id) {
+                throw new UserEmailConflictException($email);
+            }
+
+            $this->users->updateEmail($id, $email);
+        }
+
+        if ($status !== null) {
+            $this->users->updateStatus($id, $status);
+        }
+
+        $updated = $this->users->findById($id);
+        assert($updated !== null);
+
+        $this->audit->record(
+            action: AuditAction::USER_UPDATED,
+            entityType: 'user',
+            entityId: (string) $id,
+            actorUserId: $actorUserId,
+            organizationId: $organizationId,
+            beforeJson: $before,
+            afterJson: UserPresenter::present($updated),
+        );
+
+        return $updated;
+    }
+}

--- a/src/User/UpdateUserUseCaseInterface.php
+++ b/src/User/UpdateUserUseCaseInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\User;
+
+use NeneVault\Auth\User;
+
+interface UpdateUserUseCaseInterface
+{
+    /**
+     * @throws UserNotFoundException
+     * @throws InvalidUserRoleException
+     * @throws UserEmailConflictException
+     */
+    public function execute(
+        int $id,
+        int $organizationId,
+        ?string $email,
+        ?string $role,
+        ?string $status,
+        ?int $actorUserId,
+    ): User;
+}

--- a/src/User/UserEmailConflictException.php
+++ b/src/User/UserEmailConflictException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\User;
+
+use RuntimeException;
+
+final class UserEmailConflictException extends RuntimeException
+{
+    public function __construct(string $email)
+    {
+        parent::__construct("A user with email '{$email}' already exists.");
+    }
+}

--- a/src/User/UserEmailConflictExceptionHandler.php
+++ b/src/User/UserEmailConflictExceptionHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\User;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class UserEmailConflictExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $e): bool
+    {
+        return $e instanceof UserEmailConflictException;
+    }
+
+    public function handle(Throwable $e, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'user-email-conflict', 'User Email Conflict', 409, $e->getMessage());
+    }
+}

--- a/src/User/UserNotFoundException.php
+++ b/src/User/UserNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\User;
+
+use RuntimeException;
+
+final class UserNotFoundException extends RuntimeException
+{
+    public function __construct(int $id)
+    {
+        parent::__construct("User with id {$id} was not found.");
+    }
+}

--- a/src/User/UserNotFoundExceptionHandler.php
+++ b/src/User/UserNotFoundExceptionHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\User;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class UserNotFoundExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $e): bool
+    {
+        return $e instanceof UserNotFoundException;
+    }
+
+    public function handle(Throwable $e, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'user-not-found', 'User Not Found', 404, $e->getMessage());
+    }
+}

--- a/src/User/UserPresenter.php
+++ b/src/User/UserPresenter.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\User;
+
+use NeneVault\Auth\User;
+
+/**
+ * Builds the public UserResponse shape. The password_hash and any token hashes
+ * are never included (also keeps them out of audit snapshots).
+ */
+final class UserPresenter
+{
+    /** @return array<string, mixed> */
+    public static function present(User $user): array
+    {
+        return [
+            'id'              => $user->id,
+            'email'           => $user->email,
+            'role'            => $user->role,
+            'organization_id' => $user->organizationId,
+            'status'          => $user->status,
+            'created_at'      => $user->createdAt,
+            'updated_at'      => $user->updatedAt,
+        ];
+    }
+}

--- a/src/User/UserRouteRegistrar.php
+++ b/src/User/UserRouteRegistrar.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\User;
+
+use Nene2\Routing\Router;
+
+final readonly class UserRouteRegistrar
+{
+    public function __construct(
+        private ListUsersHandler $list,
+        private GetUserByIdHandler $get,
+        private CreateUserHandler $create,
+        private UpdateUserHandler $update,
+        private DeleteUserHandler $delete,
+    ) {
+    }
+
+    public function register(Router $router): void
+    {
+        $router->get('/admin/users', $this->list->handle(...));
+        $router->get('/admin/users/{id}', $this->get->handle(...));
+        $router->post('/admin/users', $this->create->handle(...));
+        $router->patch('/admin/users/{id}', $this->update->handle(...));
+        $router->delete('/admin/users/{id}', $this->delete->handle(...));
+    }
+}

--- a/src/User/UserServiceProvider.php
+++ b/src/User/UserServiceProvider.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\User;
+
+use LogicException;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use NeneVault\Audit\AuditRecorderInterface;
+use NeneVault\Auth\UserRepositoryInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+
+final readonly class UserServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                CreateUserUseCaseInterface::class,
+                static fn (ContainerInterface $c): CreateUserUseCaseInterface
+                    => new CreateUserUseCase(self::users($c), self::audit($c)),
+            )
+            ->set(
+                UpdateUserUseCaseInterface::class,
+                static fn (ContainerInterface $c): UpdateUserUseCaseInterface
+                    => new UpdateUserUseCase(self::users($c), self::audit($c)),
+            )
+            ->set(
+                DeleteUserUseCaseInterface::class,
+                static fn (ContainerInterface $c): DeleteUserUseCaseInterface
+                    => new DeleteUserUseCase(self::users($c), self::audit($c)),
+            )
+            ->set(
+                ListUsersHandler::class,
+                static fn (ContainerInterface $c): ListUsersHandler
+                    => new ListUsersHandler(self::users($c), self::json($c)),
+            )
+            ->set(
+                GetUserByIdHandler::class,
+                static fn (ContainerInterface $c): GetUserByIdHandler
+                    => new GetUserByIdHandler(self::users($c), self::json($c)),
+            )
+            ->set(
+                CreateUserHandler::class,
+                static function (ContainerInterface $c): CreateUserHandler {
+                    $uc = $c->get(CreateUserUseCaseInterface::class);
+
+                    if (!$uc instanceof CreateUserUseCaseInterface) {
+                        throw new LogicException('CreateUserUseCaseInterface service is invalid.');
+                    }
+
+                    return new CreateUserHandler($uc, self::json($c));
+                },
+            )
+            ->set(
+                UpdateUserHandler::class,
+                static function (ContainerInterface $c): UpdateUserHandler {
+                    $uc = $c->get(UpdateUserUseCaseInterface::class);
+
+                    if (!$uc instanceof UpdateUserUseCaseInterface) {
+                        throw new LogicException('UpdateUserUseCaseInterface service is invalid.');
+                    }
+
+                    return new UpdateUserHandler($uc, self::json($c));
+                },
+            )
+            ->set(
+                DeleteUserHandler::class,
+                static function (ContainerInterface $c): DeleteUserHandler {
+                    $uc = $c->get(DeleteUserUseCaseInterface::class);
+                    $rf = $c->get(ResponseFactoryInterface::class);
+
+                    if (!$uc instanceof DeleteUserUseCaseInterface) {
+                        throw new LogicException('DeleteUserUseCaseInterface service is invalid.');
+                    }
+
+                    if (!$rf instanceof ResponseFactoryInterface) {
+                        throw new LogicException('ResponseFactoryInterface service is invalid.');
+                    }
+
+                    return new DeleteUserHandler($uc, $rf);
+                },
+            )
+            ->set(
+                UserRouteRegistrar::class,
+                static function (ContainerInterface $c): UserRouteRegistrar {
+                    return new UserRouteRegistrar(
+                        self::handler($c, ListUsersHandler::class),
+                        self::handler($c, GetUserByIdHandler::class),
+                        self::handler($c, CreateUserHandler::class),
+                        self::handler($c, UpdateUserHandler::class),
+                        self::handler($c, DeleteUserHandler::class),
+                    );
+                },
+            )
+            ->set(
+                UserNotFoundExceptionHandler::class,
+                static fn (ContainerInterface $c): UserNotFoundExceptionHandler
+                    => new UserNotFoundExceptionHandler(self::pd($c)),
+            )
+            ->set(
+                UserEmailConflictExceptionHandler::class,
+                static fn (ContainerInterface $c): UserEmailConflictExceptionHandler
+                    => new UserEmailConflictExceptionHandler(self::pd($c)),
+            )
+            ->set(
+                InvalidUserRoleExceptionHandler::class,
+                static fn (ContainerInterface $c): InvalidUserRoleExceptionHandler
+                    => new InvalidUserRoleExceptionHandler(self::pd($c)),
+            )
+            ->set(
+                CannotDeleteSelfExceptionHandler::class,
+                static fn (ContainerInterface $c): CannotDeleteSelfExceptionHandler
+                    => new CannotDeleteSelfExceptionHandler(self::pd($c)),
+            );
+    }
+
+    private static function users(ContainerInterface $c): UserRepositoryInterface
+    {
+        $r = $c->get(UserRepositoryInterface::class);
+
+        if (!$r instanceof UserRepositoryInterface) {
+            throw new LogicException('UserRepositoryInterface service is invalid.');
+        }
+
+        return $r;
+    }
+
+    private static function audit(ContainerInterface $c): AuditRecorderInterface
+    {
+        $a = $c->get(AuditRecorderInterface::class);
+
+        if (!$a instanceof AuditRecorderInterface) {
+            throw new LogicException('AuditRecorderInterface service is invalid.');
+        }
+
+        return $a;
+    }
+
+    private static function json(ContainerInterface $c): JsonResponseFactory
+    {
+        $j = $c->get(JsonResponseFactory::class);
+
+        if (!$j instanceof JsonResponseFactory) {
+            throw new LogicException('JsonResponseFactory service is invalid.');
+        }
+
+        return $j;
+    }
+
+    private static function pd(ContainerInterface $c): ProblemDetailsResponseFactory
+    {
+        $p = $c->get(ProblemDetailsResponseFactory::class);
+
+        if (!$p instanceof ProblemDetailsResponseFactory) {
+            throw new LogicException('ProblemDetailsResponseFactory service is invalid.');
+        }
+
+        return $p;
+    }
+
+    /**
+     * @template T of object
+     * @param class-string<T> $class
+     * @return T
+     */
+    private static function handler(ContainerInterface $c, string $class): object
+    {
+        $h = $c->get($class);
+
+        if (!$h instanceof $class) {
+            throw new LogicException($class . ' service is invalid.');
+        }
+
+        return $h;
+    }
+}

--- a/tests/Auth/LoginUseCaseTest.php
+++ b/tests/Auth/LoginUseCaseTest.php
@@ -118,6 +118,12 @@ final class LoginUseCaseTest extends TestCase
             public function updateStatus(int $id, string $status): void
             {
             }
+            public function updateRole(int $id, string $role): void
+            {
+            }
+            public function updateEmail(int $id, string $email): void
+            {
+            }
             public function storeInviteToken(int $id, string $tokenHash, int $expiresAt): void
             {
             }

--- a/tests/User/UserApiTest.php
+++ b/tests/User/UserApiTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Tests\User;
+
+use Nene2\Auth\TokenIssuerInterface;
+use Nene2\Database\DatabaseConnectionFactoryInterface;
+use NeneVault\Http\RuntimeContainerFactory;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Nyholm\Psr7Server\ServerRequestCreator;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class UserApiTest extends TestCase
+{
+    private static ?ContainerInterface $container = null;
+    private static int $orgId = 0;
+    private static string $token = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$container = (new RuntimeContainerFactory(dirname(__DIR__, 2)))->create();
+
+        $conn = self::$container->get(DatabaseConnectionFactoryInterface::class);
+        assert($conn instanceof DatabaseConnectionFactoryInterface);
+        $pdo = $conn->create();
+
+        $pdo->exec("INSERT OR IGNORE INTO organizations
+            (name, slug, plan, is_active, created_at, updated_at)
+            VALUES ('Test Org', 'test-org', 'free', 1, datetime('now'), datetime('now'))");
+        $stmt = $pdo->query("SELECT id FROM organizations WHERE slug = 'test-org'");
+        assert($stmt !== false);
+        self::$orgId = (int) $stmt->fetch()['id'];
+
+        $issuer = self::$container->get(TokenIssuerInterface::class);
+        assert($issuer instanceof TokenIssuerInterface);
+        self::$token = $issuer->issue([
+            'sub' => 'admin@example.com',
+            'user_id' => 1000,
+            'role' => 'admin',
+            'org_id' => self::$orgId,
+            'iat' => time(),
+            'exp' => time() + 3600,
+        ]);
+    }
+
+    public function test_create_list_update_delete_user(): void
+    {
+        $handler = $this->handler();
+        $email = 'member-' . uniqid() . '@example.com';
+
+        // Create
+        $create = $handler->handle($this->request('POST', '/admin/users', json: [
+            'email' => $email,
+            'password' => 'changeme123',
+            'role' => 'member',
+        ]));
+        $this->assertSame(201, $create->getStatusCode(), (string) $create->getBody());
+        $created = json_decode((string) $create->getBody(), true);
+        $this->assertSame($email, $created['email']);
+        $this->assertSame('member', $created['role']);
+        $this->assertSame(self::$orgId, $created['organization_id']);
+        $this->assertArrayNotHasKey('password_hash', $created);
+        $userId = $created['id'];
+
+        // List — created user present
+        $list = $handler->handle($this->request('GET', '/admin/users'));
+        $this->assertSame(200, $list->getStatusCode());
+        $listBody = json_decode((string) $list->getBody(), true);
+        $this->assertContains($userId, array_column($listBody['items'], 'id'));
+
+        // Update — change role to viewer
+        $update = $handler->handle($this->request('PATCH', '/admin/users/' . $userId, json: ['role' => 'viewer']));
+        $this->assertSame(200, $update->getStatusCode(), (string) $update->getBody());
+        $this->assertSame('viewer', json_decode((string) $update->getBody(), true)['role']);
+
+        // Delete
+        $delete = $handler->handle($this->request('DELETE', '/admin/users/' . $userId));
+        $this->assertSame(204, $delete->getStatusCode());
+
+        // Get after delete → 404
+        $get = $handler->handle($this->request('GET', '/admin/users/' . $userId));
+        $this->assertSame(404, $get->getStatusCode());
+    }
+
+    public function test_create_rejects_superadmin_role(): void
+    {
+        $response = $this->handler()->handle($this->request('POST', '/admin/users', json: [
+            'email' => 'super-' . uniqid() . '@example.com',
+            'password' => 'changeme123',
+            'role' => 'superadmin',
+        ]));
+
+        $this->assertSame(422, $response->getStatusCode());
+    }
+
+    public function test_create_rejects_duplicate_email(): void
+    {
+        $handler = $this->handler();
+        $email = 'dup-' . uniqid() . '@example.com';
+        $payload = ['email' => $email, 'password' => 'changeme123', 'role' => 'member'];
+
+        $handler->handle($this->request('POST', '/admin/users', json: $payload));
+        $second = $handler->handle($this->request('POST', '/admin/users', json: $payload));
+
+        $this->assertSame(409, $second->getStatusCode());
+    }
+
+    public function test_cannot_delete_self(): void
+    {
+        $handler = $this->handler();
+        $container = self::$container;
+        assert($container !== null);
+        $conn = $container->get(DatabaseConnectionFactoryInterface::class);
+        assert($conn instanceof DatabaseConnectionFactoryInterface);
+        $pdo = $conn->create();
+        $pdo->exec("INSERT INTO users (id, email, password_hash, role, organization_id, status, created_at, updated_at)
+            VALUES (1000, 'self@example.com', 'x', 'admin', " . self::$orgId . ", 'active', datetime('now'), datetime('now'))");
+
+        // JWT user_id is 1000 — deleting id 1000 is self
+        $response = $handler->handle($this->request('DELETE', '/admin/users/1000'));
+
+        $this->assertSame(409, $response->getStatusCode());
+    }
+
+    public function test_unauthenticated_returns_401(): void
+    {
+        $response = $this->handler()->handle($this->request('GET', '/admin/users', auth: false));
+        $this->assertSame(401, $response->getStatusCode());
+    }
+
+    // ── helpers ──
+
+    private function handler(): RequestHandlerInterface
+    {
+        $container = self::$container;
+        assert($container !== null);
+        $h = $container->get(RequestHandlerInterface::class);
+        assert($h instanceof RequestHandlerInterface);
+
+        return $h;
+    }
+
+    /** @param array<string, mixed>|null $json */
+    private function request(string $method, string $uri, bool $auth = true, ?array $json = null): ServerRequestInterface
+    {
+        $container = self::$container;
+        assert($container !== null);
+        $psr17 = $container->get(Psr17Factory::class);
+        assert($psr17 instanceof Psr17Factory);
+
+        $creator = new ServerRequestCreator($psr17, $psr17, $psr17, $psr17);
+
+        $headers = ['Host' => 'localhost'];
+        if ($auth) {
+            $headers['Authorization'] = 'Bearer ' . self::$token;
+        }
+
+        $queryParams = [];
+        $queryString = parse_url($uri, PHP_URL_QUERY);
+        if (is_string($queryString)) {
+            parse_str($queryString, $queryParams);
+        }
+
+        $body = null;
+        if ($json !== null) {
+            $headers['Content-Type'] = 'application/json';
+            $body = $psr17->createStream(json_encode($json, JSON_THROW_ON_ERROR));
+        }
+
+        return $creator->fromArrays(
+            server: ['REQUEST_METHOD' => $method, 'REQUEST_URI' => $uri],
+            headers: $headers,
+            get: $queryParams,
+            body: $body,
+        );
+    }
+}


### PR DESCRIPTION
## Summary

OpenAPI 契約の User CRUD を実装。Organization モジュールと同パターン。admin 限定。
各 mutation は監査記録（password_hash は含めない）。

## エンドポイント
| Method | Path | 不変条件 |
|---|---|---|
| POST | /admin/users | superadmin ロール拒否(422)、email衝突(409)、bcrypt ハッシュ |
| GET | /admin/users | org スコープ、ページネーション |
| GET | /admin/users/{id} | org スコープ、404 |
| PATCH | /admin/users/{id} | email/role/status、superadmin拒否、email衝突 |
| DELETE | /admin/users/{id} | 自己削除拒否(409)、org スコープ |

## コンプライアンス
- 監査: user.created/updated/deleted（before/after、password_hash 非含有）
- org スコープ: 別組織のユーザーは不可視
- UserPresenter が password_hash・トークンハッシュを除外

## テスト
- create→list→update→delete サイクル、superadmin拒否、email重複、自己削除拒否、未認証401

## composer check
PHPUnit / PHPStan 8 (157 files) / CS / locales 344 / OpenAPI valid — all green

Self-review: backend-api, database, middleware-security

Closes #23