### PR TITLE
chore: Docker Compose development environment (#57)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,37 @@
+# PHP runtime artifacts
+vendor/
+var/
+.php-cs-fixer.cache
+
+# Frontend build artifacts
+frontend/node_modules/
+frontend/dist/
+frontend/storybook-static/
+frontend/coverage/
+
+# Test artifacts
+tests/
+*.test.php
+phpunit.xml.dist
+phpstan.neon.dist
+.php-cs-fixer.php
+
+# Git / editor
+.git/
+.gitignore
+.gitattributes
+.editorconfig
+*.md
+!README.md
+
+# Docker (don't include docker files in the COPY context)
+docker-compose*.yml
+.dockerignore
+Dockerfile
+frontend/Dockerfile
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo

--- a/.env.example
+++ b/.env.example
@@ -27,7 +27,17 @@ DB_USER=nene_vault
 DB_PASSWORD=
 DB_CHARSET=utf8mb4
 
-# --- Docker Compose overrides (copy to .env and uncomment for local stack) ---
+# --- Initial admin user (created on first docker compose up) ---
+ORG_NAME=NeNe Vault
+ADMIN_EMAIL=admin@example.com
+ADMIN_PASSWORD=changeme123
+
+# --- Docker Compose port bindings ---
+NENE_VAULT_PORT=8080
+NENE_VAULT_FRONTEND_PORT=5173
+NENE_VAULT_MYSQL_PORT=3307
+
+# --- Docker Compose MySQL overrides (copy to .env and uncomment) ---
 # DB_ADAPTER=mysql
 # DB_HOST=mysql
 # DB_PORT=3306
@@ -35,6 +45,6 @@ DB_CHARSET=utf8mb4
 # DB_USER=nene_vault
 # DB_PASSWORD=nene_vault
 # MYSQL_ROOT_PASSWORD=nene_vault_root
-#
-# NENE_VAULT_PORT=8080
-# NENE_VAULT_MYSQL_PORT=3307
+
+# --- Frontend proxy host (set to 'app' when using Docker Compose) ---
+# NENE_VAULT_APP_HOST=app

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 /vendor/
-/var/
+/var/*.sqlite
+/var/*.cache
 /.env
 /.php-cs-fixer.cache
 /.phpstan.cache/
 .phpunit.result.cache
-/storage/
+/storage/vault/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,75 @@
+FROM php:8.4-apache AS base
+
+# ── System dependencies ───────────────────────────────────────────────────────
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        unzip \
+        curl \
+        libzip-dev \
+        libonig-dev \
+        default-libmysqlclient-dev \
+    && docker-php-ext-install pdo pdo_mysql mbstring zip \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install Composer (used in init.sh for prod and as a tool reference)
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+# ── Apache configuration ──────────────────────────────────────────────────────
+RUN a2enmod rewrite
+
+RUN printf '<VirtualHost *:8080>\n\
+    DocumentRoot /var/www/html/public_html\n\
+    <Directory /var/www/html/public_html>\n\
+        Options -Indexes +FollowSymLinks\n\
+        AllowOverride All\n\
+        Require all granted\n\
+    </Directory>\n\
+    ErrorLog ${APACHE_LOG_DIR}/error.log\n\
+    CustomLog ${APACHE_LOG_DIR}/access.log combined\n\
+</VirtualHost>\n' > /etc/apache2/sites-available/000-default.conf
+
+RUN sed -i 's/Listen 80/Listen 8080/' /etc/apache2/ports.conf
+
+EXPOSE 8080
+
+# ── Development target ────────────────────────────────────────────────────────
+# Source is mounted at runtime (docker compose volume mount).
+# nene2 is a path-based dependency resolved on the host; the host's vendor/
+# directory is mounted read-only. init.sh only runs migrations + seeds.
+FROM base AS dev
+
+WORKDIR /var/www/html
+
+COPY docker/init.sh /usr/local/bin/init.sh
+RUN chmod +x /usr/local/bin/init.sh
+
+ENV APACHE_RUN_USER=www-data \
+    APACHE_RUN_GROUP=www-data \
+    APACHE_LOG_DIR=/var/log/apache2
+
+ENTRYPOINT ["/usr/local/bin/init.sh"]
+
+# ── Production target ─────────────────────────────────────────────────────────
+# Expects the entire monorepo context (../) including ../NENE2 so composer can
+# resolve the path dependency. Run:
+#   docker build --target prod -f nene-vault/Dockerfile ..
+FROM base AS prod
+
+WORKDIR /var/www/html
+
+# Copy the nene-vault project and NENE2 sibling (required by composer path repo)
+COPY nene-vault/ /var/www/html/
+COPY NENE2/ /NENE2/
+
+RUN composer install --no-dev --optimize-autoloader --no-interaction \
+    && chown -R www-data:www-data /var/www/html \
+    && rm -rf /NENE2
+
+COPY nene-vault/docker/init.sh /usr/local/bin/init.sh
+RUN chmod +x /usr/local/bin/init.sh
+
+ENV APACHE_RUN_USER=www-data \
+    APACHE_RUN_GROUP=www-data \
+    APACHE_LOG_DIR=/var/log/apache2
+
+ENTRYPOINT ["/usr/local/bin/init.sh"]

--- a/README.md
+++ b/README.md
@@ -49,10 +49,42 @@ without becoming accounting software or expense workflow. Built on
 | **Agents** | [`AGENTS.md`](./AGENTS.md) |
 | **Roadmap** | [`docs/roadmap.md`](./docs/roadmap.md) |
 
+## Quick start (Docker)
+
+```sh
+composer install            # once, on the host — resolves the ../NENE2 path dependency
+cp .env.example .env        # customise ADMIN_EMAIL / ADMIN_PASSWORD if desired
+docker compose up           # SQLite (default) + Vite dev server
+```
+
+Then open:
+
+| Service  | URL                     | Notes                                  |
+|----------|-------------------------|----------------------------------------|
+| Frontend | http://localhost:5173   | Vite dev server (proxies API to `app`) |
+| API      | http://localhost:8080   | Apache + PHP 8.4                        |
+
+First-run admin credentials come from `.env` (`ADMIN_EMAIL` / `ADMIN_PASSWORD`,
+default `admin@example.com` / `changeme123`). A `default` organization, its
+vault settings, and a superadmin user are seeded automatically.
+
+**MySQL instead of SQLite:**
+
+```sh
+docker compose --profile mysql -f docker-compose.yml -f docker-compose.mysql.yml up
+```
+
+**Port conflicts:** if 8080 / 5173 are already in use (e.g. a sibling product's
+dev server), override the host ports:
+
+```sh
+NENE_VAULT_PORT=8090 NENE_VAULT_FRONTEND_PORT=5180 docker compose up
+```
+
 ## Status
 
 **Phase 0 complete** — governance and product design done (PR #1, #2 merged 2026-05-30).
-Phase 1 runtime scaffold follows Issues #4+.
+Phase 1 (API) and Phase 2 (Admin UI) implemented; Docker development environment available.
 
 ## Ecosystem
 

--- a/docker-compose.mysql.yml
+++ b/docker-compose.mysql.yml
@@ -1,0 +1,24 @@
+## MySQL override for NeNe Vault
+##
+## Usage:
+##   docker compose -f docker-compose.yml -f docker-compose.mysql.yml up
+##
+## Or use the mysql profile shorthand:
+##   docker compose --profile mysql up
+
+services:
+  app:
+    environment:
+      DB_ENV: local
+      DB_ADAPTER: mysql
+      DB_HOST: mysql
+      DB_PORT: "3306"
+      DB_NAME: "${DB_NAME:-nene_vault}"
+      DB_USER: "${DB_USER:-nene_vault}"
+      DB_PASSWORD: "${DB_PASSWORD:-nene_vault}"
+    depends_on:
+      mysql:
+        condition: service_healthy
+
+  mysql:
+    profiles: []  # Remove profile restriction so MySQL always starts

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,106 @@
+## NeNe Vault — development stack
+##
+## Prerequisites:
+##   composer install     (once, on the host — resolves ../NENE2 path dependency)
+##   cp .env.example .env (and customise as needed)
+##
+## Usage:
+##   docker compose up                    # SQLite (default), Vite dev server
+##   docker compose --profile mysql up    # MySQL variant
+##
+## First-run credentials (see .env / ADMIN_EMAIL / ADMIN_PASSWORD):
+##   Admin login: admin@example.com / changeme123
+##   API base:    http://localhost:8080
+##   Frontend:    http://localhost:5173
+
+services:
+  # ── PHP backend (Apache + PHP 8.4) ──────────────────────────────────────────
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: dev
+    ports:
+      - "${NENE_VAULT_PORT:-8080}:8080"
+    volumes:
+      # Source + vendor (read-only); vendor resolved by host composer install
+      - .:/var/www/html:ro
+      # vendor/hideyukimori/nene2 is a symlink pointing 3 levels up to NENE2/.
+      # Mount the sibling NENE2 directory at the resolved path inside the container.
+      - ../NENE2:/var/www/NENE2:ro
+      # SQLite database and uploaded files need to be writable
+      - sqlite_data:/var/www/html/var
+      - vault_storage:/var/www/html/storage/vault
+    environment:
+      APP_ENV: local
+      APP_DEBUG: "true"
+      NENE2_LOCAL_JWT_SECRET: "${NENE2_LOCAL_JWT_SECRET:-nene-vault-dev-secret-CHANGE-IN-PROD}"
+      PROBLEM_DETAILS_BASE_URL: "${PROBLEM_DETAILS_BASE_URL:-https://nene-vault.dev/problems/}"
+      TENANT_RESOLUTION: "${TENANT_RESOLUTION:-single}"
+      ORG_SLUG: "${ORG_SLUG:-default}"
+      ORG_NAME: "${ORG_NAME:-NeNe Vault}"
+      ADMIN_EMAIL: "${ADMIN_EMAIL:-admin@example.com}"
+      ADMIN_PASSWORD: "${ADMIN_PASSWORD:-changeme123}"
+      NENE_VAULT_STORAGE_PATH: storage/vault
+      NENE_VAULT_MAX_FILE_SIZE_MB: "${NENE_VAULT_MAX_FILE_SIZE_MB:-20}"
+      DB_ENV: local
+      DB_ADAPTER: sqlite
+      # Absolute path — Apache's CWD is not /var/www/html, so a relative path
+      # would resolve incorrectly at request time.
+      DB_NAME: /var/www/html/var/nene_vault.sqlite
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+
+  # ── Vite dev server ──────────────────────────────────────────────────────────
+  frontend:
+    build:
+      context: .
+      dockerfile: frontend/Dockerfile
+      target: dev
+    ports:
+      - "${NENE_VAULT_FRONTEND_PORT:-5173}:5173"
+    volumes:
+      # Mount entire repo so @locales alias resolves to /app/locales
+      - .:/app:ro
+      # node_modules from the image (not overwritten by the mount)
+      - frontend_modules:/app/frontend/node_modules
+    working_dir: /app/frontend
+    command: ["npx", "vite", "--host", "0.0.0.0"]
+    environment:
+      # Proxy target: 'app' service inside Docker, 'localhost' on the host
+      NENE_VAULT_APP_HOST: app
+      NENE_VAULT_PORT: "8080"
+    depends_on:
+      app:
+        condition: service_healthy
+
+  # ── MySQL (opt-in via --profile mysql) ───────────────────────────────────────
+  mysql:
+    image: mysql:8.0
+    profiles: [mysql]
+    ports:
+      - "${NENE_VAULT_MYSQL_PORT:-3307}:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: "${MYSQL_ROOT_PASSWORD:-nene_vault_root}"
+      MYSQL_DATABASE: "${DB_NAME:-nene_vault}"
+      MYSQL_USER: "${DB_USER:-nene_vault}"
+      MYSQL_PASSWORD: "${DB_PASSWORD:-nene_vault}"
+    volumes:
+      - mysql_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root",
+             "--password=${MYSQL_ROOT_PASSWORD:-nene_vault_root}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+
+volumes:
+  sqlite_data:
+  vault_storage:
+  frontend_modules:
+  mysql_data:

--- a/docker/bootstrap-schema.php
+++ b/docker/bootstrap-schema.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * Idempotent SQLite schema bootstrap for Docker development.
+ *
+ * Mirrors tests/bootstrap.php — uses CREATE TABLE IF NOT EXISTS so it is safe
+ * to run on every container start. For MySQL, run phinx migrations instead.
+ */
+
+declare(strict_types=1);
+
+$dbName = (string) (getenv('DB_NAME') ?: 'var/nene_vault.sqlite');
+$dbPath = str_starts_with($dbName, '/') ? $dbName : (string) getcwd() . '/' . $dbName;
+
+$dir = dirname($dbPath);
+if (!is_dir($dir)) {
+    mkdir($dir, 0777, true);
+}
+
+$pdo = new PDO('sqlite:' . $dbPath, null, null, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+$pdo->exec('PRAGMA journal_mode=WAL');
+
+$pdo->exec('CREATE TABLE IF NOT EXISTS organizations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name VARCHAR(255) NOT NULL,
+    slug VARCHAR(100) NOT NULL,
+    external_id VARCHAR(255),
+    custom_domain VARCHAR(255),
+    plan VARCHAR(32) NOT NULL DEFAULT "free",
+    is_active INTEGER NOT NULL DEFAULT 1,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    UNIQUE(slug),
+    UNIQUE(custom_domain),
+    UNIQUE(external_id)
+)');
+
+$pdo->exec('CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    email VARCHAR(255) NOT NULL,
+    password_hash VARCHAR(255) NOT NULL,
+    role VARCHAR(32) NOT NULL DEFAULT "admin",
+    organization_id INTEGER,
+    status VARCHAR(16) NOT NULL DEFAULT "active",
+    invite_token_hash VARCHAR(64),
+    invite_expires_at DATETIME,
+    password_reset_token_hash VARCHAR(64),
+    password_reset_expires_at DATETIME,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    UNIQUE(email)
+)');
+
+$pdo->exec('CREATE TABLE IF NOT EXISTS vault_settings (
+    organization_id INTEGER PRIMARY KEY,
+    retention_years INTEGER NOT NULL DEFAULT 10,
+    storage_path_override VARCHAR(512),
+    invoice_api_base_url VARCHAR(512),
+    clear_api_base_url VARCHAR(512),
+    updated_by INTEGER,
+    updated_at DATETIME NOT NULL
+)');
+
+$pdo->exec('CREATE TABLE IF NOT EXISTS audit_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    action VARCHAR(64) NOT NULL,
+    entity_type VARCHAR(64) NOT NULL,
+    entity_id VARCHAR(64) NOT NULL,
+    actor_user_id INTEGER,
+    organization_id INTEGER,
+    before_json TEXT,
+    after_json TEXT,
+    source VARCHAR(32) NOT NULL DEFAULT "api",
+    metadata_json TEXT,
+    created_at DATETIME NOT NULL
+)');
+
+$pdo->exec('CREATE TABLE IF NOT EXISTS vault_documents (
+    id CHAR(26) PRIMARY KEY,
+    organization_id INTEGER NOT NULL,
+    current_version_id CHAR(26) NOT NULL,
+    status VARCHAR(16) NOT NULL DEFAULT "active",
+    transaction_date DATE,
+    amount_cents INTEGER,
+    counterparty_name VARCHAR(255) NOT NULL,
+    category VARCHAR(32) NOT NULL,
+    tags TEXT,
+    date_uncertain INTEGER NOT NULL DEFAULT 0,
+    is_metadata_confirmed INTEGER NOT NULL DEFAULT 0,
+    retention_years INTEGER NOT NULL DEFAULT 10,
+    retention_expires_at DATE NOT NULL,
+    uploaded_at DATETIME NOT NULL,
+    uploaded_by INTEGER,
+    voided_at DATETIME,
+    voided_by INTEGER,
+    void_reason VARCHAR(255),
+    void_note TEXT
+)');
+
+$pdo->exec('CREATE TABLE IF NOT EXISTS document_versions (
+    id CHAR(26) PRIMARY KEY,
+    vault_document_id CHAR(26) NOT NULL,
+    organization_id INTEGER NOT NULL,
+    version_number INTEGER NOT NULL,
+    file_path VARCHAR(512) NOT NULL,
+    file_sha256 CHAR(64) NOT NULL,
+    mime_type VARCHAR(64) NOT NULL,
+    original_filename VARCHAR(255) NOT NULL,
+    file_size_bytes INTEGER NOT NULL,
+    source VARCHAR(32) NOT NULL DEFAULT "web_upload",
+    uploaded_at DATETIME NOT NULL,
+    uploaded_by INTEGER,
+    UNIQUE(vault_document_id, version_number)
+)');
+
+echo "[schema] SQLite schema ready at {$dbPath}\n";

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+set -e
+
+cd /var/www/html
+
+# ── Sanity check ──────────────────────────────────────────────────────────────
+if [ ! -f vendor/autoload.php ]; then
+  echo "[init] ERROR: vendor/autoload.php not found."
+  echo "[init] Run 'composer install' on the host before starting the container."
+  exit 1
+fi
+
+# ── Wait for MySQL when DB_ADAPTER=mysql ──────────────────────────────────────
+if [ "${DB_ADAPTER:-sqlite}" = "mysql" ]; then
+  echo "[init] Waiting for MySQL at ${DB_HOST:-mysql}:${DB_PORT:-3306}..."
+  until php -r "
+    try {
+      \$pdo = new PDO(
+        'mysql:host=${DB_HOST:-mysql};port=${DB_PORT:-3306};dbname=${DB_NAME:-nene_vault}',
+        '${DB_USER:-nene_vault}',
+        '${DB_PASSWORD:-nene_vault}'
+      );
+      echo 'OK';
+    } catch (Exception \$e) { exit(1); }
+  " 2>/dev/null; do
+    printf '.'
+    sleep 2
+  done
+  echo ""
+  echo "[init] MySQL ready."
+fi
+
+# ── Apply schema / migrations ──────────────────────────────────────────────────
+if [ "${DB_ADAPTER:-sqlite}" = "sqlite" ]; then
+  # phinx appends .sqlite3 to the filename, mismatching the app's PDO DSN.
+  # Use the idempotent CREATE TABLE IF NOT EXISTS bootstrap script instead.
+  echo "[init] Bootstrapping SQLite schema..."
+  mkdir -p var && chmod 775 var
+  php docker/bootstrap-schema.php
+  # Apache (www-data) needs write access for WAL journal files
+  chown -R www-data:www-data var/ 2>/dev/null || true
+  chmod -R 664 var/*.sqlite 2>/dev/null || true
+else
+  echo "[init] Running MySQL migrations (env: ${DB_ENV:-local})..."
+  php vendor/bin/phinx migrate -c phinx.php -e "${DB_ENV:-local}"
+fi
+
+# ── Seed initial org + user (idempotent) ─────────────────────────────────────
+echo "[init] Seeding initial data..."
+php docker/seed-initial.php
+
+echo "[init] Starting Apache on port 8080..."
+exec apache2-foreground

--- a/docker/seed-initial.php
+++ b/docker/seed-initial.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * Idempotent initial seed for Docker development.
+ *
+ * Creates (if absent):
+ *   1. The default organization (matching ORG_SLUG env)
+ *   2. Default vault_settings for that org
+ *   3. A superadmin user (email + password from env, or safe defaults)
+ *
+ * Uses raw PDO to guarantee the same database file that phinx just migrated.
+ * Safe to run multiple times — INSERT OR IGNORE / INSERT IGNORE.
+ */
+
+declare(strict_types=1);
+
+$adapter       = (string) (getenv('DB_ADAPTER') ?: 'sqlite');
+$dbName        = (string) (getenv('DB_NAME') ?: 'var/nene_vault.sqlite');
+$orgSlug       = (string) (getenv('ORG_SLUG') ?: 'default');
+$orgName       = (string) (getenv('ORG_NAME') ?: 'NeNe Vault');
+$adminEmail    = (string) (getenv('ADMIN_EMAIL') ?: 'admin@example.com');
+$adminPassword = (string) (getenv('ADMIN_PASSWORD') ?: 'changeme123');
+
+// ── Build PDO connection directly ─────────────────────────────────────────────
+if ($adapter === 'mysql') {
+    $host   = (string) (getenv('DB_HOST') ?: 'mysql');
+    $port   = (string) (getenv('DB_PORT') ?: '3306');
+    $user   = (string) (getenv('DB_USER') ?: 'nene_vault');
+    $pass   = (string) (getenv('DB_PASSWORD') ?: 'nene_vault');
+    $dsn    = "mysql:host={$host};port={$port};dbname={$dbName};charset=utf8mb4";
+    $pdo    = new PDO($dsn, $user, $pass, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+    $ignore = 'INSERT IGNORE INTO';
+} else {
+    // Resolve relative path from CWD (init.sh does `cd /var/www/html`)
+    $dbPath = str_starts_with($dbName, '/') ? $dbName : (string) getcwd() . '/' . $dbName;
+    $pdo    = new PDO('sqlite:' . $dbPath, null, null, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+    $ignore = 'INSERT OR IGNORE INTO';
+}
+
+echo "[seed] DB adapter={$adapter}, name={$dbName}\n";
+
+$now = date('Y-m-d H:i:s');
+
+// ── 1. Default org ────────────────────────────────────────────────────────────
+$pdo->exec("{$ignore} organizations
+    (name, slug, plan, is_active, created_at, updated_at)
+    VALUES ('{$orgName}', '{$orgSlug}', 'free', 1, '{$now}', '{$now}')");
+
+$stmt = $pdo->query("SELECT id FROM organizations WHERE slug = '{$orgSlug}'");
+assert($stmt !== false);
+$row  = $stmt->fetch();
+assert($row !== false);
+$orgId = (int) $row['id'];
+echo "[seed] org '{$orgSlug}' → id={$orgId}\n";
+
+// ── 2. vault_settings for the org ─────────────────────────────────────────────
+$pdo->exec("{$ignore} vault_settings
+    (organization_id, retention_years, updated_at)
+    VALUES ({$orgId}, 10, '{$now}')");
+echo "[seed] vault_settings seeded\n";
+
+// ── 3. Superadmin user ────────────────────────────────────────────────────────
+$hash = password_hash($adminPassword, PASSWORD_BCRYPT);
+$pdo->exec("{$ignore} users
+    (email, password_hash, role, organization_id, status, created_at, updated_at)
+    VALUES ('{$adminEmail}', '{$hash}', 'superadmin', NULL, 'active', '{$now}', '{$now}')");
+echo "[seed] superadmin '{$adminEmail}' seeded\n";
+echo "[seed] Done.\n";

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,44 @@
+# ── Development target ────────────────────────────────────────────────────────
+# Build context must be the repo root so locales/ is accessible.
+# docker compose sets context: ..  for this service.
+FROM node:22-alpine AS dev
+
+WORKDIR /app/frontend
+
+# Install dependencies first (cached layer)
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+
+# Source is mounted at runtime via volume.
+# Vite is started by the dev service's command in docker-compose.yml.
+
+EXPOSE 5173
+
+# ── Build stage ───────────────────────────────────────────────────────────────
+FROM node:22-alpine AS build
+
+WORKDIR /app/frontend
+
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+
+# Copy the whole repo so locales/ resolves via the @locales alias
+COPY . /app/
+
+WORKDIR /app/frontend
+RUN npm run build
+
+# ── Production static server ──────────────────────────────────────────────────
+FROM nginx:1.27-alpine AS prod
+
+COPY --from=build /app/frontend/dist /usr/share/nginx/html
+
+# SPA routing: send all 404s back to index.html
+RUN printf 'server {\n\
+    listen 80;\n\
+    root /usr/share/nginx/html;\n\
+    index index.html;\n\
+    location / { try_files $uri $uri/ /index.html; }\n\
+}\n' > /etc/nginx/conf.d/default.conf
+
+EXPOSE 80

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -7,11 +7,14 @@ import { defineConfig, loadEnv } from 'vite';
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig(({ mode }) => {
-  // Read NENE_VAULT_PORT from the project-root .env (one level up from frontend/)
-  // so the dev proxy stays in sync without duplicating the value.
+  // Read NENE_VAULT_PORT and NENE_VAULT_APP_HOST from the project-root .env
+  // (one level up from frontend/) so the dev proxy stays in sync.
+  // NENE_VAULT_APP_HOST defaults to 'localhost' but is set to 'app' inside Docker Compose.
   const projectEnv = loadEnv(mode, path.resolve(dirname, '..'), '');
-  const appPort = projectEnv['NENE_VAULT_PORT'] ?? '8080';
-  const target = `http://localhost:${appPort}`;
+  const appHost =
+    process.env['NENE_VAULT_APP_HOST'] ?? projectEnv['NENE_VAULT_APP_HOST'] ?? 'localhost';
+  const appPort = process.env['NENE_VAULT_PORT'] ?? projectEnv['NENE_VAULT_PORT'] ?? '8080';
+  const target = `http://${appHost}:${appPort}`;
 
   return {
     plugins: [react(), tailwindcss()],
@@ -24,6 +27,7 @@ export default defineConfig(({ mode }) => {
       },
     },
     server: {
+      host: true,
       fs: { allow: [path.resolve(dirname, '..')] },
       proxy: {
         '/admin': { target, changeOrigin: true },

--- a/public_html/.htaccess
+++ b/public_html/.htaccess
@@ -1,0 +1,6 @@
+Options -MultiViews -Indexes
+RewriteEngine On
+
+# Route all requests through the front controller
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteRule ^ index.php [QSA,L]


### PR DESCRIPTION
## Summary

Closes #57. `docker compose up` brings up the full stack and was verified end-to-end.

## Services
- **app** — Apache + PHP 8.4, DocumentRoot `public_html/`, port 8080
- **frontend** — Node 22 Vite dev server, proxies `/admin` + `/health` to `app`
- **mysql** — opt-in via `--profile mysql` (SQLite is the default)

## Verified end-to-end
With the stack running:
- `POST /admin/auth/login` → JWT issued (seeded `admin@example.com` superadmin)
- `GET /admin/organizations` → returns the seeded `default` org
- `GET /admin/vault/documents` → 200 with bearer token
- All via the Vite proxy on the frontend port

## Key decisions
- **nene2 is a host path dependency** (`../NENE2`), so the dev target mounts source + `vendor/` read-only (run `composer install` on the host once). The prod target bakes NENE2 in from the monorepo context.
- **SQLite schema via `docker/bootstrap-schema.php`** (CREATE TABLE IF NOT EXISTS) — phinx appends `.sqlite3` to the DB filename, mismatching the app's PDO DSN. MySQL still uses phinx migrations.
- **`DB_NAME` is absolute** in compose — Apache's CWD is not `/var/www/html`, so a relative SQLite path resolves incorrectly at request time.
- SQLite file chowned to `www-data` so Apache can write WAL files.

## Gotcha documented in README
Sibling products' dev servers may already hold `8080` / `5173`. Override with `NENE_VAULT_PORT` / `NENE_VAULT_FRONTEND_PORT`. (During development the host's nene-records Vite server on `127.0.0.1:5173` shadowed the container — worth a heads-up.)

## Files
`Dockerfile`, `frontend/Dockerfile`, `docker-compose.yml`, `docker-compose.mysql.yml`, `docker/{init.sh,bootstrap-schema.php,seed-initial.php}`, `public_html/.htaccess`, `.dockerignore`, `.env.example`, `README.md`, `vite.config.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)