### PR TITLE
feat(frontend): settings, user management, export pages

### DIFF
--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -4,42 +4,24 @@ import { HomePage } from '@/pages/HomePage';
 import { DocumentsPage } from '@/pages/DocumentsPage';
 import { DocumentDetailPage } from '@/pages/DocumentDetailPage';
 import { AuditPage } from '@/pages/AuditPage';
+import { SettingsPage } from '@/pages/SettingsPage';
+import { UsersPage } from '@/pages/UsersPage';
+import { ExportPage } from '@/pages/ExportPage';
 import { ForbiddenPage } from '@/pages/ForbiddenPage';
 import { AuthGate } from './auth-gate';
+
+function guarded(element: React.ReactElement) {
+  return <AuthGate>{element}</AuthGate>;
+}
 
 export const router = createBrowserRouter([
   { path: '/login', element: <LoginPage /> },
   { path: '/forbidden', element: <ForbiddenPage /> },
-  {
-    path: '/',
-    element: (
-      <AuthGate>
-        <HomePage />
-      </AuthGate>
-    ),
-  },
-  {
-    path: '/documents',
-    element: (
-      <AuthGate>
-        <DocumentsPage />
-      </AuthGate>
-    ),
-  },
-  {
-    path: '/documents/:id',
-    element: (
-      <AuthGate>
-        <DocumentDetailPage />
-      </AuthGate>
-    ),
-  },
-  {
-    path: '/audit',
-    element: (
-      <AuthGate>
-        <AuditPage />
-      </AuthGate>
-    ),
-  },
+  { path: '/', element: guarded(<HomePage />) },
+  { path: '/documents', element: guarded(<DocumentsPage />) },
+  { path: '/documents/:id', element: guarded(<DocumentDetailPage />) },
+  { path: '/audit', element: guarded(<AuditPage />) },
+  { path: '/settings', element: guarded(<SettingsPage />) },
+  { path: '/users', element: guarded(<UsersPage />) },
+  { path: '/export', element: guarded(<ExportPage />) },
 ]);

--- a/frontend/src/entities/user/index.ts
+++ b/frontend/src/entities/user/index.ts
@@ -1,0 +1,9 @@
+export type {
+  User,
+  UserListResponse,
+  CreateUserInput,
+  UpdateUserInput,
+  UserRole,
+  UserStatus,
+} from './types';
+export { useUsers, useCreateUser, useUpdateUser, useDeleteUser, userQueryKeys } from './queries';

--- a/frontend/src/entities/user/queries.ts
+++ b/frontend/src/entities/user/queries.ts
@@ -1,0 +1,62 @@
+import { useQuery, useMutation, useQueryClient, type UseQueryResult } from '@tanstack/react-query';
+import { apiClient } from '@/shared/api/client';
+import type { AppError } from '@/shared/api/errors';
+import type { CreateUserInput, UpdateUserInput, User, UserListResponse } from './types';
+
+const userQueryKeys = {
+  all: ['users'] as const,
+  list: (limit: number, offset: number) => ['users', 'list', limit, offset] as const,
+  detail: (id: number) => ['users', 'detail', id] as const,
+} as const;
+
+export function useUsers(
+  limit: number,
+  offset: number,
+): UseQueryResult<UserListResponse, AppError> {
+  return useQuery<UserListResponse, AppError>({
+    queryKey: userQueryKeys.list(limit, offset),
+    queryFn: ({ signal }) =>
+      apiClient.get<UserListResponse>(
+        `/admin/users?limit=${String(limit)}&offset=${String(offset)}`,
+        signal,
+      ),
+  });
+}
+
+export function useCreateUser(onSuccess?: () => void) {
+  const queryClient = useQueryClient();
+
+  return useMutation<User, AppError, CreateUserInput>({
+    mutationFn: (body) => apiClient.post<User>('/admin/users', body),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: userQueryKeys.all });
+      onSuccess?.();
+    },
+  });
+}
+
+export function useUpdateUser(onSuccess?: () => void) {
+  const queryClient = useQueryClient();
+
+  return useMutation<User, AppError, { id: number } & UpdateUserInput>({
+    mutationFn: ({ id, ...body }) => apiClient.patch<User>(`/admin/users/${String(id)}`, body),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: userQueryKeys.all });
+      onSuccess?.();
+    },
+  });
+}
+
+export function useDeleteUser(onSuccess?: () => void) {
+  const queryClient = useQueryClient();
+
+  return useMutation<undefined, AppError, number>({
+    mutationFn: (id) => apiClient.delete<undefined>(`/admin/users/${String(id)}`),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: userQueryKeys.all });
+      onSuccess?.();
+    },
+  });
+}
+
+export { userQueryKeys };

--- a/frontend/src/entities/user/types.ts
+++ b/frontend/src/entities/user/types.ts
@@ -1,0 +1,31 @@
+export type UserRole = 'superadmin' | 'admin' | 'member' | 'viewer';
+export type UserStatus = 'active' | 'invited';
+
+export interface User {
+  id: number;
+  email: string;
+  role: UserRole;
+  organization_id: number | null;
+  status: UserStatus;
+  created_at: string | undefined;
+  updated_at: string | undefined;
+}
+
+export interface UserListResponse {
+  items: User[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface CreateUserInput {
+  email: string;
+  password: string;
+  role: UserRole;
+}
+
+export interface UpdateUserInput {
+  email?: string | undefined;
+  role?: UserRole | undefined;
+  status?: UserStatus | undefined;
+}

--- a/frontend/src/entities/vault-settings/index.ts
+++ b/frontend/src/entities/vault-settings/index.ts
@@ -1,0 +1,2 @@
+export type { VaultSettings, UpdateVaultSettingsInput } from './types';
+export { useVaultSettings, useUpdateVaultSettings } from './queries';

--- a/frontend/src/entities/vault-settings/queries.ts
+++ b/frontend/src/entities/vault-settings/queries.ts
@@ -1,0 +1,25 @@
+import { useQuery, useMutation, useQueryClient, type UseQueryResult } from '@tanstack/react-query';
+import { apiClient } from '@/shared/api/client';
+import type { AppError } from '@/shared/api/errors';
+import type { UpdateVaultSettingsInput, VaultSettings } from './types';
+
+const QUERY_KEY = ['vault-settings'] as const;
+
+export function useVaultSettings(): UseQueryResult<VaultSettings, AppError> {
+  return useQuery<VaultSettings, AppError>({
+    queryKey: QUERY_KEY,
+    queryFn: ({ signal }) => apiClient.get<VaultSettings>('/admin/vault/settings', signal),
+  });
+}
+
+export function useUpdateVaultSettings(onSuccess?: () => void) {
+  const queryClient = useQueryClient();
+
+  return useMutation<VaultSettings, AppError, UpdateVaultSettingsInput>({
+    mutationFn: (body) => apiClient.patch<VaultSettings>('/admin/vault/settings', body),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+      onSuccess?.();
+    },
+  });
+}

--- a/frontend/src/entities/vault-settings/types.ts
+++ b/frontend/src/entities/vault-settings/types.ts
@@ -1,0 +1,15 @@
+export interface VaultSettings {
+  organization_id: number;
+  retention_years: number;
+  storage_path_override: string | null;
+  invoice_api_base_url: string | null;
+  clear_api_base_url: string | null;
+  updated_at: string | null;
+}
+
+export interface UpdateVaultSettingsInput {
+  retention_years?: number | undefined;
+  storage_path_override?: string | null | undefined;
+  invoice_api_base_url?: string | null | undefined;
+  clear_api_base_url?: string | null | undefined;
+}

--- a/frontend/src/pages/ExportPage.tsx
+++ b/frontend/src/pages/ExportPage.tsx
@@ -1,0 +1,168 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { authStore } from '@/entities/auth';
+import { useTranslation } from '@/shared/i18n/use-translation';
+import { AppShell, Button, Stack, Text } from '@/shared/ui';
+import { env } from '@/shared/config/env';
+
+export function ExportPage() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const [dateFrom, setDateFrom] = useState('');
+  const [dateTo, setDateTo] = useState('');
+  const [counterparty, setCounterparty] = useState('');
+  const [includeVoided, setIncludeVoided] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
+  const [exportError, setExportError] = useState<string | null>(null);
+  const [exportSuccess, setExportSuccess] = useState(false);
+
+  function handleLogout() {
+    authStore.clearSession();
+    navigate('/login', { replace: true });
+  }
+
+  async function handleExport() {
+    setIsExporting(true);
+    setExportError(null);
+    setExportSuccess(false);
+
+    try {
+      const base = env.apiBaseUrl.replace(/\/$/, '');
+      const body: Record<string, unknown> = { include_voided: includeVoided };
+      if (dateFrom !== '') body['transaction_date_from'] = dateFrom;
+      if (dateTo !== '') body['transaction_date_to'] = dateTo;
+      if (counterparty !== '') body['counterparty_name'] = counterparty;
+
+      const token = authStore.getToken();
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+      if (token !== null) headers['Authorization'] = `Bearer ${token}`;
+
+      const response = await fetch(`${base}/admin/vault/export`, {
+        method: 'POST',
+        headers,
+        credentials: 'include',
+        body: JSON.stringify(body),
+      });
+
+      if (!response.ok) {
+        setExportError(t('common.status.error'));
+        return;
+      }
+
+      const blob = await response.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      const cd = response.headers.get('Content-Disposition') ?? '';
+      const match = /filename="?([^"]+)"?/.exec(cd);
+      a.download = match?.[1] ?? 'export.zip';
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+      setExportSuccess(true);
+    } catch {
+      setExportError(t('common.status.error'));
+    } finally {
+      setIsExporting(false);
+    }
+  }
+
+  return (
+    <AppShell onLogout={handleLogout}>
+      <div className="max-w-2xl">
+        <Stack gap="lg">
+          <Text as="h1" className="text-heading-md">
+            {t('export.title')}
+          </Text>
+
+          <Text tone="muted" className="text-body-sm">
+            {t('export.description')}
+          </Text>
+
+          <div className="rounded-lg border border-border bg-surface p-stack-md">
+            <Stack gap="md">
+              <div className="grid grid-cols-2 gap-inline-md">
+                <div className="flex flex-col gap-stack-xs">
+                  <label className="text-label-sm font-medium">
+                    {t('export.form.date_from_label')}
+                  </label>
+                  <input
+                    type="date"
+                    value={dateFrom}
+                    onChange={(e) => {
+                      setDateFrom(e.target.value);
+                    }}
+                    className="h-10 rounded-md border border-border bg-surface px-inline-sm text-body-sm focus:outline-none focus:ring-2 focus:ring-brand"
+                  />
+                </div>
+                <div className="flex flex-col gap-stack-xs">
+                  <label className="text-label-sm font-medium">
+                    {t('export.form.date_to_label')}
+                  </label>
+                  <input
+                    type="date"
+                    value={dateTo}
+                    onChange={(e) => {
+                      setDateTo(e.target.value);
+                    }}
+                    className="h-10 rounded-md border border-border bg-surface px-inline-sm text-body-sm focus:outline-none focus:ring-2 focus:ring-brand"
+                  />
+                </div>
+              </div>
+
+              <div className="flex flex-col gap-stack-xs">
+                <label className="text-label-sm font-medium">
+                  {t('export.form.counterparty_label')}
+                </label>
+                <input
+                  type="text"
+                  value={counterparty}
+                  onChange={(e) => {
+                    setCounterparty(e.target.value);
+                  }}
+                  className="h-10 rounded-md border border-border bg-surface px-inline-sm text-body-sm focus:outline-none focus:ring-2 focus:ring-brand"
+                />
+              </div>
+
+              <label className="flex items-center gap-inline-sm cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={includeVoided}
+                  onChange={(e) => {
+                    setIncludeVoided(e.target.checked);
+                  }}
+                  className="h-4 w-4 rounded border-border text-brand focus:ring-brand"
+                />
+                <span className="text-body-sm">{t('export.form.include_voided_label')}</span>
+              </label>
+
+              {exportError !== null && (
+                <Text tone="danger" className="text-body-sm">
+                  {exportError}
+                </Text>
+              )}
+              {exportSuccess && (
+                <Text tone="success" className="text-body-sm">
+                  {t('export.messages.downloaded')}
+                </Text>
+              )}
+
+              <div>
+                <Button
+                  variant="primary"
+                  onClick={() => {
+                    void handleExport();
+                  }}
+                  disabled={isExporting}
+                >
+                  {isExporting ? t('common.status.processing') : t('export.form.submit')}
+                </Button>
+              </div>
+            </Stack>
+          </div>
+        </Stack>
+      </div>
+    </AppShell>
+  );
+}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,0 +1,184 @@
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { authStore } from '@/entities/auth';
+import { useVaultSettings, useUpdateVaultSettings } from '@/entities/vault-settings';
+import { messageKeyForError } from '@/shared/i18n/map-problem-details';
+import { useTranslation } from '@/shared/i18n/use-translation';
+import { AppShell, Button, Input, Stack, Text } from '@/shared/ui';
+import { useNavigate } from 'react-router-dom';
+
+const settingsSchema = z.object({
+  retention_years: z.coerce.number().int().min(7).max(99),
+  storage_path_override: z.string().optional(),
+  invoice_api_base_url: z.string().optional(),
+  clear_api_base_url: z.string().optional(),
+});
+
+type SettingsFormValues = z.infer<typeof settingsSchema>;
+
+export function SettingsPage() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { data: settings, isLoading } = useVaultSettings();
+
+  const form = useForm<SettingsFormValues>({
+    resolver: zodResolver(settingsSchema),
+    defaultValues: {
+      retention_years: 10,
+      storage_path_override: '',
+      invoice_api_base_url: '',
+      clear_api_base_url: '',
+    },
+  });
+
+  const {
+    register,
+    watch,
+    reset,
+    formState: { errors },
+  } = form;
+  const retentionYears = watch('retention_years');
+
+  useEffect(() => {
+    if (settings !== undefined) {
+      reset({
+        retention_years: settings.retention_years,
+        storage_path_override: settings.storage_path_override ?? '',
+        invoice_api_base_url: settings.invoice_api_base_url ?? '',
+        clear_api_base_url: settings.clear_api_base_url ?? '',
+      });
+    }
+  }, [settings, reset]);
+
+  const mutation = useUpdateVaultSettings();
+  const submitError =
+    mutation.error !== null
+      ? (messageKeyForError(mutation.error) ?? 'problem.internal_server_error')
+      : null;
+
+  function handleLogout() {
+    authStore.clearSession();
+    navigate('/login', { replace: true });
+  }
+
+  return (
+    <AppShell onLogout={handleLogout}>
+      <div className="max-w-2xl">
+        <Stack gap="lg">
+          <Text as="h1" className="text-heading-md">
+            {t('vault_settings.title')}
+          </Text>
+
+          {isLoading ? (
+            <Text tone="muted">{t('common.status.loading')}</Text>
+          ) : (
+            <form
+              onSubmit={(e) => {
+                void form.handleSubmit((values) => {
+                  mutation.mutate({
+                    retention_years: values.retention_years,
+                    storage_path_override:
+                      values.storage_path_override !== '' ? values.storage_path_override : null,
+                    invoice_api_base_url:
+                      values.invoice_api_base_url !== '' ? values.invoice_api_base_url : null,
+                    clear_api_base_url:
+                      values.clear_api_base_url !== '' ? values.clear_api_base_url : null,
+                  });
+                })(e);
+              }}
+            >
+              <Stack gap="md">
+                <div className="flex flex-col gap-stack-xs">
+                  <label className="text-label-sm font-medium">
+                    {t('vault_settings.fields.retention_years_label')}
+                  </label>
+                  <Input type="number" min={7} max={99} {...register('retention_years')} />
+                  <Text tone="muted" className="text-label-xs">
+                    {t('vault_settings.fields.retention_years_hint')}
+                  </Text>
+                  {errors.retention_years !== undefined && (
+                    <Text tone="danger" className="text-label-xs">
+                      {t('common.required_marker')}
+                    </Text>
+                  )}
+                  {typeof retentionYears === 'number' && retentionYears < 10 && (
+                    <div className="rounded-md border border-warning bg-warning-muted p-stack-sm">
+                      <Text className="text-label-sm text-warning">
+                        {t('vault_settings.fields.retention_warning')}
+                      </Text>
+                    </div>
+                  )}
+                </div>
+
+                <div className="flex flex-col gap-stack-xs">
+                  <label className="text-label-sm font-medium">
+                    {t('vault_settings.fields.storage_path_label')}
+                  </label>
+                  <Input
+                    type="text"
+                    placeholder={t('vault_settings.fields.storage_path_placeholder')}
+                    {...register('storage_path_override')}
+                  />
+                  <Text tone="muted" className="text-label-xs">
+                    {t('vault_settings.fields.storage_path_hint')}
+                  </Text>
+                </div>
+
+                <div className="flex flex-col gap-stack-xs">
+                  <label className="text-label-sm font-medium">
+                    {t('vault_settings.fields.invoice_api_base_url_label')}
+                  </label>
+                  <Input
+                    type="url"
+                    placeholder={t('vault_settings.fields.invoice_api_base_url_placeholder')}
+                    {...register('invoice_api_base_url')}
+                  />
+                </div>
+
+                <div className="flex flex-col gap-stack-xs">
+                  <label className="text-label-sm font-medium">
+                    {t('vault_settings.fields.clear_api_base_url_label')}
+                  </label>
+                  <Input
+                    type="url"
+                    placeholder={t('vault_settings.fields.clear_api_base_url_placeholder')}
+                    {...register('clear_api_base_url')}
+                  />
+                </div>
+
+                {settings?.updated_at !== null && settings?.updated_at !== undefined && (
+                  <Text tone="muted" className="text-label-xs">
+                    {t('vault_settings.fields.updated_at_label')}:{' '}
+                    {settings.updated_at.slice(0, 16).replace('T', ' ')}
+                  </Text>
+                )}
+
+                {mutation.isSuccess && (
+                  <Text tone="success" className="text-body-sm">
+                    {t('vault_settings.messages.saved')}
+                  </Text>
+                )}
+
+                {submitError !== null && (
+                  <Text tone="danger" className="text-body-sm">
+                    {t(submitError)}
+                  </Text>
+                )}
+
+                <div>
+                  <Button type="submit" variant="primary" disabled={mutation.isPending}>
+                    {mutation.isPending
+                      ? t('common.status.saving')
+                      : t('vault_settings.save_button')}
+                  </Button>
+                </div>
+              </Stack>
+            </form>
+          )}
+        </Stack>
+      </div>
+    </AppShell>
+  );
+}

--- a/frontend/src/pages/UsersPage.tsx
+++ b/frontend/src/pages/UsersPage.tsx
@@ -1,0 +1,287 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { authStore } from '@/entities/auth';
+import { useUsers, useCreateUser, useDeleteUser } from '@/entities/user';
+import type { User } from '@/entities/user';
+import { messageKeyForError } from '@/shared/i18n/map-problem-details';
+import { useTranslation } from '@/shared/i18n/use-translation';
+import { AppShell, Button, Input, Stack, Text } from '@/shared/ui';
+import { Pagination } from '@/features/document-search';
+
+const PAGE_SIZE = 20;
+
+const ROLES = ['admin', 'member', 'viewer'] as const;
+
+const createUserSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(8),
+  role: z.enum(['admin', 'member', 'viewer']),
+});
+
+type CreateUserFormValues = z.infer<typeof createUserSchema>;
+
+function UserFormModal({ onClose }: { onClose: () => void }) {
+  const { t } = useTranslation();
+  const mutation = useCreateUser(onClose);
+  const form = useForm<CreateUserFormValues>({
+    resolver: zodResolver(createUserSchema),
+    defaultValues: { email: '', password: '', role: 'member' },
+  });
+  const {
+    register,
+    formState: { errors },
+  } = form;
+  const submitError =
+    mutation.error !== null
+      ? (messageKeyForError(mutation.error) ?? 'problem.internal_server_error')
+      : null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+    >
+      <div className="w-full max-w-md rounded-xl border border-border bg-surface shadow-lg">
+        <div className="flex items-center justify-between border-b border-border px-inline-lg py-stack-md">
+          <Text as="h2" className="text-heading-sm">
+            {t('user.form.create_title')}
+          </Text>
+          <button type="button" onClick={onClose} className="text-muted hover:text-foreground">
+            ✕
+          </button>
+        </div>
+        <form
+          onSubmit={(e) => {
+            void form.handleSubmit((values) => {
+              mutation.mutate(values);
+            })(e);
+          }}
+          className="p-inline-lg"
+        >
+          <Stack gap="md">
+            <div className="flex flex-col gap-stack-xs">
+              <label className="text-label-sm font-medium">{t('user.form.email_label')}</label>
+              <Input
+                type="email"
+                placeholder={t('user.form.email_placeholder')}
+                {...register('email')}
+              />
+              {errors.email !== undefined && (
+                <Text tone="danger" className="text-label-xs">
+                  {t('common.required_marker')}
+                </Text>
+              )}
+            </div>
+            <div className="flex flex-col gap-stack-xs">
+              <label className="text-label-sm font-medium">{t('user.form.password_label')}</label>
+              <Input
+                type="password"
+                placeholder={t('user.form.password_placeholder')}
+                {...register('password')}
+              />
+              {errors.password !== undefined && (
+                <Text tone="danger" className="text-label-xs">
+                  {t('common.required_marker')}
+                </Text>
+              )}
+            </div>
+            <div className="flex flex-col gap-stack-xs">
+              <label className="text-label-sm font-medium">{t('user.form.role_label')}</label>
+              <select
+                {...register('role')}
+                className="h-10 rounded-md border border-border bg-surface px-inline-sm text-body-sm focus:outline-none focus:ring-2 focus:ring-brand"
+              >
+                {ROLES.map((r) => (
+                  <option key={r} value={r}>
+                    {t(`user.role.${r}`)}
+                  </option>
+                ))}
+              </select>
+            </div>
+            {submitError !== null && (
+              <Text tone="danger" className="text-body-sm">
+                {t(submitError)}
+              </Text>
+            )}
+            <div className="flex justify-end gap-inline-md">
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={onClose}
+                disabled={mutation.isPending}
+              >
+                {t('common.buttons.cancel')}
+              </Button>
+              <Button type="submit" variant="primary" disabled={mutation.isPending}>
+                {mutation.isPending ? t('common.status.saving') : t('common.buttons.invite')}
+              </Button>
+            </div>
+          </Stack>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+function UserRow({
+  user,
+  currentUserId,
+  onDelete,
+}: {
+  user: User;
+  currentUserId: number | null;
+  onDelete: (id: number, email: string) => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <tr className="border-b border-border hover:bg-surface-raised">
+      <td className="px-inline-md py-stack-sm">{user.email}</td>
+      <td className="px-inline-md py-stack-sm">{t(`user.role.${user.role}`)}</td>
+      <td className="px-inline-md py-stack-sm">
+        <span
+          className={
+            user.status === 'active'
+              ? 'inline-flex rounded-full px-inline-sm py-stack-xs text-label-xs bg-success-muted text-success'
+              : 'inline-flex rounded-full px-inline-sm py-stack-xs text-label-xs bg-muted-bg text-muted'
+          }
+        >
+          {t(`user.status.${user.status}`)}
+        </span>
+      </td>
+      <td className="px-inline-md py-stack-sm text-muted">
+        {user.created_at !== undefined ? user.created_at.slice(0, 10) : '—'}
+      </td>
+      <td className="px-inline-md py-stack-sm">
+        {user.id !== currentUserId && (
+          <button
+            type="button"
+            onClick={() => {
+              onDelete(user.id, user.email);
+            }}
+            className="text-danger text-label-sm hover:underline"
+          >
+            {t('common.buttons.delete')}
+          </button>
+        )}
+      </td>
+    </tr>
+  );
+}
+
+export function UsersPage() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const [offset, setOffset] = useState(0);
+  const [showCreate, setShowCreate] = useState(false);
+  const session = authStore.getSession();
+  const currentUserId = session?.userId ?? null;
+
+  const { data, isLoading, isError } = useUsers(PAGE_SIZE, offset);
+  const deleteMutation = useDeleteUser();
+
+  const users = data?.items ?? [];
+  const total = data?.total ?? 0;
+
+  function handleDelete(id: number, email: string) {
+    if (!window.confirm(t('user.messages.delete_confirm', { email }))) return;
+    deleteMutation.mutate(id);
+  }
+
+  function handleLogout() {
+    authStore.clearSession();
+    navigate('/login', { replace: true });
+  }
+
+  return (
+    <AppShell onLogout={handleLogout}>
+      <Stack gap="lg">
+        <div className="flex items-center justify-between">
+          <Text as="h1" className="text-heading-md">
+            {t('user.list.title')}
+          </Text>
+          <Button
+            variant="primary"
+            onClick={() => {
+              setShowCreate(true);
+            }}
+          >
+            {t('user.list.invite_button')}
+          </Button>
+        </div>
+
+        {isError && <Text tone="danger">{t('common.status.error')}</Text>}
+
+        {isLoading ? (
+          <Text tone="muted">{t('common.status.loading')}</Text>
+        ) : (
+          <div className="rounded-lg border border-border bg-surface">
+            {users.length === 0 ? (
+              <div className="flex items-center justify-center py-stack-xl">
+                <Text tone="muted">{t('user.list.empty')}</Text>
+              </div>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="w-full border-collapse text-body-sm">
+                  <thead>
+                    <tr className="border-b border-border bg-surface-raised">
+                      <th className="px-inline-md py-stack-sm text-left text-label-sm font-medium text-muted">
+                        {t('user.list.table.email')}
+                      </th>
+                      <th className="px-inline-md py-stack-sm text-left text-label-sm font-medium text-muted">
+                        {t('user.list.table.role')}
+                      </th>
+                      <th className="px-inline-md py-stack-sm text-left text-label-sm font-medium text-muted">
+                        {t('user.list.table.status')}
+                      </th>
+                      <th className="px-inline-md py-stack-sm text-left text-label-sm font-medium text-muted">
+                        {t('user.list.table.created_at')}
+                      </th>
+                      <th className="px-inline-md py-stack-sm text-left text-label-sm font-medium text-muted">
+                        {t('user.list.table.actions')}
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {users.map((user) => (
+                      <UserRow
+                        key={user.id}
+                        user={user}
+                        currentUserId={currentUserId}
+                        onDelete={handleDelete}
+                      />
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+            <Pagination
+              offset={offset}
+              limit={PAGE_SIZE}
+              total={total}
+              canPrev={offset > 0}
+              canNext={offset + PAGE_SIZE < total}
+              onPrev={() => {
+                setOffset((o) => Math.max(0, o - PAGE_SIZE));
+              }}
+              onNext={() => {
+                setOffset((o) => o + PAGE_SIZE);
+              }}
+            />
+          </div>
+        )}
+      </Stack>
+
+      {showCreate && (
+        <UserFormModal
+          onClose={() => {
+            setShowCreate(false);
+          }}
+        />
+      )}
+    </AppShell>
+  );
+}

--- a/frontend/src/shared/ui/components/AppShell.tsx
+++ b/frontend/src/shared/ui/components/AppShell.tsx
@@ -37,6 +37,9 @@ export function AppShell({ children, onLogout }: AppShellProps) {
   const navLinks = [
     { to: '/documents', label: t('navigation.documents') },
     { to: '/audit', label: t('navigation.audit_events') },
+    { to: '/settings', label: t('navigation.settings') },
+    { to: '/users', label: t('navigation.users') },
+    { to: '/export', label: t('navigation.export') },
   ];
 
   return (

--- a/frontend/src/shared/ui/primitives/Text.tsx
+++ b/frontend/src/shared/ui/primitives/Text.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 
 export interface TextProps {
   as?: 'p' | 'span' | 'h1' | 'h2';
-  tone?: 'primary' | 'muted' | 'danger';
+  tone?: 'primary' | 'muted' | 'danger' | 'success';
   children: ReactNode;
   className?: string;
 }
@@ -11,6 +11,7 @@ const TONE_CLASS: Record<NonNullable<TextProps['tone']>, string> = {
   primary: 'text-text-primary',
   muted: 'text-text-muted',
   danger: 'text-danger',
+  success: 'text-success',
 };
 
 export function Text({ as = 'p', tone = 'primary', children, className }: TextProps) {


### PR DESCRIPTION
## Summary

Three more pages completing the core frontend:

**Vault settings** (`/settings`) — closes #45
- `useVaultSettings` / `useUpdateVaultSettings`, RHF+Zod form with `useEffect` pre-populate
- Compliance warning banner when `retention_years < 10`

**User management** (`/users`) — closes #46
- `useUsers` / `useCreateUser` / `useDeleteUser`, paginated table
- Invite modal (email, password, role), self-delete guard

**Export** (`/export`) — closes #47
- `POST /admin/vault/export` → blob download via anchor tag
- Date range, counterparty, include_voided filters

Also: AppShell nav links extended (settings/users/export), `Text` `success` tone added, `router.tsx` refactored with `guarded()` helper.

`npm run check` → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)