### PR TITLE
docs: Tax advisor review package — compliance sign-off gate before Phase 2 UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ See [ADR 0009](docs/adr/0009-separate-from-billing-and-reconciliation.md).
 - **Canonical terms — single source of truth (binding):** `docs/terms.md` ← **START HERE for any identifier**
 - **Scope contract (binding):** `docs/explanation/scope-contract.md`
 - **Compliance (binding):** `docs/explanation/received-document-compliance.md`
+- **Compliance review gate:** `docs/compliance-review/` (税理士 sign-off blocks Phase 2 UI)
 - **No competitor names (binding):** `docs/adr/0013-no-third-party-product-names.md`
 - **Naming rules:** `docs/development/naming-conventions.md`
 - **Backend standards:** `docs/development/backend-standards.md`

--- a/docs/compliance-review/2026-tax-advisor-review-package.md
+++ b/docs/compliance-review/2026-tax-advisor-review-package.md
@@ -1,0 +1,132 @@
+# Tax Advisor Review Package — NeNe Vault (2026)
+
+**For:** licensed 税理士 / 公認会計士 reviewing NeNe Vault's received-document
+(受取電子取引データ) compliance posture before Phase 2 admin UI.
+
+**Binding source of truth:** [`received-document-compliance.md`](../explanation/received-document-compliance.md).
+This package maps each rule there to concrete implementation evidence so the
+review is verifiable, not aspirational.
+
+> **Not legal advice.** This is engineering's interpretation of 電子帳簿保存法
+> for received electronic documents. We ask you to confirm the posture is
+> defensible, identify gaps, and record findings in `signoff-record.md`.
+
+---
+
+## 1. What NeNe Vault is (and is not)
+
+| | |
+| --- | --- |
+| **Is** | A self-hosted archive that stores, searches, and preserves **received** business documents (vendor invoices/contracts/receipts) for 電子帳簿保存法 visibility |
+| **Is not** | Accounting software, invoice issuance, bank reconciliation, journal entries, or tax computation (see [`scope-contract.md`](../explanation/scope-contract.md) DON'T list) |
+
+The review concerns **received electronic transaction data (電子取引データ)** only.
+
+---
+
+## 2. Statutory basis → implementation evidence
+
+Each row: the rule (with article), how it is implemented, and where to verify.
+
+### 2.1 電子取引データの保存義務 — 電帳法 第7条
+
+| Requirement | Implementation | Verify |
+| --- | --- | --- |
+| Preserve received electronic documents in electronic form | Files stored immutably outside web root; never printed-and-discarded as the system of record | `LocalFilesystemDocumentStorage`, ADR 0012; `POST /admin/vault/documents` |
+| Original electronic form retained | File bytes never overwritten; SHA-256 recorded at upload, verified at download | `document_versions.file_sha256`; `UploadDocumentUseCase`; `DownloadDocumentVersionUseCase` (hash check before serving) |
+
+### 2.2 真実性の確保 (Integrity) — 規則 第4条第1項第2号
+
+Method chosen: **訂正削除の履歴が残るシステム方式** (correction-history method), ADR 0011.
+
+| Requirement | Implementation | Verify |
+| --- | --- | --- |
+| File immutability | New version per correction; prior versions永続的に addressable | `document_versions` (unique doc+version); compliance §3.1 |
+| Metadata change history | Every change to 取引年月日 / 取引金額 / 取引先 / category / tags appends an audit event with before & after | `UpdateDocumentMetadataUseCase` → `document.metadata_changed`; `audit_events.before_json/after_json` |
+| Deletion = void, not erase | Void records reason + actor + timestamp; document stays in DB; restore is audited | `VoidDocumentUseCase` → `document.voided`; `RestoreDocumentUseCase` → `document.restored` |
+| Provenance | file_sha256, original filename, MIME, uploaded_at, uploaded_by, source recorded | `document_versions` columns; compliance §3.4 |
+| Duplicate detection | Same SHA-256 in org warns; operator confirms | `UploadDocumentUseCase` (409 unless confirm_duplicate); compliance §3.5 |
+
+### 2.3 可視性の確保 (Visibility) — 規則 第4条第1項第1号・第3号
+
+| Requirement | Implementation | Verify |
+| --- | --- | --- |
+| Legibility (見読可能性) | Files downloadable in original format via authenticated endpoint | `GET .../versions/{versionId}/download` |
+| **Search (検索要件)** — 取引年月日 | Exact + range | `searchDocuments` `transaction_date_from/to` |
+| Search — 取引金額 | Exact + range (integer JPY) | `amount_min_cents/max_cents` |
+| Search — 取引先 | Partial match | `counterparty_name` |
+| **Two-or-more field AND combinations** | Supported in one query | `searchDocuments` combination test |
+
+### 2.4 保存期間 (Retention)
+
+| Requirement | Implementation | Verify |
+| --- | --- | --- |
+| Minimum 7 years from filing deadline | Default **10 years from transaction_date** — chosen to cover the filing-deadline anchor without fiscal-year configuration | ADR 0004; `vault_documents.retention_expires_at` |
+| No silent purge before expiry | No auto-purge; purge requires admin + expiry check + export procedure | compliance §5.2/§5.4 |
+| Unknown transaction date | Anchored to uploaded_at + flagged `date_uncertain` | `UploadDocumentUseCase`; compliance §5.3 |
+
+### 2.5 監査証跡 (Audit trail) — ADR 0014
+
+| Requirement | Implementation | Verify |
+| --- | --- | --- |
+| Who changed what, before/after | Every mutation records an append-only audit event | `audit_events`; `AuditRecorder` |
+| Audit records immutable | No UPDATE/DELETE in application; DB role lacks those grants | compliance §7; ADR 0014 |
+| No secrets in audit | Snapshots exclude password_hash, tokens, file paths | `UserPresenter`, `VaultDocument` audit snapshot (no file_path) |
+
+### 2.6 税務調査対応 (Tax audit response) — compliance §10
+
+| Requirement | Implementation | Verify |
+| --- | --- | --- |
+| Produce records for inspection | Manifest CSV export filtered by date/counterparty | `POST /admin/vault/export`; columns: document_id, version, transaction_date, amount_cents, counterparty_name, category, file_sha256, uploaded_at, voided_at |
+| Read-only, no data change | Export modifies nothing; records `document.exported` audit per document | `ExportDocumentsUseCase` |
+
+---
+
+## 3. Posture we ask you to confirm
+
+1. Is the **correction-history method** (ADR 0011) an acceptable 真実性 method for
+   received 電子取引データ for the target operators (Japan SMB), given we do **not**
+   acquire accredited timestamps (認定タイムスタンプ) in MVP?
+2. Is the **10-year-from-transaction-date** retention default (ADR 0004) a safe
+   anchor for 法人税法 / 消費税法 / 会社法 without requiring operators to configure
+   fiscal-year/filing-deadline?
+3. Do the **search fields and combinations** (§2.3) satisfy 検索要件 for typical
+   SMB received-document patterns?
+4. Is the **void-not-delete** + audit posture (§2.2) acceptable as the
+   訂正削除の履歴 evidence a reviewer would expect?
+5. Are the **manifest CSV columns** (§2.6) sufficient for a 税務調査 handoff?
+
+---
+
+## 4. Known limits / out of scope (do not bless these)
+
+| Item | Status |
+| --- | --- |
+| スキャナ保存 (scanner preservation) specific requirements (resolution, accredited timestamp, prompt-entry) | **Operator responsibility.** Vault warns on `scan_upload` source; does not certify スキャナ保存. compliance §2.2/§9 |
+| 認定タイムスタンプ (accredited TSA) | Not in MVP. Correction-history method used instead. Revisit via ADR if you require TSA. |
+| 事務処理規程 (operational procedures document) | Operator maintains separately. Vault provides a template outline in Phase 2+. |
+| OCR-as-truth | Not implemented. OCR (Phase 4) is suggest-only with operator confirmation. compliance §8 |
+| Invoice issuance / reconciliation / journal entries / tax computation | **Out of product scope.** scope-contract X1/X2/X4/X12 |
+
+---
+
+## 5. Open questions for the advisor
+
+Record answers in `signoff-record.md` or as Issues:
+
+- Are there industry-specific received-document patterns where our search fields
+  fall short?
+- For operators with 繰越欠損金, should the product surface a stronger prompt to
+  raise retention beyond 10 years?
+- Any 電帳法 guidance updates since this package's date that affect the posture?
+
+---
+
+## 6. How to verify claims yourself
+
+- Read the binding doc: [`received-document-compliance.md`](../explanation/received-document-compliance.md)
+- API contract: [`docs/openapi/openapi.yaml`](../openapi/openapi.yaml)
+- Behavior is covered by automated tests (`tests/Document/`, `tests/Export/`,
+  `tests/User/`) that assert integrity, search, void/restore, audit, and export.
+
+Last updated: 2026-05-30

--- a/docs/compliance-review/README.md
+++ b/docs/compliance-review/README.md
@@ -1,0 +1,44 @@
+# Compliance Review Gate
+
+This directory holds the materials a licensed **税理士 (tax accountant)** or
+**公認会計士 (CPA)** needs to review NeNe Vault's received-document compliance
+posture, and the record of their sign-off.
+
+> This is a **gate**, not a guarantee. Engineering prepares the package; the
+> professional reviews it and records findings. Phase 2 admin UI **must not** ship
+> to production operators until §9 of
+> [`received-document-compliance.md`](../explanation/received-document-compliance.md)
+> is satisfied and the sign-off record below is completed.
+
+## Why this gate exists
+
+- [`received-document-compliance.md` §9](../explanation/received-document-compliance.md) — professional review gate before Phase 2 admin UI
+- [`scope-contract.md`](../explanation/scope-contract.md) — definition of done requires 税理士 review of received-document retention/search posture
+- [ADR 0011](../adr/0011-electronic-records-received-documents.md) — correction-history method choice (not legal advice; needs professional confirmation)
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `2026-tax-advisor-review-package.md` | The review package: statutory basis → implementation evidence, posture to confirm, known limits, open questions |
+| `signoff-record.md` | Sign-off record the professional completes (name, credential, date, findings) |
+
+## How to use
+
+1. Engineering keeps `2026-tax-advisor-review-package.md` current with the
+   implemented behavior (it links to the binding compliance doc, not a restatement).
+2. The maintainer sends the package to a licensed professional.
+3. The professional reviews the posture, raises any findings, and completes
+   `signoff-record.md`.
+4. If the professional requires changes, open Issues; any change that deviates
+   from the compliance doc needs an ADR with sign-off (compliance §0.2).
+5. Only when the sign-off record shows **approved** does the Phase 2 UI gate open.
+
+## Scope of the review
+
+In scope: received electronic documents (電子取引データ) — integrity, visibility/
+search, retention, audit, export posture.
+
+Out of scope for this product (do not ask the advisor to bless these): invoice
+issuance, bank reconciliation, journal entries, tax computation — see
+[`scope-contract.md`](../explanation/scope-contract.md) DON'T list.

--- a/docs/compliance-review/signoff-record.md
+++ b/docs/compliance-review/signoff-record.md
@@ -1,0 +1,66 @@
+# Compliance Sign-Off Record
+
+This file records the professional review of NeNe Vault's received-document
+compliance posture (the gate in
+[`received-document-compliance.md` §9](../explanation/received-document-compliance.md)).
+
+Complete one block per review. **Do not delete prior blocks** — they are the
+audit trail of the gate itself.
+
+---
+
+## Review status
+
+| Field | Value |
+| --- | --- |
+| **Gate status** | ⬜ Not yet reviewed |
+| **Package reviewed** | `2026-tax-advisor-review-package.md` |
+| **Phase 2 UI may ship** | ❌ Not until status is **Approved** below |
+
+---
+
+## Sign-off block (template — copy for each review)
+
+```
+### Review N — YYYY-MM-DD
+
+- Reviewer name:
+- Credential (税理士 / 公認会計士) and registration no.:
+- Affiliation:
+- Package version reviewed (last-updated date):
+- Decision: Approved | Approved with conditions | Changes required
+
+#### Findings
+1.
+2.
+
+#### Conditions / required changes (if any)
+- [ ] ... (open as Issue, link here)
+
+#### Notes on specific questions (package §3 / §5)
+- Q1 (correction-history method):
+- Q2 (10-year retention anchor):
+- Q3 (search fields):
+- Q4 (void-not-delete):
+- Q5 (manifest columns):
+
+- Signature / confirmation method:
+- Date:
+```
+
+---
+
+## Completed reviews
+
+_(none yet — the first completed review goes here)_
+
+---
+
+## Process notes
+
+- A decision of **Changes required** means Phase 2 UI stays blocked; open Issues
+  for each required change.
+- Any change that deviates from `received-document-compliance.md` requires an ADR
+  with this professional sign-off recorded in it (compliance §0.2).
+- When a later 電帳法 amendment or NTA guidance lands, treat re-review as a P0
+  and add a new review block.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,25 +1,37 @@
 # Current TODO
 
-**Phase 0 — Governance and product design**
+**Phase 1 — Document API complete; compliance review gate open.**
 
 ## Done
 
-- [x] Issue #1: Governance bootstrap — merged (PR #1, 2026-05-30)
-- [x] Issue #2: Product vision & requirements review — merged (PR #2, 2026-05-30)
+- [x] Governance bootstrap, product definition (PR #1, #2)
+- [x] Coding standards + review checklists (PR #4)
+- [x] `docs/terms.md` canonical identifier registry (PR #6)
+- [x] Multi-tenancy foundation — Auth / Organization / VaultSettings (PR #8)
+- [x] Audit logging — before/after on all mutations (PR #10)
+- [x] ja/en locale files (PR #12)
+- [x] OpenAPI 3.1 contract — all Phase 1 endpoints (PR #14)
+- [x] Document upload + storage + get detail (PR #16)
+- [x] Document search — date/amount/counterparty/category (PR #18)
+- [x] Metadata edit + void/restore + history (PR #20)
+- [x] Version download — SHA-256 verified (PR #22)
+- [x] User CRUD endpoints (PR #24)
+- [x] Manifest export — CSV (PR #26)
+- [x] Tax advisor review package prepared (Issue #27)
 
-## Next (Phase 0 → Phase 1)
+## In progress / gating
 
-- [ ] Issue #4: NENE2 runtime scaffold + `GET /health`
-- [ ] Issue #5: OpenAPI stub (document endpoints)
-- [ ] Issue #6: CI (`composer check`)
-- [ ] 税理士 review gate before Phase 2 UI
+- [ ] **税理士 review gate** — package ready in `docs/compliance-review/`;
+      awaiting professional sign-off in `signoff-record.md`. **Blocks Phase 2 UI.**
+
+## Next (Phase 2, after sign-off)
+
+- [ ] Admin UI scaffold — React + Vite + ja/en locale integration
+- [ ] Export ZIP bundling (currently CSV only)
+- [ ] Operator guide (storage, backup, retention, search) + 事務処理規程 template
 
 ## Blockers
 
-None.
-
-## Handoff
-
-Parallel bootstrap with **`nene-profile`**. See publication-strategy decision 0005.
+- Phase 2 admin UI is gated on the compliance sign-off above.
 
 Last updated: 2026-05-30


### PR DESCRIPTION
## Summary

received-document-compliance.md §9 の専門家レビューゲートに必要な資料を整備。
実際のサインオフは税理士（人間）が行い、記録ファイルに残す。

## 追加
- `docs/compliance-review/README.md` — ゲートの説明・使い方
- `docs/compliance-review/2026-tax-advisor-review-package.md` — レビューパッケージ
  - **法的根拠 → 実装エビデンスの対応表**（電帳法第7条・規則第4条第1項・法人税法等が、どのエンドポイント/テーブル/監査イベントで満たされるか）
  - 確認依頼ポスチャ（真実性/可視性/検索/保存期間/監査/税務調査対応）
  - 既知の限界・スコープ外（スキャナ保存・認定タイムスタンプ・OCR）
  - 税理士への質問5項目
- `docs/compliance-review/signoff-record.md` — サインオフ記録テンプレート

## 変更
- `docs/todo/current.md` — Phase 1 完了・レビューゲート進行中に更新
- `AGENTS.md` — レビューゲートへの参照追加

## ポリシー
- 英語ベース + 法定用語は日本語併記（ADR 0008）
- コード変更なし・ドキュメントのみ
- binding な compliance doc へのリンク（再記述しない）

Self-review: docs-policy, compliance

Closes #27