### PR TITLE
chore(frontend): ignore tsconfig.tsbuildinfo build cache

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 *.local
 .vite
+*.tsbuildinfo

--- a/frontend/tsconfig.tsbuildinfo
+++ b/frontend/tsconfig.tsbuildinfo
@@ -1,1 +1,0 @@
-{"root":["./src/App.tsx","./src/main.tsx","./src/vite-env.d.ts","./src/api/auth.ts","./src/api/client.ts","./src/components/LanguageSwitcher.tsx","./src/locale/LocaleContext.tsx","./src/locale/context.ts","./src/locale/locales.ts","./src/locale/useLocale.ts","./src/pages/HomePage.tsx","./src/pages/LoginPage.tsx","./vite.config.ts"],"version":"5.9.3"}


### PR DESCRIPTION
tsc -b のビルドキャッシュが誤ってコミットされていたため除外。frontend/.gitignore に `*.tsbuildinfo` を追加し追跡解除。