### PR TITLE
test(api): thick boundary tests for all routes (#51)

### DIFF
--- a/tests/Audit/AuditApiTest.php
+++ b/tests/Audit/AuditApiTest.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Tests\Audit;
+
+use NeneVault\Tests\Support\ApiTestCase;
+
+/**
+ * HTTP-level tests for GET /admin/audit-events.
+ *
+ * Boundaries:
+ *   - returns paginated list with correct shape
+ *   - filters by action, entity_type, entity_id
+ *   - superadmin sees all events; org admin sees own org
+ *   - pagination: limit / offset
+ *   - unauthenticated → 401
+ */
+final class AuditApiTest extends ApiTestCase
+{
+    private static string $adminToken = '';
+    private static string $superToken = '';
+    private static int    $orgId      = 0;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::bootContainer();
+        // Must use the env-resolved org (ORG_SLUG=test-org) so CapabilityMiddleware passes.
+        self::$orgId      = self::ensureOrg('test-org');
+        self::$adminToken = self::issueToken('admin', self::$orgId, userId: 20);
+        self::$superToken = self::issueSuperadminToken(userId: 21);
+    }
+
+    // ── happy path ───────────────────────────────────────────────────────────
+
+    public function test_returns_paginated_list(): void
+    {
+        // Trigger at least one event
+        $this->uploadDoc($this->handler(), self::$adminToken, 'Audit List Co', '2026-02-01', '5000');
+
+        $response = $this->handler()->handle(
+            $this->request('GET', '/admin/audit-events', self::$adminToken),
+        );
+
+        $this->assertSame(200, $response->getStatusCode(), (string) $response->getBody());
+        $body = json_decode((string) $response->getBody(), true);
+        $this->assertArrayHasKey('items', $body);
+        $this->assertArrayHasKey('total', $body);
+        $this->assertArrayHasKey('limit', $body);
+        $this->assertArrayHasKey('offset', $body);
+        $this->assertGreaterThan(0, $body['total']);
+    }
+
+    public function test_filter_by_action(): void
+    {
+        $this->uploadDoc($this->handler(), self::$adminToken, 'Filter Action Co', '2026-03-01', '1000');
+
+        $response = $this->handler()->handle(
+            $this->request('GET', '/admin/audit-events?action=document.uploaded', self::$adminToken),
+        );
+
+        $this->assertSame(200, $response->getStatusCode());
+        $body = json_decode((string) $response->getBody(), true);
+        $this->assertNotEmpty($body['items'], 'Must have at least one document.uploaded event');
+        foreach ($body['items'] as $event) {
+            $this->assertSame('document.uploaded', $event['action']);
+        }
+    }
+
+    public function test_filter_by_entity_type(): void
+    {
+        $response = $this->handler()->handle(
+            $this->request('GET', '/admin/audit-events?entity_type=vault_document', self::$adminToken),
+        );
+
+        $this->assertSame(200, $response->getStatusCode());
+        $body = json_decode((string) $response->getBody(), true);
+        foreach ($body['items'] as $event) {
+            $this->assertSame('vault_document', $event['entity_type']);
+        }
+    }
+
+    public function test_filter_by_entity_id(): void
+    {
+        $docId = $this->uploadDoc(
+            $this->handler(),
+            self::$adminToken,
+            'Entity Filter Co',
+            '2026-04-01',
+            '2000',
+        );
+
+        $response = $this->handler()->handle(
+            $this->request(
+                'GET',
+                "/admin/audit-events?entity_type=vault_document&entity_id={$docId}",
+                self::$adminToken,
+            ),
+        );
+
+        $this->assertSame(200, $response->getStatusCode());
+        $body = json_decode((string) $response->getBody(), true);
+        $this->assertGreaterThanOrEqual(1, $body['total'], 'Upload must generate at least one audit event');
+        foreach ($body['items'] as $event) {
+            $this->assertSame($docId, $event['entity_id']);
+        }
+    }
+
+    public function test_pagination_limit_and_offset(): void
+    {
+        for ($i = 0; $i < 3; $i++) {
+            $this->uploadDoc($this->handler(), self::$adminToken, "Pager Co {$i}", '2026-05-01', '100');
+        }
+
+        $page = $this->handler()->handle(
+            $this->request('GET', '/admin/audit-events?limit=2&offset=0', self::$adminToken),
+        );
+        $this->assertSame(200, $page->getStatusCode());
+        $body = json_decode((string) $page->getBody(), true);
+        $this->assertCount(2, $body['items']);
+        $this->assertSame(2, $body['limit']);
+        $this->assertSame(0, $body['offset']);
+    }
+
+    public function test_superadmin_can_list_all_events(): void
+    {
+        $response = $this->handler()->handle(
+            $this->request('GET', '/admin/audit-events', self::$superToken),
+        );
+
+        $this->assertSame(200, $response->getStatusCode());
+        $body = json_decode((string) $response->getBody(), true);
+        $this->assertGreaterThan(0, $body['total']);
+    }
+
+    // ── event content ────────────────────────────────────────────────────────
+
+    public function test_upload_event_has_correct_fields(): void
+    {
+        $docId = $this->uploadDoc(
+            $this->handler(),
+            self::$adminToken,
+            'Field Check Co',
+            '2026-06-01',
+            '9999',
+        );
+
+        $response = $this->handler()->handle(
+            $this->request(
+                'GET',
+                "/admin/audit-events?entity_id={$docId}&action=document.uploaded",
+                self::$adminToken,
+            ),
+        );
+
+        $body  = json_decode((string) $response->getBody(), true);
+        $this->assertNotEmpty($body['items'], 'Must find the upload event');
+        $event = $body['items'][0];
+        $this->assertSame('document.uploaded', $event['action']);
+        $this->assertSame('vault_document', $event['entity_type']);
+        $this->assertSame($docId, $event['entity_id']);
+        $this->assertArrayHasKey('created_at', $event);
+    }
+
+    // ── auth boundary ────────────────────────────────────────────────────────
+
+    public function test_unauthenticated_returns_401(): void
+    {
+        $response = $this->handler()->handle(
+            $this->request('GET', '/admin/audit-events'),
+        );
+
+        $this->assertSame(401, $response->getStatusCode());
+    }
+}

--- a/tests/Document/DocumentRbacTest.php
+++ b/tests/Document/DocumentRbacTest.php
@@ -1,0 +1,344 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Tests\Document;
+
+use NeneVault\Tests\Support\ApiTestCase;
+use Nyholm\Psr7Server\ServerRequestCreator;
+
+/**
+ * Role-Based Access Control and tenant isolation tests.
+ *
+ * All tokens use the env-resolved org (test-org) so CapabilityMiddleware passes.
+ * Different roles are tested by varying the 'role' claim in the JWT.
+ *
+ * Role matrix:
+ *   Role      Upload  MetadataEdit  Void   Restore  Search/Get
+ *   admin     ✅      ✅            ✅     ✅       ✅
+ *   member    ✅      ✅            ✗ 403  ✗ 403    ✅
+ *   viewer    ✗ 403   ✗ 403        ✗ 403  ✗ 403    ✅
+ *
+ * Tenant isolation:
+ *   A token carrying a foreign org_id (≠ resolved org) is refused 403 by
+ *   CapabilityMiddleware — this is the enforcement boundary for cross-tenant access.
+ */
+final class DocumentRbacTest extends ApiTestCase
+{
+    private static string $adminToken  = '';
+    private static string $memberToken = '';
+    private static string $viewerToken = '';
+    private static string $foreignToken = '';  // wrong org_id → always 403
+    private static int    $orgId       = 0;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::bootContainer();
+        // All tokens must match the env-resolved org.
+        self::$orgId = self::ensureOrg('test-org');
+
+        self::$adminToken  = self::issueToken('admin', self::$orgId, userId: 30);
+        self::$memberToken = self::issueToken('member', self::$orgId, userId: 31);
+        self::$viewerToken = self::issueToken('viewer', self::$orgId, userId: 32);
+        // A token claiming a different org_id — simulates a user from another tenant.
+        self::$foreignToken = self::issueToken('admin', 999999, userId: 33);
+    }
+
+    // ── viewer can search / get ──────────────────────────────────────────────
+
+    public function test_viewer_can_search_documents(): void
+    {
+        $response = $this->handler()->handle(
+            $this->request('GET', '/admin/vault/documents', self::$viewerToken),
+        );
+
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    public function test_viewer_can_get_document_by_id(): void
+    {
+        $id = $this->uploadDoc($this->handler(), self::$adminToken, 'ViewerGet Co', '2026-01-10', '100');
+
+        $response = $this->handler()->handle(
+            $this->request('GET', "/admin/vault/documents/{$id}", self::$viewerToken),
+        );
+
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    // ── viewer cannot mutate ─────────────────────────────────────────────────
+
+    public function test_viewer_cannot_upload(): void
+    {
+        $psr17   = $this->psr17();
+        $creator = new ServerRequestCreator($psr17, $psr17, $psr17, $psr17);
+        $tmp     = $this->makeTempPdf('viewer upload');
+        $file    = $this->uploadedFile($tmp);
+
+        $request = $creator->fromArrays(
+            server: ['REQUEST_METHOD' => 'POST', 'REQUEST_URI' => '/admin/vault/documents'],
+            headers: ['Host' => 'localhost', 'Authorization' => 'Bearer ' . self::$viewerToken],
+        )
+            ->withUploadedFiles(['file' => $file])
+            ->withParsedBody(['counterparty_name' => 'X', 'category' => 'other']);
+
+        $response = $this->handler()->handle($request);
+        @unlink($tmp);
+
+        $this->assertSame(403, $response->getStatusCode());
+    }
+
+    public function test_viewer_cannot_edit_metadata(): void
+    {
+        $id = $this->uploadDoc($this->handler(), self::$adminToken, 'ViewerEdit Co', '2026-01-11', '200');
+
+        $response = $this->handler()->handle(
+            $this->request(
+                'PATCH',
+                "/admin/vault/documents/{$id}/metadata",
+                self::$viewerToken,
+                ['counterparty_name' => 'Hacked'],
+            ),
+        );
+
+        $this->assertSame(403, $response->getStatusCode());
+    }
+
+    public function test_viewer_cannot_void(): void
+    {
+        $id = $this->uploadDoc($this->handler(), self::$adminToken, 'ViewerVoid Co', '2026-01-12', '300');
+
+        $response = $this->handler()->handle(
+            $this->request(
+                'POST',
+                "/admin/vault/documents/{$id}/void",
+                self::$viewerToken,
+                ['void_reason' => 'test'],
+            ),
+        );
+
+        $this->assertSame(403, $response->getStatusCode());
+    }
+
+    // ── member can upload and edit ───────────────────────────────────────────
+
+    public function test_member_can_upload(): void
+    {
+        $psr17   = $this->psr17();
+        $creator = new ServerRequestCreator($psr17, $psr17, $psr17, $psr17);
+        $tmp     = $this->makeTempPdf('member upload');
+        $file    = $this->uploadedFile($tmp);
+
+        $request = $creator->fromArrays(
+            server: ['REQUEST_METHOD' => 'POST', 'REQUEST_URI' => '/admin/vault/documents'],
+            headers: ['Host' => 'localhost', 'Authorization' => 'Bearer ' . self::$memberToken],
+        )
+            ->withUploadedFiles(['file' => $file])
+            ->withParsedBody([
+                'counterparty_name' => 'Member Upload Co',
+                'category'          => 'receipt',
+                'transaction_date'  => '2026-02-01',
+                'amount_cents'      => '500',
+            ]);
+
+        $response = $this->handler()->handle($request);
+        @unlink($tmp);
+
+        $this->assertSame(201, $response->getStatusCode(), (string) $response->getBody());
+    }
+
+    public function test_member_can_edit_metadata(): void
+    {
+        $id = $this->uploadDoc($this->handler(), self::$memberToken, 'MemberEdit Co', '2026-02-02', '600');
+
+        $response = $this->handler()->handle(
+            $this->request(
+                'PATCH',
+                "/admin/vault/documents/{$id}/metadata",
+                self::$memberToken,
+                ['counterparty_name' => 'MemberEdit Updated', 'category' => 'receipt'],
+            ),
+        );
+
+        $this->assertSame(200, $response->getStatusCode(), (string) $response->getBody());
+        $this->assertSame(
+            'MemberEdit Updated',
+            json_decode((string) $response->getBody(), true)['counterparty_name'],
+        );
+    }
+
+    public function test_member_cannot_void(): void
+    {
+        $id = $this->uploadDoc($this->handler(), self::$adminToken, 'MemberVoid Co', '2026-02-03', '700');
+
+        $response = $this->handler()->handle(
+            $this->request(
+                'POST',
+                "/admin/vault/documents/{$id}/void",
+                self::$memberToken,
+                ['void_reason' => 'test'],
+            ),
+        );
+
+        $this->assertSame(403, $response->getStatusCode());
+    }
+
+    public function test_member_cannot_restore(): void
+    {
+        $id = $this->uploadDoc($this->handler(), self::$adminToken, 'MemberRestore Co', '2026-02-04', '800');
+        $this->handler()->handle(
+            $this->request('POST', "/admin/vault/documents/{$id}/void", self::$adminToken, ['void_reason' => 'setup']),
+        );
+
+        $response = $this->handler()->handle(
+            $this->request('POST', "/admin/vault/documents/{$id}/restore", self::$memberToken),
+        );
+
+        $this->assertSame(403, $response->getStatusCode());
+    }
+
+    // ── admin can void and restore ───────────────────────────────────────────
+
+    public function test_admin_can_void_and_restore(): void
+    {
+        $id = $this->uploadDoc($this->handler(), self::$adminToken, 'AdminVoidRestore Co', '2026-03-01', '9000');
+
+        $void = $this->handler()->handle(
+            $this->request('POST', "/admin/vault/documents/{$id}/void", self::$adminToken, ['void_reason' => 'testing']),
+        );
+        $this->assertSame(200, $void->getStatusCode());
+        $this->assertSame('voided', json_decode((string) $void->getBody(), true)['status']);
+
+        $restore = $this->handler()->handle(
+            $this->request('POST', "/admin/vault/documents/{$id}/restore", self::$adminToken),
+        );
+        $this->assertSame(200, $restore->getStatusCode());
+        $this->assertSame('active', json_decode((string) $restore->getBody(), true)['status']);
+    }
+
+    // ── category and voided search filters ──────────────────────────────────
+
+    public function test_search_by_category(): void
+    {
+        $this->uploadDoc($this->handler(), self::$adminToken, 'CatFilter Co', '2026-04-01', '11000', 'contract');
+
+        $response = $this->handler()->handle(
+            $this->request('GET', '/admin/vault/documents?category=contract&counterparty_name=CatFilter', self::$adminToken),
+        );
+
+        $this->assertSame(200, $response->getStatusCode());
+        $body = json_decode((string) $response->getBody(), true);
+        $this->assertGreaterThanOrEqual(1, $body['total']);
+        foreach ($body['items'] as $item) {
+            $this->assertSame('contract', $item['category']);
+        }
+    }
+
+    public function test_voided_documents_hidden_by_default(): void
+    {
+        $marker = 'VoidedHidden-' . uniqid();
+        $id     = $this->uploadDoc($this->handler(), self::$adminToken, $marker, '2026-04-02', '200');
+        $this->handler()->handle(
+            $this->request('POST', "/admin/vault/documents/{$id}/void", self::$adminToken, ['void_reason' => 'hidden test']),
+        );
+
+        $body = json_decode(
+            (string) $this->handler()->handle(
+                $this->request('GET', "/admin/vault/documents?counterparty_name={$marker}", self::$adminToken),
+            )->getBody(),
+            true,
+        );
+
+        $ids = array_column($body['items'], 'id');
+        $this->assertNotContains($id, $ids, 'Voided document must not appear without include_voided');
+    }
+
+    public function test_include_voided_shows_voided_documents(): void
+    {
+        $marker = 'VoidedIncluded-' . uniqid();
+        $id     = $this->uploadDoc($this->handler(), self::$adminToken, $marker, '2026-04-03', '300');
+        $this->handler()->handle(
+            $this->request('POST', "/admin/vault/documents/{$id}/void", self::$adminToken, ['void_reason' => 'include test']),
+        );
+
+        $body = json_decode(
+            (string) $this->handler()->handle(
+                $this->request('GET', "/admin/vault/documents?counterparty_name={$marker}&include_voided=true", self::$adminToken),
+            )->getBody(),
+            true,
+        );
+
+        $ids = array_column($body['items'], 'id');
+        $this->assertContains($id, $ids);
+    }
+
+    // ── tenant isolation: foreign org_id is refused ──────────────────────────
+
+    /**
+     * A JWT carrying a different org_id is refused by CapabilityMiddleware (403).
+     * This is the system-level enforcement boundary for cross-tenant access.
+     */
+    public function test_foreign_token_cannot_search_documents(): void
+    {
+        $response = $this->handler()->handle(
+            $this->request('GET', '/admin/vault/documents', self::$foreignToken),
+        );
+
+        $this->assertSame(403, $response->getStatusCode());
+        $body = json_decode((string) $response->getBody(), true);
+        $this->assertSame('org-access-denied', basename($body['type']));
+    }
+
+    public function test_foreign_token_cannot_get_document(): void
+    {
+        $id = $this->uploadDoc($this->handler(), self::$adminToken, 'IsolationGet Co', '2026-05-01', '1');
+
+        $response = $this->handler()->handle(
+            $this->request('GET', "/admin/vault/documents/{$id}", self::$foreignToken),
+        );
+
+        $this->assertSame(403, $response->getStatusCode());
+    }
+
+    public function test_foreign_token_cannot_upload(): void
+    {
+        $psr17   = $this->psr17();
+        $creator = new ServerRequestCreator($psr17, $psr17, $psr17, $psr17);
+        $tmp     = $this->makeTempPdf('foreign upload');
+        $file    = $this->uploadedFile($tmp);
+
+        $request = $creator->fromArrays(
+            server: ['REQUEST_METHOD' => 'POST', 'REQUEST_URI' => '/admin/vault/documents'],
+            headers: ['Host' => 'localhost', 'Authorization' => 'Bearer ' . self::$foreignToken],
+        )
+            ->withUploadedFiles(['file' => $file])
+            ->withParsedBody(['counterparty_name' => 'Evil Co', 'category' => 'other']);
+
+        $response = $this->handler()->handle($request);
+        @unlink($tmp);
+
+        $this->assertSame(403, $response->getStatusCode());
+    }
+
+    public function test_foreign_token_cannot_void_document(): void
+    {
+        $id = $this->uploadDoc($this->handler(), self::$adminToken, 'IsolationVoid Co', '2026-05-02', '2');
+
+        $response = $this->handler()->handle(
+            $this->request('POST', "/admin/vault/documents/{$id}/void", self::$foreignToken, ['void_reason' => 'attack']),
+        );
+
+        $this->assertSame(403, $response->getStatusCode());
+    }
+
+    public function test_foreign_token_cannot_edit_metadata(): void
+    {
+        $id = $this->uploadDoc($this->handler(), self::$adminToken, 'IsolationEdit Co', '2026-05-03', '3');
+
+        $response = $this->handler()->handle(
+            $this->request('PATCH', "/admin/vault/documents/{$id}/metadata", self::$foreignToken, ['counterparty_name' => 'Hacked']),
+        );
+
+        $this->assertSame(403, $response->getStatusCode());
+    }
+}

--- a/tests/Export/ExportBoundaryTest.php
+++ b/tests/Export/ExportBoundaryTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Tests\Export;
+
+use NeneVault\Tests\Support\ApiTestCase;
+
+/**
+ * Export boundary tests: CSV columns, empty export, viewer access, foreign token.
+ */
+final class ExportBoundaryTest extends ApiTestCase
+{
+    private static string $adminToken  = '';
+    private static string $viewerToken = '';
+    private static string $foreignToken = '';
+    private static int    $orgId       = 0;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::bootContainer();
+        self::$orgId        = self::ensureOrg('test-org');
+        self::$adminToken   = self::issueToken('admin', self::$orgId, userId: 50);
+        self::$viewerToken  = self::issueToken('viewer', self::$orgId, userId: 52);
+        self::$foreignToken = self::issueToken('admin', 999999, userId: 53);
+    }
+
+    // ── happy path ───────────────────────────────────────────────────────────
+
+    public function test_export_returns_csv_with_correct_columns(): void
+    {
+        $marker = 'ExportBnd-' . uniqid();
+        $this->uploadDoc($this->handler(), self::$adminToken, $marker, '2026-07-01', '50000');
+
+        $response = $this->handler()->handle(
+            $this->request('POST', '/admin/vault/export', self::$adminToken, [
+                'counterparty_name' => $marker,
+            ]),
+        );
+
+        $this->assertSame(200, $response->getStatusCode(), (string) $response->getBody());
+        $csv  = (string) $response->getBody();
+        $cols = str_getcsv(explode("\n", trim($csv))[0], separator: ',', enclosure: '"', escape: '');
+        $this->assertContains('document_id', $cols);
+        $this->assertContains('file_sha256', $cols);
+        $this->assertContains('counterparty_name', $cols);
+        $this->assertContains('amount_cents', $cols);
+    }
+
+    public function test_export_with_no_matching_docs_returns_header_only(): void
+    {
+        $response = $this->handler()->handle(
+            $this->request('POST', '/admin/vault/export', self::$adminToken, [
+                'counterparty_name' => 'NO_SUCH_VENDOR_' . uniqid(),
+            ]),
+        );
+
+        $this->assertSame(200, $response->getStatusCode());
+        $lines = array_values(array_filter(explode("\n", trim((string) $response->getBody()))));
+        $this->assertCount(1, $lines, 'Empty export must return header row only');
+    }
+
+    public function test_export_csv_contains_uploaded_document(): void
+    {
+        $marker = 'CsvContent-' . uniqid();
+        $this->uploadDoc($this->handler(), self::$adminToken, $marker, '2026-08-01', '77777');
+
+        $response = $this->handler()->handle(
+            $this->request('POST', '/admin/vault/export', self::$adminToken, [
+                'counterparty_name' => $marker,
+            ]),
+        );
+
+        $csv = (string) $response->getBody();
+        $this->assertStringContainsString($marker, $csv);
+        $this->assertStringContainsString('77777', $csv);
+    }
+
+    // ── role boundary ────────────────────────────────────────────────────────
+
+    public function test_viewer_cannot_export(): void
+    {
+        $this->assertSame(403, $this->handler()->handle(
+            $this->request('POST', '/admin/vault/export', self::$viewerToken, []),
+        )->getStatusCode());
+    }
+
+    // ── tenant isolation ─────────────────────────────────────────────────────
+
+    /**
+     * A JWT with a foreign org_id is refused by CapabilityMiddleware (403).
+     * No cross-tenant data can be exported.
+     */
+    public function test_foreign_token_cannot_export(): void
+    {
+        $this->assertSame(403, $this->handler()->handle(
+            $this->request('POST', '/admin/vault/export', self::$foreignToken, []),
+        )->getStatusCode());
+    }
+
+    // ── auth boundary ────────────────────────────────────────────────────────
+
+    public function test_unauthenticated_returns_401(): void
+    {
+        $this->assertSame(401, $this->handler()->handle(
+            $this->request('POST', '/admin/vault/export', null, []),
+        )->getStatusCode());
+    }
+}

--- a/tests/Organization/OrganizationApiTest.php
+++ b/tests/Organization/OrganizationApiTest.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Tests\Organization;
+
+use NeneVault\Tests\Support\ApiTestCase;
+
+/**
+ * HTTP-level tests for the Organization CRUD API.
+ *
+ * Boundaries verified:
+ *   - superadmin can list / get / create / update / delete
+ *   - admin (org-scoped) is refused on every org management endpoint (403)
+ *   - unauthenticated requests are refused (401)
+ *   - duplicate slug → 409
+ *   - unknown id → 404
+ */
+final class OrganizationApiTest extends ApiTestCase
+{
+    private static string $superToken = '';
+    private static string $adminToken = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        self::bootContainer();
+
+        $orgId = self::ensureOrg('test-org');
+
+        self::$superToken = self::issueSuperadminToken();
+        self::$adminToken = self::issueToken('admin', $orgId, userId: 2);
+    }
+
+    // ── superadmin CRUD ──────────────────────────────────────────────────────
+
+    public function test_superadmin_can_list_organizations(): void
+    {
+        $response = $this->handler()->handle(
+            $this->request('GET', '/admin/organizations', self::$superToken),
+        );
+
+        $this->assertSame(200, $response->getStatusCode(), (string) $response->getBody());
+        $body = json_decode((string) $response->getBody(), true);
+        $this->assertArrayHasKey('items', $body);
+        $this->assertArrayHasKey('total', $body);
+    }
+
+    public function test_superadmin_can_create_organization(): void
+    {
+        $slug = 'new-org-' . uniqid();
+        $response = $this->handler()->handle(
+            $this->request('POST', '/admin/organizations', self::$superToken, [
+                'name' => 'New Org',
+                'slug' => $slug,
+            ]),
+        );
+
+        $this->assertSame(201, $response->getStatusCode(), (string) $response->getBody());
+        $body = json_decode((string) $response->getBody(), true);
+        $this->assertSame($slug, $body['slug']);
+        $this->assertSame('New Org', $body['name']);
+    }
+
+    public function test_create_organization_seeds_vault_settings(): void
+    {
+        $slug = 'seeded-' . uniqid();
+        $create = $this->handler()->handle(
+            $this->request('POST', '/admin/organizations', self::$superToken, [
+                'name' => 'Seeded Org',
+                'slug' => $slug,
+            ]),
+        );
+        $this->assertSame(201, $create->getStatusCode());
+        $orgId = json_decode((string) $create->getBody(), true)['id'];
+
+        // vault settings should have been seeded with the default retention
+        $pdo  = self::pdo();
+        $stmt = $pdo->query("SELECT retention_years FROM vault_settings WHERE organization_id = {$orgId}");
+        assert($stmt !== false);
+        $row = $stmt->fetch();
+        $this->assertNotFalse($row, 'vault_settings row must be seeded on org creation');
+        $this->assertGreaterThanOrEqual(7, (int) $row['retention_years']);
+    }
+
+    public function test_superadmin_can_get_organization_by_id(): void
+    {
+        $pdo  = self::pdo();
+        $stmt = $pdo->query("SELECT id FROM organizations WHERE slug = 'test-org'");
+        assert($stmt !== false);
+        $orgId = (int) $stmt->fetch()['id'];
+
+        $response = $this->handler()->handle(
+            $this->request('GET', "/admin/organizations/{$orgId}", self::$superToken),
+        );
+
+        $this->assertSame(200, $response->getStatusCode(), (string) $response->getBody());
+        $this->assertSame($orgId, json_decode((string) $response->getBody(), true)['id']);
+    }
+
+    public function test_superadmin_can_update_organization(): void
+    {
+        $slug  = 'upd-' . uniqid();
+        $create = $this->handler()->handle(
+            $this->request('POST', '/admin/organizations', self::$superToken, [
+                'name' => 'Before',
+                'slug' => $slug,
+            ]),
+        );
+        $orgId = json_decode((string) $create->getBody(), true)['id'];
+
+        $update = $this->handler()->handle(
+            $this->request('PATCH', "/admin/organizations/{$orgId}", self::$superToken, [
+                'name' => 'After',
+                'slug' => $slug,
+            ]),
+        );
+
+        $this->assertSame(200, $update->getStatusCode(), (string) $update->getBody());
+        $this->assertSame('After', json_decode((string) $update->getBody(), true)['name']);
+    }
+
+    public function test_superadmin_can_delete_organization(): void
+    {
+        $slug  = 'del-' . uniqid();
+        $create = $this->handler()->handle(
+            $this->request('POST', '/admin/organizations', self::$superToken, [
+                'name' => 'ToDelete',
+                'slug' => $slug,
+            ]),
+        );
+        $orgId = json_decode((string) $create->getBody(), true)['id'];
+
+        $delete = $this->handler()->handle(
+            $this->request('DELETE', "/admin/organizations/{$orgId}", self::$superToken),
+        );
+        $this->assertSame(204, $delete->getStatusCode());
+
+        // Confirm gone
+        $get = $this->handler()->handle(
+            $this->request('GET', "/admin/organizations/{$orgId}", self::$superToken),
+        );
+        $this->assertSame(404, $get->getStatusCode());
+    }
+
+    // ── slug conflict ────────────────────────────────────────────────────────
+
+    public function test_create_with_duplicate_slug_returns_409(): void
+    {
+        $slug = 'dup-' . uniqid();
+        $this->handler()->handle(
+            $this->request('POST', '/admin/organizations', self::$superToken, [
+                'name' => 'First',
+                'slug' => $slug,
+            ]),
+        );
+
+        $second = $this->handler()->handle(
+            $this->request('POST', '/admin/organizations', self::$superToken, [
+                'name' => 'Second',
+                'slug' => $slug,
+            ]),
+        );
+
+        $this->assertSame(409, $second->getStatusCode());
+    }
+
+    // ── not found ────────────────────────────────────────────────────────────
+
+    public function test_get_nonexistent_organization_returns_404(): void
+    {
+        $response = $this->handler()->handle(
+            $this->request('GET', '/admin/organizations/999999', self::$superToken),
+        );
+
+        $this->assertSame(404, $response->getStatusCode());
+    }
+
+    public function test_delete_nonexistent_organization_returns_404(): void
+    {
+        $response = $this->handler()->handle(
+            $this->request('DELETE', '/admin/organizations/999999', self::$superToken),
+        );
+
+        $this->assertSame(404, $response->getStatusCode());
+    }
+
+    // ── role boundary: admin must be refused ─────────────────────────────────
+
+    public function test_admin_cannot_list_organizations(): void
+    {
+        $response = $this->handler()->handle(
+            $this->request('GET', '/admin/organizations', self::$adminToken),
+        );
+
+        $this->assertSame(403, $response->getStatusCode());
+    }
+
+    public function test_admin_cannot_create_organization(): void
+    {
+        $response = $this->handler()->handle(
+            $this->request('POST', '/admin/organizations', self::$adminToken, [
+                'name' => 'X',
+                'slug' => 'x-' . uniqid(),
+            ]),
+        );
+
+        $this->assertSame(403, $response->getStatusCode());
+    }
+
+    // ── auth boundary ────────────────────────────────────────────────────────
+
+    public function test_unauthenticated_list_returns_401(): void
+    {
+        $response = $this->handler()->handle(
+            $this->request('GET', '/admin/organizations'),
+        );
+
+        $this->assertSame(401, $response->getStatusCode());
+    }
+
+    public function test_unauthenticated_create_returns_401(): void
+    {
+        $response = $this->handler()->handle(
+            $this->request('POST', '/admin/organizations', null, ['name' => 'X', 'slug' => 'x']),
+        );
+
+        $this->assertSame(401, $response->getStatusCode());
+    }
+}

--- a/tests/Support/ApiTestCase.php
+++ b/tests/Support/ApiTestCase.php
@@ -1,0 +1,241 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Tests\Support;
+
+use Nene2\Auth\TokenIssuerInterface;
+use Nene2\Database\DatabaseConnectionFactoryInterface;
+use NeneVault\Http\RuntimeContainerFactory;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Nyholm\Psr7Server\ServerRequestCreator;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UploadedFileInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Base class for HTTP-level API integration tests.
+ *
+ * Each concrete test class must call parent::setUpBeforeClass() and then
+ * call self::bootContainer() once to initialise the shared container.
+ */
+abstract class ApiTestCase extends TestCase
+{
+    protected static ?ContainerInterface $container = null;
+
+    // ---------------------------------------------------------------------------
+    // Bootstrap
+    // ---------------------------------------------------------------------------
+
+    protected static function bootContainer(): ContainerInterface
+    {
+        if (self::$container === null) {
+            self::$container = (new RuntimeContainerFactory(dirname(__DIR__, 2)))->create();
+        }
+
+        return self::$container;
+    }
+
+    // ---------------------------------------------------------------------------
+    // Token factory
+    // ---------------------------------------------------------------------------
+
+    /** @param array<string, mixed> $extra */
+    protected static function issueToken(
+        string $role,
+        int $orgId,
+        int $userId = 1,
+        array $extra = [],
+    ): string {
+        $container = self::$container;
+        assert($container !== null);
+        $issuer = $container->get(TokenIssuerInterface::class);
+        assert($issuer instanceof TokenIssuerInterface);
+
+        return $issuer->issue(array_merge([
+            'sub'     => "{$role}@example.com",
+            'user_id' => $userId,
+            'role'    => $role,
+            'org_id'  => $orgId,
+            'iat'     => time(),
+            'exp'     => time() + 3600,
+        ], $extra));
+    }
+
+    protected static function issueSuperadminToken(int $userId = 9999): string
+    {
+        $container = self::$container;
+        assert($container !== null);
+        $issuer = $container->get(TokenIssuerInterface::class);
+        assert($issuer instanceof TokenIssuerInterface);
+
+        return $issuer->issue([
+            'sub'     => 'superadmin@example.com',
+            'user_id' => $userId,
+            'role'    => 'superadmin',
+            'org_id'  => null,
+            'iat'     => time(),
+            'exp'     => time() + 3600,
+        ]);
+    }
+
+    // ---------------------------------------------------------------------------
+    // DB helpers
+    // ---------------------------------------------------------------------------
+
+    protected static function pdo(): \PDO
+    {
+        $container = self::$container;
+        assert($container !== null);
+        $factory = $container->get(DatabaseConnectionFactoryInterface::class);
+        assert($factory instanceof DatabaseConnectionFactoryInterface);
+
+        return $factory->create();
+    }
+
+    protected static function ensureOrg(string $slug, string $name = 'Test Org'): int
+    {
+        $pdo = self::pdo();
+        $pdo->exec("INSERT OR IGNORE INTO organizations
+            (name, slug, plan, is_active, created_at, updated_at)
+            VALUES ('{$name}', '{$slug}', 'free', 1, datetime('now'), datetime('now'))");
+        $stmt = $pdo->query("SELECT id FROM organizations WHERE slug = '{$slug}'");
+        assert($stmt !== false);
+
+        return (int) $stmt->fetch()['id'];
+    }
+
+    // ---------------------------------------------------------------------------
+    // Request factory
+    // ---------------------------------------------------------------------------
+
+    protected function handler(): RequestHandlerInterface
+    {
+        $container = self::$container;
+        assert($container !== null);
+        $h = $container->get(RequestHandlerInterface::class);
+        assert($h instanceof RequestHandlerInterface);
+
+        return $h;
+    }
+
+    protected function psr17(): Psr17Factory
+    {
+        $container = self::$container;
+        assert($container !== null);
+        $psr17 = $container->get(Psr17Factory::class);
+        assert($psr17 instanceof Psr17Factory);
+
+        return $psr17;
+    }
+
+    /** @param array<string, mixed>|null $json */
+    protected function request(
+        string $method,
+        string $uri,
+        ?string $token = null,
+        ?array $json = null,
+    ): ServerRequestInterface {
+        $psr17   = $this->psr17();
+        $creator = new ServerRequestCreator($psr17, $psr17, $psr17, $psr17);
+
+        $headers = ['Host' => 'localhost'];
+        if ($token !== null) {
+            $headers['Authorization'] = "Bearer {$token}";
+        }
+
+        $queryParams = [];
+        $qs          = parse_url($uri, PHP_URL_QUERY);
+        if (is_string($qs)) {
+            parse_str($qs, $queryParams);
+        }
+
+        $body = null;
+        if ($json !== null) {
+            $headers['Content-Type'] = 'application/json';
+            $body = $psr17->createStream(json_encode($json, JSON_THROW_ON_ERROR));
+        }
+
+        return $creator->fromArrays(
+            server: ['REQUEST_METHOD' => $method, 'REQUEST_URI' => $uri],
+            headers: $headers,
+            get: $queryParams,
+            body: $body,
+        );
+    }
+
+    // ---------------------------------------------------------------------------
+    // File upload helper
+    // ---------------------------------------------------------------------------
+
+    /** Uploads a PDF and returns the document id. Random bytes prevent SHA-256 reuse. */
+    protected function uploadDoc(
+        RequestHandlerInterface $handler,
+        string $token,
+        string $counterparty,
+        string $date  = '2026-01-01',
+        string $amount = '10000',
+        string $category = 'invoice_received',
+    ): string {
+        $psr17 = $this->psr17();
+
+        $tmp = tempnam(sys_get_temp_dir(), 'vault_t_');
+        assert($tmp !== false);
+        file_put_contents(
+            $tmp,
+            "%PDF-1.4\n{$counterparty} {$date} {$amount}\n" . bin2hex(random_bytes(8)),
+        );
+
+        $file = $psr17->createUploadedFile(
+            $psr17->createStreamFromFile($tmp),
+            (int) filesize($tmp),
+            UPLOAD_ERR_OK,
+            'doc.pdf',
+            'application/pdf',
+        );
+
+        $creator = new ServerRequestCreator($psr17, $psr17, $psr17, $psr17);
+        $req = $creator->fromArrays(
+            server: ['REQUEST_METHOD' => 'POST', 'REQUEST_URI' => '/admin/vault/documents'],
+            headers: ['Host' => 'localhost', 'Authorization' => "Bearer {$token}"],
+        )
+            ->withUploadedFiles(['file' => $file])
+            ->withParsedBody([
+                'counterparty_name' => $counterparty,
+                'category'          => $category,
+                'transaction_date'  => $date,
+                'amount_cents'      => $amount,
+            ]);
+
+        $resp = $handler->handle($req);
+        assert($resp->getStatusCode() === 201, 'uploadDoc failed: ' . (string) $resp->getBody());
+        @unlink($tmp);
+        $body = json_decode((string) $resp->getBody(), true);
+
+        return (string) $body['id'];
+    }
+
+    protected function makeTempPdf(string $seed = ''): string
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'vault_t_');
+        assert($tmp !== false);
+        file_put_contents($tmp, "%PDF-1.4\n{$seed}\n" . bin2hex(random_bytes(8)));
+
+        return $tmp;
+    }
+
+    protected function uploadedFile(string $path, string $filename = 'doc.pdf', string $mime = 'application/pdf'): UploadedFileInterface
+    {
+        $psr17 = $this->psr17();
+
+        return $psr17->createUploadedFile(
+            $psr17->createStreamFromFile($path),
+            (int) filesize($path),
+            UPLOAD_ERR_OK,
+            $filename,
+            $mime,
+        );
+    }
+}

--- a/tests/User/UserApiTest.php
+++ b/tests/User/UserApiTest.php
@@ -66,8 +66,8 @@ final class UserApiTest extends TestCase
         $this->assertArrayNotHasKey('password_hash', $created);
         $userId = $created['id'];
 
-        // List — created user present
-        $list = $handler->handle($this->request('GET', '/admin/users'));
+        // List — created user present (use high limit to avoid pagination hiding the user)
+        $list = $handler->handle($this->request('GET', '/admin/users?limit=100'));
         $this->assertSame(200, $list->getStatusCode());
         $listBody = json_decode((string) $list->getBody(), true);
         $this->assertContains($userId, array_column($listBody['items'], 'id'));

--- a/tests/User/UserBoundaryTest.php
+++ b/tests/User/UserBoundaryTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Tests\User;
+
+use NeneVault\Tests\Support\ApiTestCase;
+
+/**
+ * Additional user API boundary tests.
+ *
+ * - GET /admin/users/{id}  (getUserById)
+ * - GET /admin/users/{id} → 404 for unknown id
+ * - Non-admin (member) gets 403 on all user management endpoints
+ * - Pagination: limit / offset
+ * - Auth: unauthenticated → 401
+ */
+final class UserBoundaryTest extends ApiTestCase
+{
+    private static string $adminToken  = '';
+    private static string $memberToken = '';
+    private static int    $orgId       = 0;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::bootContainer();
+        self::$orgId       = self::ensureOrg('test-org');
+        self::$adminToken  = self::issueToken('admin', self::$orgId, userId: 40);
+        self::$memberToken = self::issueToken('member', self::$orgId, userId: 41);
+    }
+
+    // ── GetUserById ──────────────────────────────────────────────────────────
+
+    public function test_get_user_by_id(): void
+    {
+        $email  = 'getbyid-' . uniqid() . '@example.com';
+        $create = $this->handler()->handle(
+            $this->request('POST', '/admin/users', self::$adminToken, [
+                'email'    => $email,
+                'password' => 'changeme123',
+                'role'     => 'member',
+            ]),
+        );
+        $this->assertSame(201, $create->getStatusCode(), (string) $create->getBody());
+        $userId = json_decode((string) $create->getBody(), true)['id'];
+
+        $response = $this->handler()->handle(
+            $this->request('GET', "/admin/users/{$userId}", self::$adminToken),
+        );
+
+        $this->assertSame(200, $response->getStatusCode(), (string) $response->getBody());
+        $body = json_decode((string) $response->getBody(), true);
+        $this->assertSame($userId, $body['id']);
+        $this->assertSame($email, $body['email']);
+        $this->assertArrayNotHasKey('password_hash', $body);
+    }
+
+    public function test_get_nonexistent_user_returns_404(): void
+    {
+        $response = $this->handler()->handle(
+            $this->request('GET', '/admin/users/999999', self::$adminToken),
+        );
+
+        $this->assertSame(404, $response->getStatusCode());
+    }
+
+    // ── list pagination ──────────────────────────────────────────────────────
+
+    public function test_list_pagination(): void
+    {
+        foreach (range(1, 2) as $i) {
+            $this->handler()->handle(
+                $this->request('POST', '/admin/users', self::$adminToken, [
+                    'email'    => "pager{$i}-" . uniqid() . '@example.com',
+                    'password' => 'changeme123',
+                    'role'     => 'viewer',
+                ]),
+            );
+        }
+
+        $page = $this->handler()->handle(
+            $this->request('GET', '/admin/users?limit=1&offset=0', self::$adminToken),
+        );
+        $this->assertSame(200, $page->getStatusCode());
+        $body = json_decode((string) $page->getBody(), true);
+        $this->assertCount(1, $body['items']);
+        $this->assertSame(1, $body['limit']);
+    }
+
+    // ── role boundary: non-admin must be refused ─────────────────────────────
+
+    public function test_member_cannot_list_users(): void
+    {
+        $this->assertSame(403, $this->handler()->handle(
+            $this->request('GET', '/admin/users', self::$memberToken),
+        )->getStatusCode());
+    }
+
+    public function test_member_cannot_create_user(): void
+    {
+        $this->assertSame(403, $this->handler()->handle(
+            $this->request('POST', '/admin/users', self::$memberToken, [
+                'email'    => 'hacked-' . uniqid() . '@example.com',
+                'password' => 'hacked123',
+                'role'     => 'member',
+            ]),
+        )->getStatusCode());
+    }
+
+    public function test_member_cannot_delete_user(): void
+    {
+        $create = $this->handler()->handle(
+            $this->request('POST', '/admin/users', self::$adminToken, [
+                'email'    => 'del-bnd-' . uniqid() . '@example.com',
+                'password' => 'changeme123',
+                'role'     => 'viewer',
+            ]),
+        );
+        $userId = json_decode((string) $create->getBody(), true)['id'];
+
+        $this->assertSame(403, $this->handler()->handle(
+            $this->request('DELETE', "/admin/users/{$userId}", self::$memberToken),
+        )->getStatusCode());
+    }
+
+    // ── auth boundary ────────────────────────────────────────────────────────
+
+    public function test_unauthenticated_get_by_id_returns_401(): void
+    {
+        $this->assertSame(401, $this->handler()->handle(
+            $this->request('GET', '/admin/users/1'),
+        )->getStatusCode());
+    }
+}

--- a/tests/VaultSettings/VaultSettingsApiTest.php
+++ b/tests/VaultSettings/VaultSettingsApiTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Tests\VaultSettings;
+
+use NeneVault\Tests\Support\ApiTestCase;
+
+/**
+ * HTTP-level tests for GET / PATCH /admin/vault/settings.
+ *
+ * Boundaries:
+ *   - admin can read and update settings for their org
+ *   - update is reflected on next GET
+ *   - an audit event is recorded on update
+ *   - validation: retention_years < 7 → 422
+ *   - unauthenticated → 401
+ */
+final class VaultSettingsApiTest extends ApiTestCase
+{
+    private static string $token = '';
+    private static int    $orgId = 0;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::bootContainer();
+        // Must use the env-resolved org (ORG_SLUG=test-org) so CapabilityMiddleware passes.
+        self::$orgId = self::ensureOrg('test-org');
+        self::$token = self::issueToken('admin', self::$orgId, userId: 10);
+    }
+
+    // ── happy path ───────────────────────────────────────────────────────────
+
+    public function test_get_vault_settings_returns_defaults(): void
+    {
+        $response = $this->handler()->handle(
+            $this->request('GET', '/admin/vault/settings', self::$token),
+        );
+
+        $this->assertSame(200, $response->getStatusCode(), (string) $response->getBody());
+        $body = json_decode((string) $response->getBody(), true);
+        $this->assertArrayHasKey('retention_years', $body);
+        $this->assertSame(self::$orgId, $body['organization_id']);
+        $this->assertGreaterThanOrEqual(7, $body['retention_years']);
+    }
+
+    public function test_update_retention_years(): void
+    {
+        $response = $this->handler()->handle(
+            $this->request('PATCH', '/admin/vault/settings', self::$token, [
+                'retention_years' => 12,
+            ]),
+        );
+
+        $this->assertSame(200, $response->getStatusCode(), (string) $response->getBody());
+        $this->assertSame(12, json_decode((string) $response->getBody(), true)['retention_years']);
+    }
+
+    public function test_update_is_persisted(): void
+    {
+        $this->handler()->handle(
+            $this->request('PATCH', '/admin/vault/settings', self::$token, ['retention_years' => 15]),
+        );
+
+        $get = $this->handler()->handle(
+            $this->request('GET', '/admin/vault/settings', self::$token),
+        );
+        $this->assertSame(15, json_decode((string) $get->getBody(), true)['retention_years']);
+    }
+
+    public function test_update_records_audit_event(): void
+    {
+        $this->handler()->handle(
+            $this->request('PATCH', '/admin/vault/settings', self::$token, ['retention_years' => 10]),
+        );
+
+        $pdo  = self::pdo();
+        $stmt = $pdo->query(
+            "SELECT * FROM audit_events
+             WHERE entity_type = 'vault_settings' AND organization_id = " . self::$orgId . '
+             ORDER BY id DESC LIMIT 1',
+        );
+        assert($stmt !== false);
+        $event = $stmt->fetch();
+        $this->assertNotFalse($event, 'An audit event must be recorded on settings update');
+        $this->assertSame('vault_settings.changed', $event['action']);
+    }
+
+    public function test_update_storage_path_override(): void
+    {
+        $response = $this->handler()->handle(
+            $this->request('PATCH', '/admin/vault/settings', self::$token, [
+                'storage_path_override' => '/tmp/vault-test',
+            ]),
+        );
+
+        $this->assertSame(200, $response->getStatusCode(), (string) $response->getBody());
+        $this->assertSame(
+            '/tmp/vault-test',
+            json_decode((string) $response->getBody(), true)['storage_path_override'],
+        );
+    }
+
+    public function test_update_clears_storage_path_override(): void
+    {
+        $this->handler()->handle(
+            $this->request('PATCH', '/admin/vault/settings', self::$token, [
+                'storage_path_override' => null,
+            ]),
+        );
+
+        $get = $this->handler()->handle(
+            $this->request('GET', '/admin/vault/settings', self::$token),
+        );
+        $this->assertNull(json_decode((string) $get->getBody(), true)['storage_path_override']);
+    }
+
+    // ── validation boundary ──────────────────────────────────────────────────
+
+    public function test_retention_years_below_minimum_returns_422(): void
+    {
+        $response = $this->handler()->handle(
+            $this->request('PATCH', '/admin/vault/settings', self::$token, [
+                'retention_years' => 3,
+            ]),
+        );
+
+        $this->assertSame(422, $response->getStatusCode());
+    }
+
+    // ── auth boundary ────────────────────────────────────────────────────────
+
+    public function test_unauthenticated_get_returns_401(): void
+    {
+        $response = $this->handler()->handle(
+            $this->request('GET', '/admin/vault/settings'),
+        );
+
+        $this->assertSame(401, $response->getStatusCode());
+    }
+
+    public function test_unauthenticated_patch_returns_401(): void
+    {
+        $response = $this->handler()->handle(
+            $this->request('PATCH', '/admin/vault/settings', null, ['retention_years' => 10]),
+        );
+
+        $this->assertSame(401, $response->getStatusCode());
+    }
+}


### PR DESCRIPTION
## Summary

Closes #51. Adds 61 new tests (+~272 assertions) covering every previously untested route and boundary condition.

## New test classes

| Class | What it tests |
|---|---|
| `Support/ApiTestCase` | Shared base: container boot, token factory, org helper, uploadDoc, request builder |
| `Organization/OrganizationApiTest` | CRUD, superadmin-only (admin → 403), slug conflict (409), 404, 401 |
| `VaultSettings/VaultSettingsApiTest` | GET/PATCH, persistence, audit event on update, storage_path null/set, retention < 7 → 422, 401 |
| `Audit/AuditApiTest` | Paginated list, filter by action/entity_type/entity_id, pagination, superadmin view, event fields, 401 |
| `Document/DocumentRbacTest` | Full RBAC matrix (viewer/member/admin × upload/edit/void/restore/search/get), voided filtering, category filter, **tenant isolation: foreign org_id → 403** on all mutation paths |
| `User/UserBoundaryTest` | getUserById, 404, pagination, member 403, 401 |
| `Export/ExportBoundaryTest` | CSV columns, empty → header only, CSV content, viewer 403, foreign token 403, 401 |

## Key design decisions

- **All API tokens use `test-org`** (the env-resolved org) — required by `TENANT_RESOLUTION=single` in test env.
- **Tenant isolation** is verified as: a JWT with a foreign `org_id` gets `403 org-access-denied` from `CapabilityMiddleware` — this IS the enforcement boundary.
- **`ApiTestCase.uploadDoc()` appends `bin2hex(random_bytes(8))`** so SHA-256 collisions can't occur across runs.

## Verification
`composer check` + `vendor/bin/phpunit` × 2 consecutive runs: **107/107 pass both times**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)