### PR TITLE
fix(tests): prevent SHA-256 collision and UNIQUE constraint errors across runs (#49)

### DIFF
--- a/tests/Document/DocumentApiTest.php
+++ b/tests/Document/DocumentApiTest.php
@@ -354,7 +354,8 @@ final class DocumentApiTest extends TestCase
     {
         $tmp = tempnam(sys_get_temp_dir(), 'vault_test_');
         assert($tmp !== false);
-        file_put_contents($tmp, $content);
+        // Append random bytes so each test run produces a unique SHA-256.
+        file_put_contents($tmp, $content . bin2hex(random_bytes(8)));
 
         return $tmp;
     }

--- a/tests/User/UserApiTest.php
+++ b/tests/User/UserApiTest.php
@@ -117,7 +117,7 @@ final class UserApiTest extends TestCase
         $conn = $container->get(DatabaseConnectionFactoryInterface::class);
         assert($conn instanceof DatabaseConnectionFactoryInterface);
         $pdo = $conn->create();
-        $pdo->exec("INSERT INTO users (id, email, password_hash, role, organization_id, status, created_at, updated_at)
+        $pdo->exec("INSERT OR IGNORE INTO users (id, email, password_hash, role, organization_id, status, created_at, updated_at)
             VALUES (1000, 'self@example.com', 'x', 'admin', " . self::$orgId . ", 'active', datetime('now'), datetime('now'))");
 
         // JWT user_id is 1000 — deleting id 1000 is self


### PR DESCRIPTION
## Root cause

**DocumentApiTest (4 failures):**
`makeTempFile()` generated deterministic content, so the second test run produced the same SHA-256 already in the DB → 409 duplicate-file. All tests using the `upload()` helper then got empty document IDs, causing chained assertion failures.

**UserApiTest (1 error):**
`INSERT INTO users (id=1000, ...)` in `test_cannot_delete_self` hit a UNIQUE constraint on the second run because the row persisted from the previous run.

## Fix
- `makeTempFile()`: append `bin2hex(random_bytes(8))` — unique SHA-256 every run
- `test_cannot_delete_self`: `INSERT OR IGNORE INTO users` — skip if already exists; self-delete guard test still exercises correctly

## Verification
`vendor/bin/phpunit` run twice consecutively: **46/46 pass both times**
`composer check`: all steps green

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)