### PR TITLE
test(frontend): MSW handlers + hook tests for all entities and features (#53)

### DIFF
--- a/frontend/src/entities/audit/queries.test.ts
+++ b/frontend/src/entities/audit/queries.test.ts
@@ -1,0 +1,65 @@
+import { waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { renderHookWithProviders } from '@tests/render/render-with-providers';
+import { DOCUMENT_ID, mockAuditEvent, mockDocumentHistory } from '@tests/msw/fixtures';
+import { useAuditEvents, useDocumentHistory } from './queries';
+
+describe('useAuditEvents', () => {
+  it('returns paginated audit events', async () => {
+    const { result } = renderHookWithProviders(() => useAuditEvents({}));
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data?.items).toHaveLength(1);
+    expect(result.current.data?.items[0]?.action).toBe('document.uploaded');
+    expect(result.current.data?.total).toBe(1);
+  });
+
+  it('returns correct event shape', async () => {
+    const { result } = renderHookWithProviders(() => useAuditEvents({}));
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    const event = result.current.data?.items[0];
+    expect(event?.entity_type).toBe(mockAuditEvent.entity_type);
+    expect(event?.entity_id).toBe(DOCUMENT_ID);
+    expect(event?.actor_user_id).toBe(1);
+  });
+
+  it('passes filter params (action)', async () => {
+    const { result } = renderHookWithProviders(() =>
+      useAuditEvents({ action: 'document.uploaded' }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data?.items[0]?.action).toBe('document.uploaded');
+  });
+});
+
+describe('useDocumentHistory', () => {
+  it('returns versions and audit events for a document', async () => {
+    const { result } = renderHookWithProviders(() => useDocumentHistory(DOCUMENT_ID));
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data?.versions).toHaveLength(1);
+    expect(result.current.data?.versions[0]?.version_number).toBe(1);
+    expect(result.current.data?.audit_events).toHaveLength(mockDocumentHistory.audit_events.length);
+  });
+
+  it('is in error state for an unknown document id', async () => {
+    const { result } = renderHookWithProviders(() => useDocumentHistory('no-such-doc'));
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+  });
+});

--- a/frontend/src/entities/document/mutations.test.ts
+++ b/frontend/src/entities/document/mutations.test.ts
@@ -1,0 +1,107 @@
+import { act, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+import { renderHookWithProviders } from '@tests/render/render-with-providers';
+import { DOCUMENT_ID, mockDocument, mockVoidedDocument, problemDetails } from '@tests/msw/fixtures';
+import { server } from '@tests/msw/server';
+import { useUpdateDocumentMetadata, useVoidDocument, useRestoreDocument } from './mutations';
+
+describe('useUpdateDocumentMetadata', () => {
+  it('patches metadata and returns the updated document', async () => {
+    const { result } = renderHookWithProviders(() => useUpdateDocumentMetadata());
+
+    act(() => {
+      result.current.mutate({ id: DOCUMENT_ID, counterparty_name: 'Updated Inc.' });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data?.counterparty_name).toBe('Updated Inc.');
+  });
+
+  it('is in error state for an unknown document id', async () => {
+    const { result } = renderHookWithProviders(() => useUpdateDocumentMetadata());
+
+    act(() => {
+      result.current.mutate({ id: 'no-such-doc', counterparty_name: 'X' });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+  });
+});
+
+describe('useVoidDocument', () => {
+  it('voids a document and returns voided status', async () => {
+    const { result } = renderHookWithProviders(() => useVoidDocument());
+
+    act(() => {
+      result.current.mutate({ id: DOCUMENT_ID, void_reason: 'Duplicate entry' });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data?.status).toBe('voided');
+    expect(result.current.data?.void_reason).toBe(mockVoidedDocument.void_reason);
+  });
+
+  it('returns error when void_reason is missing', async () => {
+    // Override handler: POST without void_reason → 422
+    server.use(
+      http.post(`/admin/vault/documents/${DOCUMENT_ID}/void`, async ({ request }) => {
+        const body = (await request.json()) as Record<string, unknown>;
+        if (!body['void_reason']) {
+          return HttpResponse.json(problemDetails('validation-failed', 422, 'Validation Failed'), {
+            status: 422,
+            headers: { 'Content-Type': 'application/problem+json' },
+          });
+        }
+        return HttpResponse.json(mockVoidedDocument);
+      }),
+    );
+
+    const { result } = renderHookWithProviders(() => useVoidDocument());
+
+    act(() => {
+      result.current.mutate({ id: DOCUMENT_ID, void_reason: '' });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+  });
+});
+
+describe('useRestoreDocument', () => {
+  it('restores a voided document', async () => {
+    const { result } = renderHookWithProviders(() => useRestoreDocument());
+
+    act(() => {
+      result.current.mutate(DOCUMENT_ID);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data?.status).toBe('active');
+    expect(result.current.data?.id).toBe(mockDocument.id);
+  });
+
+  it('is in error state for an unknown document id', async () => {
+    const { result } = renderHookWithProviders(() => useRestoreDocument());
+
+    act(() => {
+      result.current.mutate('no-such-doc');
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+  });
+});

--- a/frontend/src/entities/document/queries.test.ts
+++ b/frontend/src/entities/document/queries.test.ts
@@ -1,0 +1,57 @@
+import { waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { renderHookWithProviders } from '@tests/render/render-with-providers';
+import { DOCUMENT_ID, mockDocument } from '@tests/msw/fixtures';
+import { useDocuments, useDocumentById } from './queries';
+
+describe('useDocuments', () => {
+  it('returns a paginated document list', async () => {
+    const { result } = renderHookWithProviders(() => useDocuments({}));
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data?.items).toHaveLength(1);
+    expect(result.current.data?.total).toBe(1);
+    expect(result.current.data?.items[0]?.id).toBe(DOCUMENT_ID);
+  });
+
+  it('is in loading state initially', () => {
+    const { result } = renderHookWithProviders(() => useDocuments({}));
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('passes query params in the request URL', async () => {
+    const { result } = renderHookWithProviders(() =>
+      useDocuments({ counterparty_name: 'Sample', category: 'invoice_received' }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data?.items[0]?.counterparty_name).toBe('Sample Inc.');
+  });
+});
+
+describe('useDocumentById', () => {
+  it('fetches a single document by id', async () => {
+    const { result } = renderHookWithProviders(() => useDocumentById(DOCUMENT_ID));
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data?.id).toBe(DOCUMENT_ID);
+    expect(result.current.data?.counterparty_name).toBe(mockDocument.counterparty_name);
+    expect(result.current.data?.amount_cents).toBe(110000);
+  });
+
+  it('is in error state for an unknown id', async () => {
+    const { result } = renderHookWithProviders(() => useDocumentById('unknown-id'));
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+  });
+});

--- a/frontend/src/entities/user/queries.test.ts
+++ b/frontend/src/entities/user/queries.test.ts
@@ -1,0 +1,109 @@
+import { act, waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { renderHookWithProviders } from '@tests/render/render-with-providers';
+import { mockUser, mockUserList } from '@tests/msw/fixtures';
+import { useUsers, useCreateUser, useDeleteUser } from './queries';
+
+describe('useUsers', () => {
+  it('returns paginated user list', async () => {
+    const { result } = renderHookWithProviders(() => useUsers(20, 0));
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data?.items).toHaveLength(1);
+    expect(result.current.data?.total).toBe(mockUserList.total);
+    expect(result.current.data?.items[0]?.email).toBe(mockUser.email);
+  });
+
+  it('returns correct user shape without password_hash', async () => {
+    const { result } = renderHookWithProviders(() => useUsers(20, 0));
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    const user = result.current.data?.items[0];
+    expect(user?.role).toBe('member');
+    expect(user?.status).toBe('active');
+    expect(user).not.toHaveProperty('password_hash');
+  });
+});
+
+describe('useCreateUser', () => {
+  it('creates a user and returns the new user', async () => {
+    const { result } = renderHookWithProviders(() => useCreateUser());
+
+    act(() => {
+      result.current.mutate({
+        email: 'new@example.com',
+        password: 'changeme123',
+        role: 'member',
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data?.email).toBe('new@example.com');
+    expect(result.current.data?.role).toBe('member');
+  });
+
+  it('calls onSuccess callback after creation', async () => {
+    let called = false;
+    const { result } = renderHookWithProviders(() =>
+      useCreateUser(() => {
+        called = true;
+      }),
+    );
+
+    act(() => {
+      result.current.mutate({
+        email: 'cb@example.com',
+        password: 'changeme123',
+        role: 'viewer',
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(called).toBe(true);
+  });
+});
+
+describe('useDeleteUser', () => {
+  it('deletes a user (204 response)', async () => {
+    const { result } = renderHookWithProviders(() => useDeleteUser());
+
+    act(() => {
+      result.current.mutate(42);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+  });
+
+  it('calls onSuccess callback after deletion', async () => {
+    let called = false;
+    const { result } = renderHookWithProviders(() =>
+      useDeleteUser(() => {
+        called = true;
+      }),
+    );
+
+    act(() => {
+      result.current.mutate(42);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(called).toBe(true);
+  });
+});

--- a/frontend/src/entities/vault-settings/queries.test.ts
+++ b/frontend/src/entities/vault-settings/queries.test.ts
@@ -1,0 +1,72 @@
+import { act, waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { renderHookWithProviders } from '@tests/render/render-with-providers';
+import { mockVaultSettings } from '@tests/msw/fixtures';
+import { useVaultSettings, useUpdateVaultSettings } from './queries';
+
+describe('useVaultSettings', () => {
+  it('returns vault settings with retention_years', async () => {
+    const { result } = renderHookWithProviders(() => useVaultSettings());
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data?.retention_years).toBe(mockVaultSettings.retention_years);
+    expect(result.current.data?.organization_id).toBe(1);
+  });
+
+  it('is in loading state initially', () => {
+    const { result } = renderHookWithProviders(() => useVaultSettings());
+    expect(result.current.isLoading).toBe(true);
+  });
+});
+
+describe('useUpdateVaultSettings', () => {
+  it('patches retention_years and returns updated settings', async () => {
+    const { result } = renderHookWithProviders(() => useUpdateVaultSettings());
+
+    act(() => {
+      result.current.mutate({ retention_years: 15 });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data?.retention_years).toBe(15);
+  });
+
+  it('patches storage_path_override', async () => {
+    const { result } = renderHookWithProviders(() => useUpdateVaultSettings());
+
+    act(() => {
+      result.current.mutate({ storage_path_override: '/custom/path' });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data?.storage_path_override).toBe('/custom/path');
+  });
+
+  it('calls onSuccess callback after successful mutation', async () => {
+    let called = false;
+    const { result } = renderHookWithProviders(() =>
+      useUpdateVaultSettings(() => {
+        called = true;
+      }),
+    );
+
+    act(() => {
+      result.current.mutate({ retention_years: 12 });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(called).toBe(true);
+  });
+});

--- a/frontend/src/features/document-search/hooks/use-document-search.test.ts
+++ b/frontend/src/features/document-search/hooks/use-document-search.test.ts
@@ -1,0 +1,101 @@
+import { act, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+import { renderHookWithProviders } from '@tests/render/render-with-providers';
+import { mockDocumentList } from '@tests/msw/fixtures';
+import { server } from '@tests/msw/server';
+import { useDocumentSearch } from './use-document-search';
+
+describe('useDocumentSearch', () => {
+  it('fetches documents on mount with default params', async () => {
+    const { result } = renderHookWithProviders(() => useDocumentSearch());
+
+    await waitFor(() => {
+      expect(result.current.result.isSuccess).toBe(true);
+    });
+
+    expect(result.current.result.data?.items).toHaveLength(1);
+    expect(result.current.pagination.total).toBe(1);
+  });
+
+  it('exposes search form with register and onSubmit', () => {
+    const { result } = renderHookWithProviders(() => useDocumentSearch());
+
+    expect(result.current.form).toBeDefined();
+    expect(result.current.onSubmit).toBeTypeOf('function');
+    expect(result.current.onReset).toBeTypeOf('function');
+  });
+
+  it('pagination reflects total count', async () => {
+    const { result } = renderHookWithProviders(() => useDocumentSearch());
+
+    await waitFor(() => {
+      expect(result.current.result.isSuccess).toBe(true);
+    });
+
+    expect(result.current.pagination.canPrev).toBe(false);
+    expect(result.current.pagination.canNext).toBe(false);
+    expect(result.current.pagination.totalPages).toBe(1);
+  });
+
+  it('pagination goNext advances offset when more pages exist', async () => {
+    // Return 25 items so canNext is true (page size is 20)
+    server.use(
+      http.get('/admin/vault/documents', () => {
+        return HttpResponse.json({ ...mockDocumentList, total: 25 });
+      }),
+    );
+
+    const { result } = renderHookWithProviders(() => useDocumentSearch());
+
+    await waitFor(() => {
+      expect(result.current.result.isSuccess).toBe(true);
+    });
+
+    expect(result.current.pagination.canNext).toBe(true);
+
+    act(() => {
+      result.current.pagination.goNext();
+    });
+
+    expect(result.current.pagination.offset).toBe(20);
+  });
+
+  it('onReset clears the offset back to 0', async () => {
+    server.use(
+      http.get('/admin/vault/documents', () => {
+        return HttpResponse.json({ ...mockDocumentList, total: 25 });
+      }),
+    );
+
+    const { result } = renderHookWithProviders(() => useDocumentSearch());
+
+    await waitFor(() => {
+      expect(result.current.result.isSuccess).toBe(true);
+    });
+
+    act(() => {
+      result.current.pagination.goNext();
+    });
+    expect(result.current.pagination.offset).toBe(20);
+
+    act(() => {
+      result.current.onReset();
+    });
+    expect(result.current.pagination.offset).toBe(0);
+  });
+
+  it('is in error state when the API returns an error', async () => {
+    server.use(
+      http.get('/admin/vault/documents', () => {
+        return new HttpResponse(null, { status: 500 });
+      }),
+    );
+
+    const { result } = renderHookWithProviders(() => useDocumentSearch());
+
+    await waitFor(() => {
+      expect(result.current.result.isError).toBe(true);
+    });
+  });
+});

--- a/frontend/src/features/document-upload/hooks/use-document-upload.test.ts
+++ b/frontend/src/features/document-upload/hooks/use-document-upload.test.ts
@@ -1,0 +1,120 @@
+import { act, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+import { renderHookWithProviders } from '@tests/render/render-with-providers';
+import { mockDocument, problemDetails } from '@tests/msw/fixtures';
+import { server } from '@tests/msw/server';
+import { useUploadDocument } from '@/entities/document';
+
+import { useDocumentUpload } from './use-document-upload';
+
+function makePdfFile(name = 'invoice.pdf'): File {
+  return new File(['%PDF-1.4\nfake content'], name, { type: 'application/pdf' });
+}
+
+describe('useDocumentUpload (form hook)', () => {
+  it('initialises with empty defaults', () => {
+    const { result } = renderHookWithProviders(() => useDocumentUpload(() => undefined));
+
+    expect(result.current.form).toBeDefined();
+    expect(result.current.isSubmitting).toBe(false);
+    expect(result.current.submitError).toBeNull();
+  });
+});
+
+describe('useUploadDocument (entity mutation)', () => {
+  it('calls onSuccess after a successful upload', async () => {
+    let called = false;
+    const { result } = renderHookWithProviders(() =>
+      useUploadDocument(() => {
+        called = true;
+      }),
+    );
+
+    act(() => {
+      result.current.mutate({
+        file: makePdfFile(),
+        counterparty_name: 'Sample Inc.',
+        category: 'invoice_received',
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(called).toBe(true);
+    expect(result.current.data?.id).toBe(mockDocument.id);
+  });
+
+  it('returns the uploaded document with correct shape', async () => {
+    const { result } = renderHookWithProviders(() => useUploadDocument());
+
+    act(() => {
+      result.current.mutate({
+        file: makePdfFile(),
+        counterparty_name: 'Sample Inc.',
+        category: 'invoice_received',
+        transaction_date: '2026-03-31',
+        amount_cents: '110000',
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data?.counterparty_name).toBe(mockDocument.counterparty_name);
+    expect(result.current.data?.status).toBe('active');
+  });
+
+  it('is in error state when the server returns 415', async () => {
+    server.use(
+      http.post('/admin/vault/documents', () => {
+        return HttpResponse.json(
+          problemDetails('mime-type-not-allowed', 415, 'MIME Type Not Allowed'),
+          { status: 415, headers: { 'Content-Type': 'application/problem+json' } },
+        );
+      }),
+    );
+
+    const { result } = renderHookWithProviders(() => useUploadDocument());
+
+    act(() => {
+      result.current.mutate({
+        file: makePdfFile('doc.txt'),
+        counterparty_name: 'Test',
+        category: 'other',
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+  });
+
+  it('is in error state on duplicate file (409)', async () => {
+    server.use(
+      http.post('/admin/vault/documents', () => {
+        return HttpResponse.json(problemDetails('duplicate-file', 409, 'Duplicate File'), {
+          status: 409,
+          headers: { 'Content-Type': 'application/problem+json' },
+        });
+      }),
+    );
+
+    const { result } = renderHookWithProviders(() => useUploadDocument());
+
+    act(() => {
+      result.current.mutate({
+        file: makePdfFile(),
+        counterparty_name: 'Dup Co',
+        category: 'receipt',
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+  });
+});

--- a/frontend/tests/msw/fixtures.ts
+++ b/frontend/tests/msw/fixtures.ts
@@ -1,0 +1,133 @@
+import type { VaultDocument, DocumentListResponse } from '@/entities/document';
+import type { AuditEvent, AuditEventListResponse, DocumentHistoryResponse } from '@/entities/audit';
+import type { VaultSettings } from '@/entities/vault-settings';
+import type { User, UserListResponse } from '@/entities/user';
+
+// ── Document ──────────────────────────────────────────────────────────────────
+
+export const DOCUMENT_ID = 'doc-01J0000000000000000000000';
+export const DOCUMENT_ID_2 = 'doc-01J0000000000000000000002';
+
+export const mockDocument: VaultDocument = {
+  id: DOCUMENT_ID,
+  organization_id: 1,
+  status: 'active',
+  transaction_date: '2026-03-31',
+  amount_cents: 110000,
+  counterparty_name: 'Sample Inc.',
+  category: 'invoice_received',
+  tags: ['q1', 'important'],
+  file_sha256: 'a'.repeat(64),
+  mime_type: 'application/pdf',
+  original_filename: 'invoice.pdf',
+  file_size_bytes: 4096,
+  version_number: 1,
+  source: 'web_upload',
+  uploaded_at: '2026-04-01T10:00:00Z',
+  uploaded_by: 1,
+  voided_at: null,
+  voided_by: null,
+  void_reason: null,
+  date_uncertain: false,
+  is_metadata_confirmed: true,
+  retention_years: 10,
+  retention_expires_at: '2036-03-31',
+};
+
+export const mockVoidedDocument: VaultDocument = {
+  ...mockDocument,
+  id: DOCUMENT_ID_2,
+  status: 'voided',
+  voided_at: '2026-04-10T12:00:00Z',
+  voided_by: 1,
+  void_reason: 'Duplicate entry',
+};
+
+export const mockDocumentList: DocumentListResponse = {
+  items: [mockDocument],
+  total: 1,
+  limit: 20,
+  offset: 0,
+};
+
+// ── Audit ─────────────────────────────────────────────────────────────────────
+
+export const mockAuditEvent: AuditEvent = {
+  id: 1,
+  action: 'document.uploaded',
+  entity_type: 'vault_document',
+  entity_id: DOCUMENT_ID,
+  actor_user_id: 1,
+  organization_id: 1,
+  before_json: null,
+  after_json: { counterparty_name: 'Sample Inc.', amount_cents: 110000 },
+  source: 'api',
+  metadata_json: null,
+  created_at: '2026-04-01T10:00:00Z',
+};
+
+export const mockAuditEventList: AuditEventListResponse = {
+  items: [mockAuditEvent],
+  total: 1,
+  limit: 20,
+  offset: 0,
+};
+
+export const mockDocumentHistory: DocumentHistoryResponse = {
+  versions: [
+    {
+      id: 'ver-01J0000000000000000000001',
+      version_number: 1,
+      file_sha256: 'a'.repeat(64),
+      mime_type: 'application/pdf',
+      original_filename: 'invoice.pdf',
+      file_size_bytes: 4096,
+      source: 'web_upload',
+      uploaded_at: '2026-04-01T10:00:00Z',
+      uploaded_by: 1,
+    },
+  ],
+  audit_events: [mockAuditEvent],
+};
+
+// ── VaultSettings ────────────────────────────────────────────────────────────
+
+export const mockVaultSettings: VaultSettings = {
+  organization_id: 1,
+  retention_years: 10,
+  storage_path_override: null,
+  invoice_api_base_url: null,
+  clear_api_base_url: null,
+  updated_at: '2026-04-01T08:00:00Z',
+};
+
+// ── User ─────────────────────────────────────────────────────────────────────
+
+export const mockUser: User = {
+  id: 42,
+  email: 'member@example.com',
+  role: 'member',
+  organization_id: 1,
+  status: 'active',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+};
+
+export const mockUserList: UserListResponse = {
+  items: [mockUser],
+  total: 1,
+  limit: 20,
+  offset: 0,
+};
+
+// ── Problem Details ───────────────────────────────────────────────────────────
+
+export function problemDetails(slug: string, status: number, title: string) {
+  return {
+    type: `https://nene-vault.dev/problems/${slug}`,
+    title,
+    status,
+    detail: `${title}.`,
+    instance: '/test',
+  };
+}

--- a/frontend/tests/msw/handlers.ts
+++ b/frontend/tests/msw/handlers.ts
@@ -1,7 +1,22 @@
 import { http, HttpResponse } from 'msw';
+import {
+  mockDocument,
+  mockVoidedDocument,
+  mockDocumentList,
+  mockAuditEventList,
+  mockDocumentHistory,
+  mockVaultSettings,
+  mockUserList,
+  mockUser,
+  DOCUMENT_ID,
+  problemDetails,
+} from './fixtures';
 
 // MSW handlers mirror the OpenAPI contract shapes.
+// All paths are relative (no host) because apiBaseUrl is '' in test env.
 export const handlers = [
+  // ── Auth ────────────────────────────────────────────────────────────────────
+
   http.post('/admin/auth/login', async ({ request }) => {
     const body = (await request.json()) as { email: string; password: string };
 
@@ -16,13 +31,113 @@ export const handlers = [
       });
     }
 
-    return HttpResponse.json(
-      {
-        type: 'https://nene-vault.dev/problems/invalid-credentials',
-        title: 'Invalid Credentials',
-        status: 401,
-      },
-      { status: 401, headers: { 'Content-Type': 'application/problem+json' } },
-    );
+    return HttpResponse.json(problemDetails('invalid-credentials', 401, 'Invalid Credentials'), {
+      status: 401,
+      headers: { 'Content-Type': 'application/problem+json' },
+    });
+  }),
+
+  // ── Documents ────────────────────────────────────────────────────────────────
+
+  http.get('/admin/vault/documents', () => {
+    return HttpResponse.json(mockDocumentList);
+  }),
+
+  http.get('/admin/vault/documents/:id', ({ params }) => {
+    const { id } = params;
+    if (id === DOCUMENT_ID) {
+      return HttpResponse.json(mockDocument);
+    }
+    return HttpResponse.json(problemDetails('document-not-found', 404, 'Document Not Found'), {
+      status: 404,
+      headers: { 'Content-Type': 'application/problem+json' },
+    });
+  }),
+
+  http.post('/admin/vault/documents', () => {
+    return HttpResponse.json(mockDocument, { status: 201 });
+  }),
+
+  http.patch('/admin/vault/documents/:id/metadata', ({ params }) => {
+    const { id } = params;
+    if (id === DOCUMENT_ID) {
+      return HttpResponse.json({ ...mockDocument, counterparty_name: 'Updated Inc.' });
+    }
+    return HttpResponse.json(problemDetails('document-not-found', 404, 'Document Not Found'), {
+      status: 404,
+      headers: { 'Content-Type': 'application/problem+json' },
+    });
+  }),
+
+  http.post('/admin/vault/documents/:id/void', async ({ params, request }) => {
+    const { id } = params;
+    const body = (await request.json()) as { void_reason?: string };
+    if (!body.void_reason) {
+      return HttpResponse.json(problemDetails('validation-failed', 422, 'Validation Failed'), {
+        status: 422,
+        headers: { 'Content-Type': 'application/problem+json' },
+      });
+    }
+    if (id === DOCUMENT_ID) {
+      return HttpResponse.json(mockVoidedDocument);
+    }
+    return HttpResponse.json(problemDetails('document-not-found', 404, 'Document Not Found'), {
+      status: 404,
+      headers: { 'Content-Type': 'application/problem+json' },
+    });
+  }),
+
+  http.post('/admin/vault/documents/:id/restore', ({ params }) => {
+    const { id } = params;
+    if (id === DOCUMENT_ID) {
+      return HttpResponse.json(mockDocument);
+    }
+    return HttpResponse.json(problemDetails('document-not-found', 404, 'Document Not Found'), {
+      status: 404,
+      headers: { 'Content-Type': 'application/problem+json' },
+    });
+  }),
+
+  http.get('/admin/vault/documents/:id/history', ({ params }) => {
+    const { id } = params;
+    if (id === DOCUMENT_ID) {
+      return HttpResponse.json(mockDocumentHistory);
+    }
+    return HttpResponse.json(problemDetails('document-not-found', 404, 'Document Not Found'), {
+      status: 404,
+      headers: { 'Content-Type': 'application/problem+json' },
+    });
+  }),
+
+  // ── Audit events ──────────────────────────────────────────────────────────────
+
+  http.get('/admin/audit-events', () => {
+    return HttpResponse.json(mockAuditEventList);
+  }),
+
+  // ── Vault settings ────────────────────────────────────────────────────────────
+
+  http.get('/admin/vault/settings', () => {
+    return HttpResponse.json(mockVaultSettings);
+  }),
+
+  http.patch('/admin/vault/settings', async ({ request }) => {
+    const body = (await request.json()) as Record<string, unknown>;
+    return HttpResponse.json({ ...mockVaultSettings, ...body });
+  }),
+
+  // ── Users ────────────────────────────────────────────────────────────────────
+
+  http.get('/admin/users', () => {
+    return HttpResponse.json(mockUserList);
+  }),
+
+  http.post('/admin/users', async ({ request }) => {
+    const body = (await request.json()) as { email: string; role: string };
+    return HttpResponse.json({ ...mockUser, email: body.email, role: body.role }, { status: 201 });
+  }),
+
+  http.delete('/admin/users/:id', () => {
+    return new HttpResponse(null, { status: 204 });
   }),
 ];


### PR DESCRIPTION
## Summary

Closes #53. Grows frontend test coverage from **2 tests** (login only) to **40 tests** across all entities and features.

## What was added

**`tests/msw/fixtures.ts`** — shared typed fixtures for all domains (single source of truth for test shapes)

**`tests/msw/handlers.ts`** — extended from login-only to 14 handlers covering every API route:
`documents` (list/get/upload/metadata/void/restore/history), `audit-events`, `vault/settings`, `users`

**New test files:**

| File | Tests | What's covered |
|---|---|---|
| `entities/document/queries.test.ts` | 5 | `useDocuments` (list, loading state, params), `useDocumentById` (found, 404) |
| `entities/document/mutations.test.ts` | 6 | `useUpdateDocumentMetadata`, `useVoidDocument` (happy + 422), `useRestoreDocument` |
| `entities/audit/queries.test.ts` | 5 | `useAuditEvents` (shape, filter), `useDocumentHistory` (found, 404) |
| `entities/vault-settings/queries.test.ts` | 5 | `useVaultSettings`, `useUpdateVaultSettings` (retention, path, callback) |
| `entities/user/queries.test.ts` | 6 | `useUsers`, `useCreateUser`, `useDeleteUser` (+ callbacks) |
| `features/document-search/queries.test.ts` | 6 | initial fetch, pagination goNext/onReset, error state |
| `features/document-upload/queries.test.ts` | 5 | form defaults, upload success + callback, 415/409 error paths |

## Verification
`npm run check` (type-check → lint → format → **test: 40/40** → knip → build-storybook) → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)