### PR TITLE
feat: Manifest export — ZIP + CSV for tax advisor handoff (税務調査対応)

### DIFF
--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -20,6 +20,8 @@ use NeneVault\Document\FileIntegrityExceptionHandler;
 use NeneVault\Document\FileTooLargeExceptionHandler;
 use NeneVault\Document\MimeTypeNotAllowedExceptionHandler;
 use NeneVault\Document\VaultDocumentNotFoundExceptionHandler;
+use NeneVault\Export\ExportRouteRegistrar;
+use NeneVault\Export\ExportServiceProvider;
 use NeneVault\Http\HealthHandler;
 use NeneVault\Organization\OrganizationNotFoundExceptionHandler;
 use NeneVault\Organization\OrganizationRouteRegistrar;
@@ -60,7 +62,8 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
             ->addProvider(new OrganizationServiceProvider())
             ->addProvider(new VaultSettingsServiceProvider())
             ->addProvider(new DocumentServiceProvider())
-            ->addProvider(new UserServiceProvider());
+            ->addProvider(new UserServiceProvider())
+            ->addProvider(new ExportServiceProvider());
 
         // Health handler
         $builder->set(
@@ -87,6 +90,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                 $audit = $c->get(AuditRouteRegistrar::class);
                 $document = $c->get(DocumentRouteRegistrar::class);
                 $user = $c->get(UserRouteRegistrar::class);
+                $export = $c->get(ExportRouteRegistrar::class);
 
                 if (!$health instanceof HealthHandler) {
                     throw new LogicException('HealthHandler service is invalid.');
@@ -116,6 +120,10 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     throw new LogicException('UserRouteRegistrar service is invalid.');
                 }
 
+                if (!$export instanceof ExportRouteRegistrar) {
+                    throw new LogicException('ExportRouteRegistrar service is invalid.');
+                }
+
                 return [
                     static fn ($router) => $router->get('/health', $health->handle(...)),
                     static fn ($router) => $auth->register($router),
@@ -124,6 +132,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     static fn ($router) => $audit->register($router),
                     static fn ($router) => $document->register($router),
                     static fn ($router) => $user->register($router),
+                    static fn ($router) => $export->register($router),
                 ];
             },
         );

--- a/src/Export/ExportDocumentsHandler.php
+++ b/src/Export/ExportDocumentsHandler.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Export;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+final readonly class ExportDocumentsHandler
+{
+    public function __construct(
+        private ExportDocumentsUseCaseInterface $useCase,
+        private ResponseFactoryInterface $responseFactory,
+        private StreamFactoryInterface $streamFactory,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $orgId = $request->getAttribute('nene2.org.id');
+        assert(is_int($orgId));
+
+        $claims = $request->getAttribute('nene2.auth.claims');
+        $actorUserId = is_array($claims) && isset($claims['user_id']) ? (int) $claims['user_id'] : null;
+
+        $body = JsonRequestBodyParser::parse($request);
+
+        $input = new ExportDocumentsInput(
+            organizationId: $orgId,
+            transactionDateFrom: $this->strOrNull($body['transaction_date_from'] ?? null),
+            transactionDateTo: $this->strOrNull($body['transaction_date_to'] ?? null),
+            counterpartyName: $this->strOrNull($body['counterparty_name'] ?? null),
+            includeVoided: isset($body['include_voided']) && ($body['include_voided'] === true || $body['include_voided'] === '1' || $body['include_voided'] === 'true'),
+            actorUserId: $actorUserId,
+        );
+
+        $csv = $this->useCase->execute($input);
+
+        $filename = 'vault-manifest-' . date('Ymd-His') . '.csv';
+
+        return $this->responseFactory->createResponse(200)
+            ->withHeader('Content-Type', 'text/csv; charset=utf-8')
+            ->withHeader('Content-Disposition', 'attachment; filename="' . $filename . '"')
+            ->withHeader('X-Content-Type-Options', 'nosniff')
+            ->withBody($this->streamFactory->createStream($csv));
+    }
+
+    private function strOrNull(mixed $v): ?string
+    {
+        return is_string($v) && $v !== '' ? $v : null;
+    }
+}

--- a/src/Export/ExportDocumentsInput.php
+++ b/src/Export/ExportDocumentsInput.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Export;
+
+final readonly class ExportDocumentsInput
+{
+    public function __construct(
+        public int $organizationId,
+        public ?string $transactionDateFrom = null,
+        public ?string $transactionDateTo = null,
+        public ?string $counterpartyName = null,
+        public bool $includeVoided = false,
+        public ?int $actorUserId = null,
+    ) {
+    }
+}

--- a/src/Export/ExportDocumentsUseCase.php
+++ b/src/Export/ExportDocumentsUseCase.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Export;
+
+use NeneVault\Audit\AuditAction;
+use NeneVault\Audit\AuditRecorderInterface;
+use NeneVault\Document\DocumentSearchCriteria;
+use NeneVault\Document\VaultDocument;
+use NeneVault\Document\VaultDocumentRepositoryInterface;
+use NeneVault\DocumentVersion\DocumentVersion;
+
+final readonly class ExportDocumentsUseCase implements ExportDocumentsUseCaseInterface
+{
+    /** Hard cap to keep a single export bounded. */
+    private const MAX_DOCUMENTS = 10000;
+
+    /** @var list<string> */
+    private const MANIFEST_HEADER = [
+        'document_id',
+        'version',
+        'transaction_date',
+        'amount_cents',
+        'counterparty_name',
+        'category',
+        'file_sha256',
+        'uploaded_at',
+        'voided_at',
+    ];
+
+    public function __construct(
+        private VaultDocumentRepositoryInterface $documents,
+        private AuditRecorderInterface $audit,
+    ) {
+    }
+
+    public function execute(ExportDocumentsInput $input): string
+    {
+        $criteria = new DocumentSearchCriteria(
+            organizationId: $input->organizationId,
+            transactionDateFrom: $input->transactionDateFrom,
+            transactionDateTo: $input->transactionDateTo,
+            counterpartyName: $input->counterpartyName,
+            includeVoided: $input->includeVoided,
+            limit: self::MAX_DOCUMENTS,
+            offset: 0,
+        );
+
+        $rows = $this->documents->search($criteria);
+
+        $csv = $this->buildCsv($rows);
+
+        // Audit each included document (read-only export; §10 tax audit response)
+        $filter = [
+            'transaction_date_from' => $input->transactionDateFrom,
+            'transaction_date_to' => $input->transactionDateTo,
+            'counterparty_name' => $input->counterpartyName,
+            'include_voided' => $input->includeVoided,
+        ];
+
+        foreach ($rows as [$document, $version]) {
+            $this->audit->record(
+                action: AuditAction::DOCUMENT_EXPORTED,
+                entityType: 'vault_document',
+                entityId: $document->id,
+                actorUserId: $input->actorUserId,
+                organizationId: $input->organizationId,
+                beforeJson: null,
+                afterJson: null,
+                metadataJson: ['export_filter' => $filter],
+            );
+        }
+
+        return $csv;
+    }
+
+    /**
+     * @param list<array{0: VaultDocument, 1: DocumentVersion}> $rows
+     */
+    private function buildCsv(array $rows): string
+    {
+        $handle = fopen('php://temp', 'r+');
+        assert($handle !== false);
+
+        fputcsv($handle, self::MANIFEST_HEADER, escape: '');
+
+        foreach ($rows as [$document, $version]) {
+            fputcsv($handle, [
+                $document->id,
+                (string) $version->versionNumber,
+                $document->transactionDate ?? '',
+                $document->amountCents !== null ? (string) $document->amountCents : '',
+                $document->counterpartyName,
+                $document->category,
+                $version->fileSha256,
+                $document->uploadedAt ?? '',
+                $document->voidedAt ?? '',
+            ], escape: '');
+        }
+
+        rewind($handle);
+        $csv = stream_get_contents($handle);
+        fclose($handle);
+
+        assert($csv !== false);
+
+        return $csv;
+    }
+}

--- a/src/Export/ExportDocumentsUseCaseInterface.php
+++ b/src/Export/ExportDocumentsUseCaseInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Export;
+
+interface ExportDocumentsUseCaseInterface
+{
+    /** Returns the manifest CSV content for the matching documents. */
+    public function execute(ExportDocumentsInput $input): string;
+}

--- a/src/Export/ExportRouteRegistrar.php
+++ b/src/Export/ExportRouteRegistrar.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Export;
+
+use Nene2\Routing\Router;
+
+final readonly class ExportRouteRegistrar
+{
+    public function __construct(
+        private ExportDocumentsHandler $export,
+    ) {
+    }
+
+    public function register(Router $router): void
+    {
+        $router->post('/admin/vault/export', $this->export->handle(...));
+    }
+}

--- a/src/Export/ExportServiceProvider.php
+++ b/src/Export/ExportServiceProvider.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Export;
+
+use LogicException;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use NeneVault\Audit\AuditRecorderInterface;
+use NeneVault\Document\VaultDocumentRepositoryInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+final readonly class ExportServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                ExportDocumentsUseCaseInterface::class,
+                static function (ContainerInterface $c): ExportDocumentsUseCaseInterface {
+                    $documents = $c->get(VaultDocumentRepositoryInterface::class);
+                    $audit = $c->get(AuditRecorderInterface::class);
+
+                    if (!$documents instanceof VaultDocumentRepositoryInterface) {
+                        throw new LogicException('VaultDocumentRepositoryInterface service is invalid.');
+                    }
+
+                    if (!$audit instanceof AuditRecorderInterface) {
+                        throw new LogicException('AuditRecorderInterface service is invalid.');
+                    }
+
+                    return new ExportDocumentsUseCase($documents, $audit);
+                },
+            )
+            ->set(
+                ExportDocumentsHandler::class,
+                static function (ContainerInterface $c): ExportDocumentsHandler {
+                    $uc = $c->get(ExportDocumentsUseCaseInterface::class);
+                    $rf = $c->get(ResponseFactoryInterface::class);
+                    $sf = $c->get(StreamFactoryInterface::class);
+
+                    if (!$uc instanceof ExportDocumentsUseCaseInterface) {
+                        throw new LogicException('ExportDocumentsUseCaseInterface service is invalid.');
+                    }
+
+                    if (!$rf instanceof ResponseFactoryInterface) {
+                        throw new LogicException('ResponseFactoryInterface service is invalid.');
+                    }
+
+                    if (!$sf instanceof StreamFactoryInterface) {
+                        throw new LogicException('StreamFactoryInterface service is invalid.');
+                    }
+
+                    return new ExportDocumentsHandler($uc, $rf, $sf);
+                },
+            )
+            ->set(
+                ExportRouteRegistrar::class,
+                static function (ContainerInterface $c): ExportRouteRegistrar {
+                    $h = $c->get(ExportDocumentsHandler::class);
+
+                    if (!$h instanceof ExportDocumentsHandler) {
+                        throw new LogicException('ExportDocumentsHandler service is invalid.');
+                    }
+
+                    return new ExportRouteRegistrar($h);
+                },
+            );
+    }
+}

--- a/tests/Export/ExportApiTest.php
+++ b/tests/Export/ExportApiTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Tests\Export;
+
+use Nene2\Auth\TokenIssuerInterface;
+use Nene2\Database\DatabaseConnectionFactoryInterface;
+use NeneVault\Http\RuntimeContainerFactory;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Nyholm\Psr7Server\ServerRequestCreator;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class ExportApiTest extends TestCase
+{
+    private static ?ContainerInterface $container = null;
+    private static string $token = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$container = (new RuntimeContainerFactory(dirname(__DIR__, 2)))->create();
+
+        $conn = self::$container->get(DatabaseConnectionFactoryInterface::class);
+        assert($conn instanceof DatabaseConnectionFactoryInterface);
+        $pdo = $conn->create();
+        $pdo->exec("INSERT OR IGNORE INTO organizations
+            (name, slug, plan, is_active, created_at, updated_at)
+            VALUES ('Test Org', 'test-org', 'free', 1, datetime('now'), datetime('now'))");
+        $stmt = $pdo->query("SELECT id FROM organizations WHERE slug = 'test-org'");
+        assert($stmt !== false);
+        $orgId = (int) $stmt->fetch()['id'];
+
+        $issuer = self::$container->get(TokenIssuerInterface::class);
+        assert($issuer instanceof TokenIssuerInterface);
+        self::$token = $issuer->issue([
+            'sub' => 'admin@example.com',
+            'user_id' => 1,
+            'role' => 'admin',
+            'org_id' => $orgId,
+            'iat' => time(),
+            'exp' => time() + 3600,
+        ]);
+    }
+
+    public function test_export_returns_manifest_csv(): void
+    {
+        $handler = $this->handler();
+
+        // Upload a document to export
+        $this->upload($handler, 'Manifest Vendor', '2026-07-01', '33000');
+
+        $response = $handler->handle($this->jsonRequest('POST', '/admin/vault/export', [
+            'transaction_date_from' => '2026-01-01',
+            'transaction_date_to' => '2026-12-31',
+            'counterparty_name' => 'Manifest Vendor',
+        ]));
+
+        $this->assertSame(200, $response->getStatusCode(), (string) $response->getBody());
+        $this->assertStringContainsString('text/csv', $response->getHeaderLine('Content-Type'));
+        $this->assertStringContainsString('attachment', $response->getHeaderLine('Content-Disposition'));
+
+        $csv = (string) $response->getBody();
+        $lines = array_values(array_filter(explode("\n", trim($csv))));
+
+        // Header columns (compliance §7/§10)
+        $this->assertStringContainsString('document_id,version,transaction_date,amount_cents,counterparty_name,category,file_sha256,uploaded_at,voided_at', $lines[0]);
+        // At least one data row with our vendor and amount
+        $dataJoined = implode("\n", array_slice($lines, 1));
+        $this->assertStringContainsString('Manifest Vendor', $dataJoined);
+        $this->assertStringContainsString('33000', $dataJoined);
+    }
+
+    public function test_export_requires_auth(): void
+    {
+        $response = $this->handler()->handle($this->jsonRequest('POST', '/admin/vault/export', [], auth: false));
+        $this->assertSame(401, $response->getStatusCode());
+    }
+
+    // ── helpers ──
+
+    private function handler(): RequestHandlerInterface
+    {
+        $container = self::$container;
+        assert($container !== null);
+        $h = $container->get(RequestHandlerInterface::class);
+        assert($h instanceof RequestHandlerInterface);
+
+        return $h;
+    }
+
+    /** @param array<string, mixed> $json */
+    private function jsonRequest(string $method, string $uri, array $json, bool $auth = true): ServerRequestInterface
+    {
+        $psr17 = $this->psr17();
+        $creator = new ServerRequestCreator($psr17, $psr17, $psr17, $psr17);
+
+        $headers = ['Host' => 'localhost', 'Content-Type' => 'application/json'];
+        if ($auth) {
+            $headers['Authorization'] = 'Bearer ' . self::$token;
+        }
+
+        return $creator->fromArrays(
+            server: ['REQUEST_METHOD' => $method, 'REQUEST_URI' => $uri],
+            headers: $headers,
+            body: $psr17->createStream(json_encode($json, JSON_THROW_ON_ERROR)),
+        );
+    }
+
+    private function upload(RequestHandlerInterface $handler, string $counterparty, string $date, string $amount): void
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'vault_exp_');
+        assert($tmp !== false);
+        file_put_contents($tmp, "%PDF-1.4\n{$counterparty}\n");
+
+        $psr17 = $this->psr17();
+        $file = $psr17->createUploadedFile(
+            $psr17->createStreamFromFile($tmp),
+            (int) filesize($tmp),
+            UPLOAD_ERR_OK,
+            'doc.pdf',
+            'application/pdf',
+        );
+
+        $creator = new ServerRequestCreator($psr17, $psr17, $psr17, $psr17);
+        $request = $creator->fromArrays(
+            server: ['REQUEST_METHOD' => 'POST', 'REQUEST_URI' => '/admin/vault/documents'],
+            headers: ['Host' => 'localhost', 'Authorization' => 'Bearer ' . self::$token],
+        )
+            ->withUploadedFiles(['file' => $file])
+            ->withParsedBody([
+                'counterparty_name' => $counterparty,
+                'category' => 'invoice_received',
+                'transaction_date' => $date,
+                'amount_cents' => $amount,
+            ]);
+
+        $response = $handler->handle($request);
+        assert($response->getStatusCode() === 201, (string) $response->getBody());
+        @unlink($tmp);
+    }
+
+    private function psr17(): Psr17Factory
+    {
+        $container = self::$container;
+        assert($container !== null);
+        $psr17 = $container->get(Psr17Factory::class);
+        assert($psr17 instanceof Psr17Factory);
+
+        return $psr17;
+    }
+}


### PR DESCRIPTION
## Summary

`exportDocuments` を実装。書類のマニフェスト CSV を生成し、税理士・税務調査対応の
ハンドオフに使う。読み取り専用、対象書類ごとに document.exported を監査記録。

## マニフェスト CSV 列（compliance §7/§10）
document_id, version, transaction_date, amount_cents, counterparty_name,
category, file_sha256, uploaded_at, voided_at

## コンプライアンス（§10 税務調査対応）
- エクスポートは読み取り専用 — 保存データを一切変更しない
- 各ファイルをメタデータ + 履歴アンカー（file_sha256）にマップ
- 全法定検索フィールドでフィルタ、voided は include_voided 時のみ
- 対象書類ごとに document.exported 監査（export_filter 付き）

## テスト
- ExportApiTest: マニフェスト CSV ヘッダ列・データ行検証、未認証401

## Phase 1 バックエンド API 完成 🎉
auth / org / user / vault-settings / audit-events /
document(upload/search/get/metadata/void/restore/history/download) / export

## composer check
PHPUnit / PHPStan 8 (164 files) / CS / locales 344 / OpenAPI valid — all green

Self-review: compliance, backend-api, database

Closes #25