### PR TITLE
feat(frontend): document detail, audit log, app shell navigation

### DIFF
--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -2,6 +2,8 @@ import { createBrowserRouter } from 'react-router-dom';
 import { LoginPage } from '@/pages/LoginPage';
 import { HomePage } from '@/pages/HomePage';
 import { DocumentsPage } from '@/pages/DocumentsPage';
+import { DocumentDetailPage } from '@/pages/DocumentDetailPage';
+import { AuditPage } from '@/pages/AuditPage';
 import { ForbiddenPage } from '@/pages/ForbiddenPage';
 import { AuthGate } from './auth-gate';
 
@@ -21,6 +23,22 @@ export const router = createBrowserRouter([
     element: (
       <AuthGate>
         <DocumentsPage />
+      </AuthGate>
+    ),
+  },
+  {
+    path: '/documents/:id',
+    element: (
+      <AuthGate>
+        <DocumentDetailPage />
+      </AuthGate>
+    ),
+  },
+  {
+    path: '/audit',
+    element: (
+      <AuthGate>
+        <AuditPage />
       </AuthGate>
     ),
   },

--- a/frontend/src/entities/audit/index.ts
+++ b/frontend/src/entities/audit/index.ts
@@ -1,0 +1,8 @@
+export type {
+  AuditEvent,
+  AuditEventListResponse,
+  DocumentVersion,
+  DocumentHistoryResponse,
+  ListAuditEventsParams,
+} from './types';
+export { useAuditEvents, useDocumentHistory, auditQueryKeys } from './queries';

--- a/frontend/src/entities/audit/queries.ts
+++ b/frontend/src/entities/audit/queries.ts
@@ -1,0 +1,43 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { apiClient } from '@/shared/api/client';
+import type { AppError } from '@/shared/api/errors';
+import type {
+  AuditEventListResponse,
+  DocumentHistoryResponse,
+  ListAuditEventsParams,
+} from './types';
+
+export const auditQueryKeys = {
+  all: ['audit'] as const,
+  list: (params: ListAuditEventsParams) => ['audit', 'list', params] as const,
+  documentHistory: (id: string) => ['audit', 'history', id] as const,
+} as const;
+
+function buildAuditPath(params: ListAuditEventsParams): string {
+  const q = new URLSearchParams();
+  if (params.entity_type !== undefined) q.set('entity_type', params.entity_type);
+  if (params.entity_id !== undefined) q.set('entity_id', params.entity_id);
+  if (params.action !== undefined) q.set('action', params.action);
+  if (params.actor_user_id !== undefined) q.set('actor_user_id', String(params.actor_user_id));
+  if (params.limit !== undefined) q.set('limit', String(params.limit));
+  if (params.offset !== undefined) q.set('offset', String(params.offset));
+  const qs = q.toString();
+  return `/admin/audit-events${qs !== '' ? `?${qs}` : ''}`;
+}
+
+export function useAuditEvents(
+  params: ListAuditEventsParams,
+): UseQueryResult<AuditEventListResponse, AppError> {
+  return useQuery<AuditEventListResponse, AppError>({
+    queryKey: auditQueryKeys.list(params),
+    queryFn: ({ signal }) => apiClient.get<AuditEventListResponse>(buildAuditPath(params), signal),
+  });
+}
+
+export function useDocumentHistory(id: string): UseQueryResult<DocumentHistoryResponse, AppError> {
+  return useQuery<DocumentHistoryResponse, AppError>({
+    queryKey: auditQueryKeys.documentHistory(id),
+    queryFn: ({ signal }) =>
+      apiClient.get<DocumentHistoryResponse>(`/admin/vault/documents/${id}/history`, signal),
+  });
+}

--- a/frontend/src/entities/audit/types.ts
+++ b/frontend/src/entities/audit/types.ts
@@ -1,0 +1,46 @@
+export interface AuditEvent {
+  id: number;
+  action: string;
+  entity_type: string;
+  entity_id: string;
+  actor_user_id: number | null;
+  organization_id: number | null;
+  before_json: Record<string, unknown> | null;
+  after_json: Record<string, unknown> | null;
+  source: string;
+  metadata_json: Record<string, unknown> | null;
+  created_at: string;
+}
+
+export interface AuditEventListResponse {
+  items: AuditEvent[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface DocumentVersion {
+  id: string;
+  version_number: number;
+  file_sha256: string;
+  mime_type: string;
+  original_filename: string;
+  file_size_bytes: number | undefined;
+  source: string;
+  uploaded_at: string;
+  uploaded_by: number | null;
+}
+
+export interface DocumentHistoryResponse {
+  versions: DocumentVersion[];
+  audit_events: AuditEvent[];
+}
+
+export interface ListAuditEventsParams {
+  entity_type?: string | undefined;
+  entity_id?: string | undefined;
+  action?: string | undefined;
+  actor_user_id?: number | undefined;
+  limit?: number | undefined;
+  offset?: number | undefined;
+}

--- a/frontend/src/entities/document/index.ts
+++ b/frontend/src/entities/document/index.ts
@@ -7,5 +7,10 @@ export type {
   DocumentSource,
 } from './types';
 export { useDocuments, useDocumentById, documentQueryKeys } from './queries';
-export { useUploadDocument } from './mutations';
-export type { UploadDocumentInput } from './mutations';
+export {
+  useUploadDocument,
+  useUpdateDocumentMetadata,
+  useVoidDocument,
+  useRestoreDocument,
+} from './mutations';
+export type { UploadDocumentInput, UpdateMetadataInput, VoidDocumentInput } from './mutations';

--- a/frontend/src/entities/document/mutations.ts
+++ b/frontend/src/entities/document/mutations.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from '@/shared/api/client';
 import type { AppError } from '@/shared/api/errors';
-import type { VaultDocument } from './types';
+import type { DocumentCategory, VaultDocument } from './types';
 import { documentQueryKeys } from './queries';
 
 export interface UploadDocumentInput {
@@ -34,6 +34,62 @@ export function useUploadDocument(onSuccess?: () => void) {
       return apiClient.upload<VaultDocument>('/admin/vault/documents', fd);
     },
     onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: documentQueryKeys.all });
+      onSuccess?.();
+    },
+  });
+}
+
+export interface UpdateMetadataInput {
+  id: string;
+  transaction_date?: string | null | undefined;
+  amount_cents?: number | null | undefined;
+  counterparty_name?: string | undefined;
+  category?: DocumentCategory | undefined;
+  tags?: string[] | undefined;
+}
+
+export function useUpdateDocumentMetadata(onSuccess?: () => void) {
+  const queryClient = useQueryClient();
+
+  return useMutation<VaultDocument, AppError, UpdateMetadataInput>({
+    mutationFn: ({ id, ...body }) =>
+      apiClient.patch<VaultDocument>(`/admin/vault/documents/${id}/metadata`, body),
+    onSuccess: (_, { id }) => {
+      void queryClient.invalidateQueries({ queryKey: documentQueryKeys.detail(id) });
+      void queryClient.invalidateQueries({ queryKey: documentQueryKeys.all });
+      onSuccess?.();
+    },
+  });
+}
+
+export interface VoidDocumentInput {
+  id: string;
+  void_reason: string;
+  void_note?: string | null | undefined;
+}
+
+export function useVoidDocument(onSuccess?: () => void) {
+  const queryClient = useQueryClient();
+
+  return useMutation<VaultDocument, AppError, VoidDocumentInput>({
+    mutationFn: ({ id, ...body }) =>
+      apiClient.post<VaultDocument>(`/admin/vault/documents/${id}/void`, body),
+    onSuccess: (_, { id }) => {
+      void queryClient.invalidateQueries({ queryKey: documentQueryKeys.detail(id) });
+      void queryClient.invalidateQueries({ queryKey: documentQueryKeys.all });
+      onSuccess?.();
+    },
+  });
+}
+
+export function useRestoreDocument(onSuccess?: () => void) {
+  const queryClient = useQueryClient();
+
+  return useMutation<VaultDocument, AppError, string>({
+    mutationFn: (id) => apiClient.post<VaultDocument>(`/admin/vault/documents/${id}/restore`, {}),
+    onSuccess: (_, id) => {
+      void queryClient.invalidateQueries({ queryKey: documentQueryKeys.detail(id) });
       void queryClient.invalidateQueries({ queryKey: documentQueryKeys.all });
       onSuccess?.();
     },

--- a/frontend/src/features/document-detail/hooks/use-metadata-edit.ts
+++ b/frontend/src/features/document-detail/hooks/use-metadata-edit.ts
@@ -1,0 +1,63 @@
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { useUpdateDocumentMetadata } from '@/entities/document';
+import type { VaultDocument } from '@/entities/document';
+import { messageKeyForError } from '@/shared/i18n/map-problem-details';
+
+const metadataSchema = z.object({
+  transaction_date: z.string().optional(),
+  amount_cents: z.string().optional(),
+  counterparty_name: z.string().min(1),
+  category: z.enum(['invoice_received', 'contract', 'receipt', 'delivery_note', 'other']),
+  tags: z.string().optional(),
+});
+
+export type MetadataFormValues = z.infer<typeof metadataSchema>;
+
+function tagsToString(tags: string[] | undefined): string {
+  return (tags ?? []).join(', ');
+}
+
+export function useMetadataEditForm(doc: VaultDocument, onSuccess: () => void) {
+  const mutation = useUpdateDocumentMetadata(onSuccess);
+
+  const form = useForm<MetadataFormValues>({
+    resolver: zodResolver(metadataSchema),
+    defaultValues: {
+      transaction_date: doc.transaction_date ?? '',
+      amount_cents: doc.amount_cents !== null ? String(doc.amount_cents) : '',
+      counterparty_name: doc.counterparty_name,
+      category: doc.category,
+      tags: tagsToString(doc.tags),
+    },
+  });
+
+  const submitError =
+    mutation.error !== null
+      ? (messageKeyForError(mutation.error) ?? 'problem.internal_server_error')
+      : null;
+
+  return {
+    form,
+    onSubmit: form.handleSubmit((values) => {
+      const amountRaw = parseInt(values.amount_cents ?? '', 10);
+      mutation.mutate({
+        id: doc.id,
+        transaction_date: values.transaction_date !== '' ? values.transaction_date : null,
+        amount_cents: !isNaN(amountRaw) ? amountRaw : null,
+        counterparty_name: values.counterparty_name,
+        category: values.category,
+        tags:
+          values.tags !== '' && values.tags !== undefined
+            ? values.tags
+                .split(',')
+                .map((t) => t.trim())
+                .filter((t) => t !== '')
+            : [],
+      });
+    }),
+    isSubmitting: mutation.isPending,
+    submitError,
+  };
+}

--- a/frontend/src/features/document-detail/hooks/use-void-document.ts
+++ b/frontend/src/features/document-detail/hooks/use-void-document.ts
@@ -1,0 +1,35 @@
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { useVoidDocument } from '@/entities/document';
+import { messageKeyForError } from '@/shared/i18n/map-problem-details';
+
+const voidSchema = z.object({
+  void_reason: z.string().min(1),
+  void_note: z.string().optional(),
+});
+
+export type VoidFormValues = z.infer<typeof voidSchema>;
+
+export function useVoidDocumentForm(id: string, onSuccess: () => void) {
+  const mutation = useVoidDocument(onSuccess);
+
+  const form = useForm<VoidFormValues>({
+    resolver: zodResolver(voidSchema),
+    defaultValues: { void_reason: '', void_note: '' },
+  });
+
+  const submitError =
+    mutation.error !== null
+      ? (messageKeyForError(mutation.error) ?? 'problem.internal_server_error')
+      : null;
+
+  return {
+    form,
+    onSubmit: form.handleSubmit((values) => {
+      mutation.mutate({ id, ...values });
+    }),
+    isSubmitting: mutation.isPending,
+    submitError,
+  };
+}

--- a/frontend/src/features/document-detail/index.ts
+++ b/frontend/src/features/document-detail/index.ts
@@ -1,0 +1,4 @@
+export { VoidModal } from './ui/VoidModal';
+export { RestoreModal } from './ui/RestoreModal';
+export { MetadataEditModal } from './ui/MetadataEditModal';
+export { DocumentHistoryTable } from './ui/DocumentHistoryTable';

--- a/frontend/src/features/document-detail/ui/DocumentHistoryTable.tsx
+++ b/frontend/src/features/document-detail/ui/DocumentHistoryTable.tsx
@@ -1,0 +1,72 @@
+import { useTranslation } from '@/shared/i18n/use-translation';
+import { Text } from '@/shared/ui';
+import type { AuditEvent } from '@/entities/audit';
+
+interface DocumentHistoryTableProps {
+  events: AuditEvent[];
+}
+
+export function DocumentHistoryTable({ events }: DocumentHistoryTableProps) {
+  const { t } = useTranslation();
+
+  if (events.length === 0) {
+    return <Text tone="muted">{t('document.history.no_history')}</Text>;
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full border-collapse text-body-sm">
+        <thead>
+          <tr className="border-b border-border bg-surface-raised">
+            <th className="px-inline-md py-stack-sm text-left text-label-sm font-medium text-muted">
+              {t('document.history.table.action')}
+            </th>
+            <th className="px-inline-md py-stack-sm text-left text-label-sm font-medium text-muted">
+              {t('document.history.table.actor')}
+            </th>
+            <th className="px-inline-md py-stack-sm text-left text-label-sm font-medium text-muted">
+              {t('document.history.table.timestamp')}
+            </th>
+            <th className="px-inline-md py-stack-sm text-left text-label-sm font-medium text-muted">
+              {t('document.history.table.before')}
+            </th>
+            <th className="px-inline-md py-stack-sm text-left text-label-sm font-medium text-muted">
+              {t('document.history.table.after')}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {events.map((event) => (
+            <tr key={event.id} className="border-b border-border">
+              <td className="px-inline-md py-stack-sm font-medium">{event.action}</td>
+              <td className="px-inline-md py-stack-sm text-muted">
+                {event.actor_user_id !== null ? String(event.actor_user_id) : '—'}
+              </td>
+              <td className="px-inline-md py-stack-sm text-muted">
+                {event.created_at.slice(0, 16).replace('T', ' ')}
+              </td>
+              <td className="px-inline-md py-stack-sm">
+                {event.before_json !== null ? (
+                  <pre className="text-label-xs text-muted max-w-48 overflow-hidden text-ellipsis whitespace-pre-wrap">
+                    {JSON.stringify(event.before_json, null, 2)}
+                  </pre>
+                ) : (
+                  '—'
+                )}
+              </td>
+              <td className="px-inline-md py-stack-sm">
+                {event.after_json !== null ? (
+                  <pre className="text-label-xs text-muted max-w-48 overflow-hidden text-ellipsis whitespace-pre-wrap">
+                    {JSON.stringify(event.after_json, null, 2)}
+                  </pre>
+                ) : (
+                  '—'
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/features/document-detail/ui/MetadataEditModal.tsx
+++ b/frontend/src/features/document-detail/ui/MetadataEditModal.tsx
@@ -1,0 +1,112 @@
+import { useTranslation } from '@/shared/i18n/use-translation';
+import { Button, Input, Stack, Text } from '@/shared/ui';
+import type { VaultDocument } from '@/entities/document';
+import { useMetadataEditForm } from '../hooks/use-metadata-edit';
+
+const CATEGORIES = ['invoice_received', 'contract', 'receipt', 'delivery_note', 'other'] as const;
+
+interface MetadataEditModalProps {
+  doc: VaultDocument;
+  onClose: () => void;
+}
+
+export function MetadataEditModal({ doc, onClose }: MetadataEditModalProps) {
+  const { t } = useTranslation();
+  const { form, onSubmit, isSubmitting, submitError } = useMetadataEditForm(doc, onClose);
+  const { register } = form;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+    >
+      <div className="w-full max-w-lg rounded-xl border border-border bg-surface shadow-lg">
+        <div className="flex items-center justify-between border-b border-border px-inline-lg py-stack-md">
+          <Text as="h2" className="text-heading-sm">
+            {t('document.metadata_edit.title')}
+          </Text>
+          <button type="button" onClick={onClose} className="text-muted hover:text-foreground">
+            ✕
+          </button>
+        </div>
+
+        <form
+          onSubmit={(e) => {
+            void onSubmit(e);
+          }}
+          className="p-inline-lg"
+        >
+          <Stack gap="md">
+            <Text tone="muted" className="text-body-sm">
+              {t('document.metadata_edit.description')}
+            </Text>
+
+            <div className="flex flex-col gap-stack-xs">
+              <label className="text-label-sm font-medium">
+                {t('document.metadata.counterparty_name')}
+                <span className="ml-1 text-danger text-label-xs">
+                  {t('common.required_marker')}
+                </span>
+              </label>
+              <Input type="text" {...register('counterparty_name')} />
+            </div>
+
+            <div className="flex flex-col gap-stack-xs">
+              <label className="text-label-sm font-medium">{t('document.metadata.category')}</label>
+              <select
+                {...register('category')}
+                className="h-10 rounded-md border border-border bg-surface px-inline-sm text-body-sm focus:outline-none focus:ring-2 focus:ring-brand"
+              >
+                {CATEGORIES.map((cat) => (
+                  <option key={cat} value={cat}>
+                    {t(`document.category.${cat}`)}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="grid grid-cols-2 gap-inline-md">
+              <div className="flex flex-col gap-stack-xs">
+                <label className="text-label-sm font-medium">
+                  {t('document.metadata.transaction_date')}
+                </label>
+                <Input type="date" {...register('transaction_date')} />
+              </div>
+              <div className="flex flex-col gap-stack-xs">
+                <label className="text-label-sm font-medium">
+                  {t('document.metadata.amount_cents')}
+                </label>
+                <Input type="number" placeholder="0" {...register('amount_cents')} />
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-stack-xs">
+              <label className="text-label-sm font-medium">{t('document.metadata.tags')}</label>
+              <Input
+                type="text"
+                placeholder={t('document.upload.tags_placeholder')}
+                {...register('tags')}
+              />
+            </div>
+
+            {submitError !== null && (
+              <Text tone="danger" className="text-body-sm">
+                {t(submitError)}
+              </Text>
+            )}
+
+            <div className="flex justify-end gap-inline-md">
+              <Button type="button" variant="secondary" onClick={onClose} disabled={isSubmitting}>
+                {t('common.buttons.cancel')}
+              </Button>
+              <Button type="submit" variant="primary" disabled={isSubmitting}>
+                {isSubmitting ? t('common.status.saving') : t('document.metadata_edit.save_button')}
+              </Button>
+            </div>
+          </Stack>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/document-detail/ui/RestoreModal.tsx
+++ b/frontend/src/features/document-detail/ui/RestoreModal.tsx
@@ -1,0 +1,64 @@
+import { useRestoreDocument } from '@/entities/document';
+import { messageKeyForError } from '@/shared/i18n/map-problem-details';
+import { useTranslation } from '@/shared/i18n/use-translation';
+import { Button, Stack, Text } from '@/shared/ui';
+
+interface RestoreModalProps {
+  documentId: string;
+  onClose: () => void;
+}
+
+export function RestoreModal({ documentId, onClose }: RestoreModalProps) {
+  const { t } = useTranslation();
+  const mutation = useRestoreDocument(onClose);
+  const submitError =
+    mutation.error !== null
+      ? (messageKeyForError(mutation.error) ?? 'problem.internal_server_error')
+      : null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+    >
+      <div className="w-full max-w-md rounded-xl border border-border bg-surface shadow-lg p-inline-lg">
+        <Stack gap="md">
+          <Text as="h2" className="text-heading-sm">
+            {t('document.restore.title')}
+          </Text>
+          <Text tone="muted" className="text-body-sm">
+            {t('document.restore.description')}
+          </Text>
+          {submitError !== null && (
+            <Text tone="danger" className="text-body-sm">
+              {t(submitError)}
+            </Text>
+          )}
+          <div className="flex justify-end gap-inline-md">
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={onClose}
+              disabled={mutation.isPending}
+            >
+              {t('common.buttons.cancel')}
+            </Button>
+            <Button
+              type="button"
+              variant="primary"
+              disabled={mutation.isPending}
+              onClick={() => {
+                mutation.mutate(documentId);
+              }}
+            >
+              {mutation.isPending
+                ? t('common.status.processing')
+                : t('document.restore.confirm_button')}
+            </Button>
+          </div>
+        </Stack>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/document-detail/ui/VoidModal.tsx
+++ b/frontend/src/features/document-detail/ui/VoidModal.tsx
@@ -1,0 +1,96 @@
+import { useTranslation } from '@/shared/i18n/use-translation';
+import { Button, Input, Stack, Text } from '@/shared/ui';
+import { useVoidDocumentForm } from '../hooks/use-void-document';
+
+interface VoidModalProps {
+  documentId: string;
+  onClose: () => void;
+}
+
+export function VoidModal({ documentId, onClose }: VoidModalProps) {
+  const { t } = useTranslation();
+  const { form, onSubmit, isSubmitting, submitError } = useVoidDocumentForm(documentId, onClose);
+  const {
+    register,
+    formState: { errors },
+  } = form;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+    >
+      <div className="w-full max-w-md rounded-xl border border-border bg-surface shadow-lg">
+        <div className="flex items-center justify-between border-b border-border px-inline-lg py-stack-md">
+          <Text as="h2" className="text-heading-sm">
+            {t('document.void.title')}
+          </Text>
+          <button type="button" onClick={onClose} className="text-muted hover:text-foreground">
+            ✕
+          </button>
+        </div>
+
+        <form
+          onSubmit={(e) => {
+            void onSubmit(e);
+          }}
+          className="p-inline-lg"
+        >
+          <Stack gap="md">
+            <Text tone="muted" className="text-body-sm">
+              {t('document.void.description')}
+            </Text>
+
+            <div className="rounded-md border border-warning bg-warning-muted p-stack-sm">
+              <Text className="text-label-sm text-warning">{t('document.void.warning')}</Text>
+            </div>
+
+            <div className="flex flex-col gap-stack-xs">
+              <label className="text-label-sm font-medium">
+                {t('document.void.reason_label')}
+                <span className="ml-1 text-danger text-label-xs">
+                  {t('common.required_marker')}
+                </span>
+              </label>
+              <Input
+                type="text"
+                placeholder={t('document.void.reason_placeholder')}
+                {...register('void_reason')}
+              />
+              {errors.void_reason !== undefined && (
+                <Text tone="danger" className="text-label-xs">
+                  {t('common.required_marker')}
+                </Text>
+              )}
+            </div>
+
+            <div className="flex flex-col gap-stack-xs">
+              <label className="text-label-sm font-medium">{t('document.void.note_label')}</label>
+              <textarea
+                {...register('void_note')}
+                rows={3}
+                className="rounded-md border border-border bg-surface px-inline-sm py-stack-xs text-body-sm focus:outline-none focus:ring-2 focus:ring-brand resize-none"
+              />
+            </div>
+
+            {submitError !== null && (
+              <Text tone="danger" className="text-body-sm">
+                {t(submitError)}
+              </Text>
+            )}
+
+            <div className="flex justify-end gap-inline-md">
+              <Button type="button" variant="secondary" onClick={onClose} disabled={isSubmitting}>
+                {t('common.buttons.cancel')}
+              </Button>
+              <Button type="submit" variant="danger" disabled={isSubmitting}>
+                {isSubmitting ? t('common.status.processing') : t('document.void.confirm_button')}
+              </Button>
+            </div>
+          </Stack>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/AuditPage.tsx
+++ b/frontend/src/pages/AuditPage.tsx
@@ -1,0 +1,201 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuditEvents } from '@/entities/audit';
+import type { ListAuditEventsParams } from '@/entities/audit';
+import { authStore } from '@/entities/auth';
+import { useTranslation } from '@/shared/i18n/use-translation';
+import { AppShell, Button, Input, Stack, Text } from '@/shared/ui';
+import { Pagination } from '@/features/document-search';
+
+const PAGE_SIZE = 20;
+
+export function AuditPage() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  const [filterEntityType, setFilterEntityType] = useState('');
+  const [filterEntityId, setFilterEntityId] = useState('');
+  const [filterAction, setFilterAction] = useState('');
+  const [committed, setCommitted] = useState<ListAuditEventsParams>({
+    limit: PAGE_SIZE,
+    offset: 0,
+  });
+  const [offset, setOffset] = useState(0);
+
+  const params: ListAuditEventsParams = { ...committed, offset };
+  const { data, isLoading, isError } = useAuditEvents(params);
+
+  const events = data?.items ?? [];
+  const total = data?.total ?? 0;
+
+  function handleSearch() {
+    setOffset(0);
+    setCommitted({
+      limit: PAGE_SIZE,
+      offset: 0,
+      entity_type: filterEntityType !== '' ? filterEntityType : undefined,
+      entity_id: filterEntityId !== '' ? filterEntityId : undefined,
+      action: filterAction !== '' ? filterAction : undefined,
+    });
+  }
+
+  function handleLogout() {
+    authStore.clearSession();
+    navigate('/login', { replace: true });
+  }
+
+  function handleReset() {
+    setFilterEntityType('');
+    setFilterEntityId('');
+    setFilterAction('');
+    setOffset(0);
+    setCommitted({ limit: PAGE_SIZE, offset: 0 });
+  }
+
+  return (
+    <AppShell onLogout={handleLogout}>
+      <Stack gap="lg">
+        <Text as="h1" className="text-heading-md">
+          {t('audit_event.list.title')}
+        </Text>
+
+        <div className="rounded-lg border border-border bg-surface-raised p-stack-md">
+          <div className="grid grid-cols-3 gap-inline-md">
+            <div className="flex flex-col gap-stack-xs">
+              <label className="text-label-sm text-muted">
+                {t('audit_event.list.filter.entity_type_label')}
+              </label>
+              <Input
+                type="text"
+                value={filterEntityType}
+                onChange={(e) => {
+                  setFilterEntityType(e.target.value);
+                }}
+              />
+            </div>
+            <div className="flex flex-col gap-stack-xs">
+              <label className="text-label-sm text-muted">
+                {t('audit_event.list.filter.entity_id_label')}
+              </label>
+              <Input
+                type="text"
+                value={filterEntityId}
+                onChange={(e) => {
+                  setFilterEntityId(e.target.value);
+                }}
+              />
+            </div>
+            <div className="flex flex-col gap-stack-xs">
+              <label className="text-label-sm text-muted">
+                {t('audit_event.list.filter.action_label')}
+              </label>
+              <Input
+                type="text"
+                value={filterAction}
+                onChange={(e) => {
+                  setFilterAction(e.target.value);
+                }}
+              />
+            </div>
+          </div>
+          <div className="mt-stack-md flex gap-inline-md">
+            <Button variant="primary" onClick={handleSearch} disabled={isLoading}>
+              {t('document.search.search_button')}
+            </Button>
+            <Button variant="secondary" onClick={handleReset}>
+              {t('document.search.reset_button')}
+            </Button>
+          </div>
+        </div>
+
+        {isError && <Text tone="danger">{t('common.status.error')}</Text>}
+
+        {isLoading ? (
+          <Text tone="muted">{t('common.status.loading')}</Text>
+        ) : (
+          <div className="rounded-lg border border-border bg-surface">
+            {events.length === 0 ? (
+              <div className="flex items-center justify-center py-stack-xl">
+                <Text tone="muted">{t('audit_event.list.empty')}</Text>
+              </div>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="w-full border-collapse text-body-sm">
+                  <thead>
+                    <tr className="border-b border-border bg-surface-raised">
+                      <th className="px-inline-md py-stack-sm text-left text-label-sm font-medium text-muted">
+                        {t('audit_event.list.table.action')}
+                      </th>
+                      <th className="px-inline-md py-stack-sm text-left text-label-sm font-medium text-muted">
+                        {t('audit_event.list.table.entity')}
+                      </th>
+                      <th className="px-inline-md py-stack-sm text-left text-label-sm font-medium text-muted">
+                        {t('audit_event.list.table.actor')}
+                      </th>
+                      <th className="px-inline-md py-stack-sm text-left text-label-sm font-medium text-muted">
+                        {t('audit_event.list.table.timestamp')}
+                      </th>
+                      <th className="px-inline-md py-stack-sm text-left text-label-sm font-medium text-muted">
+                        {t('audit_event.list.table.before')}
+                      </th>
+                      <th className="px-inline-md py-stack-sm text-left text-label-sm font-medium text-muted">
+                        {t('audit_event.list.table.after')}
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {events.map((event) => (
+                      <tr key={event.id} className="border-b border-border hover:bg-surface-raised">
+                        <td className="px-inline-md py-stack-sm font-medium">{event.action}</td>
+                        <td className="px-inline-md py-stack-sm text-muted">
+                          {event.entity_type}/{event.entity_id}
+                        </td>
+                        <td className="px-inline-md py-stack-sm text-muted">
+                          {event.actor_user_id !== null ? String(event.actor_user_id) : '—'}
+                        </td>
+                        <td className="px-inline-md py-stack-sm text-muted">
+                          {event.created_at.slice(0, 16).replace('T', ' ')}
+                        </td>
+                        <td className="px-inline-md py-stack-sm">
+                          {event.before_json !== null ? (
+                            <pre className="text-label-xs text-muted max-w-48 overflow-hidden whitespace-pre-wrap">
+                              {JSON.stringify(event.before_json, null, 2)}
+                            </pre>
+                          ) : (
+                            '—'
+                          )}
+                        </td>
+                        <td className="px-inline-md py-stack-sm">
+                          {event.after_json !== null ? (
+                            <pre className="text-label-xs text-muted max-w-48 overflow-hidden whitespace-pre-wrap">
+                              {JSON.stringify(event.after_json, null, 2)}
+                            </pre>
+                          ) : (
+                            '—'
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+            <Pagination
+              offset={offset}
+              limit={PAGE_SIZE}
+              total={total}
+              canPrev={offset > 0}
+              canNext={offset + PAGE_SIZE < total}
+              onPrev={() => {
+                setOffset((o) => Math.max(0, o - PAGE_SIZE));
+              }}
+              onNext={() => {
+                setOffset((o) => o + PAGE_SIZE);
+              }}
+            />
+          </div>
+        )}
+      </Stack>
+    </AppShell>
+  );
+}

--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -1,0 +1,241 @@
+import { useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useDocumentById } from '@/entities/document';
+import { useDocumentHistory } from '@/entities/audit';
+import { authStore } from '@/entities/auth';
+import {
+  VoidModal,
+  RestoreModal,
+  MetadataEditModal,
+  DocumentHistoryTable,
+} from '@/features/document-detail';
+import { useTranslation } from '@/shared/i18n/use-translation';
+import { AppShell, Button, Stack, Text } from '@/shared/ui';
+import { env } from '@/shared/config/env';
+
+type Modal = 'void' | 'restore' | 'metadata-edit' | null;
+
+function formatAmount(cents: number | null): string {
+  if (cents === null) return '—';
+  return new Intl.NumberFormat('ja-JP', { style: 'currency', currency: 'JPY' }).format(cents);
+}
+
+export function DocumentDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const [modal, setModal] = useState<Modal>(null);
+
+  const docId = id ?? '';
+  const { data: doc, isLoading, isError } = useDocumentById(docId);
+  const { data: history } = useDocumentHistory(docId);
+
+  function handleLogout() {
+    authStore.clearSession();
+    navigate('/login', { replace: true });
+  }
+
+  function handleDownload() {
+    if (doc === undefined) return;
+    const base = env.apiBaseUrl.replace(/\/$/, '');
+    const url = `${base}/admin/vault/documents/${doc.id}/versions/${String(doc.version_number)}/download`;
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = doc.original_filename ?? `document-${doc.id}`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+  }
+
+  return (
+    <AppShell onLogout={handleLogout}>
+      <div className="max-w-4xl">
+        <div className="mb-stack-md">
+          <button
+            type="button"
+            onClick={() => {
+              navigate('/documents');
+            }}
+            className="text-brand text-body-sm hover:underline"
+          >
+            ← {t('navigation.documents')}
+          </button>
+        </div>
+
+        {isLoading && <Text tone="muted">{t('common.status.loading')}</Text>}
+        {isError && <Text tone="danger">{t('common.status.error')}</Text>}
+
+        {doc !== undefined && (
+          <Stack gap="lg">
+            <div className="flex items-start justify-between">
+              <div>
+                <Text as="h1" className="text-heading-md">
+                  {doc.counterparty_name}
+                </Text>
+                <div className="mt-stack-xs flex items-center gap-inline-sm">
+                  <span
+                    className={
+                      doc.status === 'voided'
+                        ? 'inline-flex rounded-full px-inline-sm py-stack-xs text-label-xs bg-danger-muted text-danger'
+                        : 'inline-flex rounded-full px-inline-sm py-stack-xs text-label-xs bg-success-muted text-success'
+                    }
+                  >
+                    {t(`document.status.${doc.status}`)}
+                  </span>
+                  {doc.date_uncertain && (
+                    <span className="inline-flex rounded-full px-inline-sm py-stack-xs text-label-xs bg-warning-muted text-warning">
+                      {t('document.detail.date_uncertain_badge')}
+                    </span>
+                  )}
+                  {!doc.is_metadata_confirmed && (
+                    <span className="inline-flex rounded-full px-inline-sm py-stack-xs text-label-xs bg-muted-bg text-muted">
+                      {t('document.detail.metadata_unconfirmed_badge')}
+                    </span>
+                  )}
+                </div>
+              </div>
+
+              <div className="flex gap-inline-md">
+                <Button variant="secondary" onClick={handleDownload}>
+                  {t('document.detail.download_button')}
+                </Button>
+                <Button
+                  variant="secondary"
+                  onClick={() => {
+                    setModal('metadata-edit');
+                  }}
+                >
+                  {t('common.buttons.edit')}
+                </Button>
+                {doc.status === 'active' ? (
+                  <Button
+                    variant="danger"
+                    onClick={() => {
+                      setModal('void');
+                    }}
+                  >
+                    {t('common.buttons.void')}
+                  </Button>
+                ) : (
+                  <Button
+                    variant="secondary"
+                    onClick={() => {
+                      setModal('restore');
+                    }}
+                  >
+                    {t('common.buttons.restore')}
+                  </Button>
+                )}
+              </div>
+            </div>
+
+            <section className="rounded-lg border border-border bg-surface p-stack-md">
+              <Text as="h2" className="mb-stack-md text-heading-sm">
+                {t('document.detail.metadata_section')}
+              </Text>
+              <dl className="grid grid-cols-2 gap-x-inline-lg gap-y-stack-sm text-body-sm">
+                <div>
+                  <dt className="text-label-sm text-muted">
+                    {t('document.metadata.transaction_date')}
+                  </dt>
+                  <dd className="mt-stack-xs">{doc.transaction_date ?? '—'}</dd>
+                </div>
+                <div>
+                  <dt className="text-label-sm text-muted">
+                    {t('document.metadata.amount_cents')}
+                  </dt>
+                  <dd className="mt-stack-xs tabular-nums">{formatAmount(doc.amount_cents)}</dd>
+                </div>
+                <div>
+                  <dt className="text-label-sm text-muted">{t('document.metadata.category')}</dt>
+                  <dd className="mt-stack-xs">{t(`document.category.${doc.category}`)}</dd>
+                </div>
+                <div>
+                  <dt className="text-label-sm text-muted">{t('document.metadata.source')}</dt>
+                  <dd className="mt-stack-xs">{t(`document.source.${doc.source}`)}</dd>
+                </div>
+                <div>
+                  <dt className="text-label-sm text-muted">{t('document.metadata.uploaded_at')}</dt>
+                  <dd className="mt-stack-xs">{doc.uploaded_at.slice(0, 16).replace('T', ' ')}</dd>
+                </div>
+                <div>
+                  <dt className="text-label-sm text-muted">
+                    {t('document.metadata.retention_expires_at')}
+                  </dt>
+                  <dd className="mt-stack-xs">{doc.retention_expires_at}</dd>
+                </div>
+                {doc.tags.length > 0 && (
+                  <div className="col-span-2">
+                    <dt className="text-label-sm text-muted">{t('document.metadata.tags')}</dt>
+                    <dd className="mt-stack-xs flex flex-wrap gap-inline-sm">
+                      {doc.tags.map((tag) => (
+                        <span
+                          key={tag}
+                          className="rounded-full bg-surface-raised px-inline-sm py-stack-xs text-label-xs"
+                        >
+                          {tag}
+                        </span>
+                      ))}
+                    </dd>
+                  </div>
+                )}
+              </dl>
+            </section>
+
+            <section className="rounded-lg border border-border bg-surface p-stack-md">
+              <Text as="h2" className="mb-stack-md text-heading-sm">
+                {t('document.detail.file_section')}
+              </Text>
+              <dl className="grid grid-cols-2 gap-x-inline-lg gap-y-stack-sm text-body-sm">
+                <div>
+                  <dt className="text-label-sm text-muted">
+                    {t('document.metadata.version_number')}
+                  </dt>
+                  <dd className="mt-stack-xs">{doc.version_number}</dd>
+                </div>
+                <div>
+                  <dt className="text-label-sm text-muted">{t('document.metadata.file_sha256')}</dt>
+                  <dd className="mt-stack-xs font-mono text-label-xs break-all">
+                    {doc.file_sha256}
+                  </dd>
+                </div>
+              </dl>
+            </section>
+
+            <section className="rounded-lg border border-border bg-surface p-stack-md">
+              <Text as="h2" className="mb-stack-md text-heading-sm">
+                {t('document.history.title')}
+              </Text>
+              <DocumentHistoryTable events={history?.audit_events ?? []} />
+            </section>
+          </Stack>
+        )}
+      </div>
+
+      {modal === 'void' && doc !== undefined && (
+        <VoidModal
+          documentId={doc.id}
+          onClose={() => {
+            setModal(null);
+          }}
+        />
+      )}
+      {modal === 'restore' && doc !== undefined && (
+        <RestoreModal
+          documentId={doc.id}
+          onClose={() => {
+            setModal(null);
+          }}
+        />
+      )}
+      {modal === 'metadata-edit' && doc !== undefined && (
+        <MetadataEditModal
+          doc={doc}
+          onClose={() => {
+            setModal(null);
+          }}
+        />
+      )}
+    </AppShell>
+  );
+}

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -7,10 +7,9 @@ import {
   Pagination,
 } from '@/features/document-search';
 import { DocumentUploadModal } from '@/features/document-upload';
-import { useTranslation } from '@/shared/i18n/use-translation';
-import { Button, Stack, Text } from '@/shared/ui';
-import { LanguageSwitcher } from '@/shared/ui/components/LanguageSwitcher';
 import { authStore } from '@/entities/auth';
+import { useTranslation } from '@/shared/i18n/use-translation';
+import { AppShell, Button, Stack, Text } from '@/shared/ui';
 
 export function DocumentsPage() {
   const { t } = useTranslation();
@@ -29,72 +28,53 @@ export function DocumentsPage() {
   }
 
   return (
-    <div className="min-h-screen bg-surface">
-      <header className="flex items-center gap-inline-lg border-b border-border bg-surface-raised px-inline-lg py-stack-sm">
-        <Text as="span" className="text-heading-sm">
-          NeNe Vault
-        </Text>
-        <nav className="flex gap-inline-md">
-          <Text as="span" className="font-medium text-brand">
-            {t('navigation.documents')}
+    <AppShell onLogout={handleLogout}>
+      <Stack gap="lg">
+        <div className="flex items-center justify-between">
+          <Text as="h1" className="text-heading-md">
+            {t('document.list.title')}
           </Text>
-        </nav>
-        <div className="ml-auto flex items-center gap-inline-md">
-          <LanguageSwitcher />
-          <Button variant="secondary" onClick={handleLogout}>
-            {t('navigation.logout')}
+          <Button
+            variant="primary"
+            onClick={() => {
+              setShowUpload(true);
+            }}
+          >
+            {t('document.list.upload_button')}
           </Button>
         </div>
-      </header>
 
-      <main className="mx-auto max-w-7xl px-inline-lg py-stack-lg">
-        <Stack gap="lg">
-          <div className="flex items-center justify-between">
-            <Text as="h1" className="text-heading-md">
-              {t('document.list.title')}
-            </Text>
-            <Button
-              variant="primary"
-              onClick={() => {
-                setShowUpload(true);
+        <DocumentSearchForm
+          form={form}
+          onSubmit={onSubmit}
+          onReset={onReset}
+          isLoading={isLoading}
+        />
+
+        {isError && <Text tone="danger">{t('common.status.error')}</Text>}
+
+        {isLoading ? (
+          <Text tone="muted">{t('common.status.loading')}</Text>
+        ) : (
+          <div className="rounded-lg border border-border bg-surface">
+            <DocumentTable
+              documents={documents}
+              onSelectDocument={(id) => {
+                navigate(`/documents/${id}`);
               }}
-            >
-              {t('document.list.upload_button')}
-            </Button>
+            />
+            <Pagination
+              offset={pagination.offset}
+              limit={pagination.limit}
+              total={pagination.total}
+              canPrev={pagination.canPrev}
+              canNext={pagination.canNext}
+              onPrev={pagination.goPrev}
+              onNext={pagination.goNext}
+            />
           </div>
-
-          <DocumentSearchForm
-            form={form}
-            onSubmit={onSubmit}
-            onReset={onReset}
-            isLoading={isLoading}
-          />
-
-          {isError && <Text tone="danger">{t('common.status.error')}</Text>}
-
-          {isLoading ? (
-            <Text tone="muted">{t('common.status.loading')}</Text>
-          ) : (
-            <div className="rounded-lg border border-border bg-surface">
-              <DocumentTable
-                documents={documents}
-                onSelectDocument={(id) => {
-                  navigate(`/documents/${id}`);
-                }}
-              />
-              <Pagination
-                offset={pagination.offset}
-                limit={pagination.limit}
-                total={pagination.total}
-                canPrev={pagination.canPrev}
-                canNext={pagination.canNext}
-                onPrev={pagination.goPrev}
-                onNext={pagination.goNext}
-              />
-            </div>
-          )}
-        </Stack>
-      </main>
+        )}
+      </Stack>
 
       {showUpload && (
         <DocumentUploadModal
@@ -103,6 +83,6 @@ export function DocumentsPage() {
           }}
         />
       )}
-    </div>
+    </AppShell>
   );
 }

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,8 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import { authStore } from '@/entities/auth';
 import { useTranslation } from '@/shared/i18n/use-translation';
-import { Button, Stack, Text } from '@/shared/ui';
-import { LanguageSwitcher } from '@/shared/ui/components/LanguageSwitcher';
+import { AppShell, Stack, Text } from '@/shared/ui';
 
 export function HomePage() {
   const { t } = useTranslation();
@@ -15,42 +14,51 @@ export function HomePage() {
   }
 
   return (
-    <div className="min-h-screen bg-surface">
-      <header className="flex items-center gap-inline-lg border-b border-border bg-surface-raised px-inline-lg py-stack-sm">
-        <Text as="span" className="text-heading-sm">
-          NeNe Vault
-        </Text>
-        <nav className="flex gap-inline-md">
-          <Text as="span" tone="muted">
-            {t('navigation.documents')}
+    <AppShell onLogout={handleLogout}>
+      <Stack gap="lg">
+        <div>
+          <Text as="h1" className="text-heading-md">
+            NeNe Vault
           </Text>
-          <Text as="span" tone="muted">
-            {t('navigation.audit_events')}
-          </Text>
-          <Text as="span" tone="muted">
-            {t('navigation.settings')}
-          </Text>
-        </nav>
-        <div className="ml-auto flex items-center gap-inline-md">
-          <LanguageSwitcher />
           {session !== null && (
-            <Text as="span" tone="muted">
-              {session.email} ({t(`user.role.${session.role}`)})
+            <Text tone="muted" className="mt-stack-xs">
+              {session.email}
             </Text>
           )}
-          <Button variant="secondary" onClick={handleLogout}>
-            {t('navigation.logout')}
-          </Button>
         </div>
-      </header>
-      <main className="p-inline-lg">
-        <Stack gap="md">
-          <Text as="h1" className="text-heading-md">
-            {t('navigation.documents')}
-          </Text>
-          <Text tone="muted">{t('document.list.empty')}</Text>
-        </Stack>
-      </main>
-    </div>
+
+        <div className="grid grid-cols-2 gap-inline-lg">
+          <button
+            type="button"
+            onClick={() => {
+              navigate('/documents');
+            }}
+            className="rounded-lg border border-border bg-surface-raised p-stack-lg text-left hover:bg-surface transition-colors"
+          >
+            <Text as="h2" className="text-heading-sm">
+              {t('navigation.documents')}
+            </Text>
+            <Text tone="muted" className="mt-stack-xs text-body-sm">
+              {t('document.list.title')}
+            </Text>
+          </button>
+
+          <button
+            type="button"
+            onClick={() => {
+              navigate('/audit');
+            }}
+            className="rounded-lg border border-border bg-surface-raised p-stack-lg text-left hover:bg-surface transition-colors"
+          >
+            <Text as="h2" className="text-heading-sm">
+              {t('navigation.audit_events')}
+            </Text>
+            <Text tone="muted" className="mt-stack-xs text-body-sm">
+              {t('audit_event.list.title')}
+            </Text>
+          </button>
+        </div>
+      </Stack>
+    </AppShell>
   );
 }

--- a/frontend/src/shared/ui/components/AppShell.tsx
+++ b/frontend/src/shared/ui/components/AppShell.tsx
@@ -1,0 +1,83 @@
+import { useNavigate, useLocation } from 'react-router-dom';
+import { useTranslation } from '@/shared/i18n/use-translation';
+import { LanguageSwitcher } from './LanguageSwitcher';
+
+interface NavLinkProps {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}
+
+function NavLink({ label, active, onClick }: NavLinkProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={
+        active
+          ? 'text-brand text-body-sm font-medium'
+          : 'text-muted text-body-sm hover:text-foreground transition-colors'
+      }
+    >
+      {label}
+    </button>
+  );
+}
+
+interface AppShellProps {
+  children: React.ReactNode;
+  onLogout: () => void;
+}
+
+export function AppShell({ children, onLogout }: AppShellProps) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+
+  const navLinks = [
+    { to: '/documents', label: t('navigation.documents') },
+    { to: '/audit', label: t('navigation.audit_events') },
+  ];
+
+  return (
+    <div className="min-h-screen bg-surface">
+      <header className="sticky top-0 z-40 flex items-center gap-inline-lg border-b border-border bg-surface-raised px-inline-lg py-stack-sm">
+        <button
+          type="button"
+          onClick={() => {
+            navigate('/');
+          }}
+          className="text-heading-sm font-semibold hover:opacity-80 transition-opacity"
+        >
+          NeNe Vault
+        </button>
+
+        <nav className="flex gap-inline-md">
+          {navLinks.map((link) => (
+            <NavLink
+              key={link.to}
+              label={link.label}
+              active={pathname.startsWith(link.to)}
+              onClick={() => {
+                navigate(link.to);
+              }}
+            />
+          ))}
+        </nav>
+
+        <div className="ml-auto flex items-center gap-inline-md">
+          <LanguageSwitcher />
+          <button
+            type="button"
+            onClick={onLogout}
+            className="text-body-sm text-muted hover:text-foreground transition-colors"
+          >
+            {t('navigation.logout')}
+          </button>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-7xl px-inline-lg py-stack-lg">{children}</main>
+    </div>
+  );
+}

--- a/frontend/src/shared/ui/index.ts
+++ b/frontend/src/shared/ui/index.ts
@@ -3,3 +3,4 @@ export { Button } from './primitives/Button';
 export { Input } from './primitives/Input';
 export { Text } from './primitives/Text';
 export { Stack } from './primitives/Stack';
+export { AppShell } from './components/AppShell';


### PR DESCRIPTION
## Summary

Three features in one branch:

**Document detail page** (`/documents/:id`) — closes #41
- Metadata display (dl grid), void/restore/metadata-edit modals (RHF+Zod), change history table, file download
- New entity mutations: `useUpdateDocumentMetadata`, `useVoidDocument`, `useRestoreDocument`
- New entity queries: `useAuditEvents`, `useDocumentHistory`

**Audit log page** (`/audit`) — closes #42
- Filter form (entity_type, entity_id, action), before/after diff columns, pagination

**App shell navigation** — closes #43
- `AppShell` component: sticky header, logo, nav links (documents/audit), language switcher, logout
- All authenticated pages now use `AppShell` — no per-page duplicate headers
- FSD-compliant: `AppShell` receives `onLogout` callback; doesn't import entities

## Verification
`npm run check` → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)