### PR TITLE
fix(frontend): login impossible — Input forwards RHF ref (#59)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>NeNe Vault</title>
   </head>
   <body>

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <rect width="32" height="32" rx="6" fill="#1f2937" />
+  <rect x="6" y="6" width="20" height="20" rx="3" fill="none" stroke="#60a5fa" stroke-width="2" />
+  <circle cx="16" cy="16" r="4.5" fill="none" stroke="#60a5fa" stroke-width="2" />
+  <circle cx="16" cy="16" r="1.5" fill="#60a5fa" />
+  <line x1="16" y1="16" x2="16" y2="11.5" stroke="#60a5fa" stroke-width="2" stroke-linecap="round" />
+</svg>

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -14,14 +14,21 @@ function guarded(element: React.ReactElement) {
   return <AuthGate>{element}</AuthGate>;
 }
 
-export const router = createBrowserRouter([
-  { path: '/login', element: <LoginPage /> },
-  { path: '/forbidden', element: <ForbiddenPage /> },
-  { path: '/', element: guarded(<HomePage />) },
-  { path: '/documents', element: guarded(<DocumentsPage />) },
-  { path: '/documents/:id', element: guarded(<DocumentDetailPage />) },
-  { path: '/audit', element: guarded(<AuditPage />) },
-  { path: '/settings', element: guarded(<SettingsPage />) },
-  { path: '/users', element: guarded(<UsersPage />) },
-  { path: '/export', element: guarded(<ExportPage />) },
-]);
+export const router = createBrowserRouter(
+  [
+    { path: '/login', element: <LoginPage /> },
+    { path: '/forbidden', element: <ForbiddenPage /> },
+    { path: '/', element: guarded(<HomePage />) },
+    { path: '/documents', element: guarded(<DocumentsPage />) },
+    { path: '/documents/:id', element: guarded(<DocumentDetailPage />) },
+    { path: '/audit', element: guarded(<AuditPage />) },
+    { path: '/settings', element: guarded(<SettingsPage />) },
+    { path: '/users', element: guarded(<UsersPage />) },
+    { path: '/export', element: guarded(<ExportPage />) },
+  ],
+  {
+    future: {
+      v7_relativeSplatPath: true,
+    },
+  },
+);

--- a/frontend/src/features/login/ui/LoginForm.test.tsx
+++ b/frontend/src/features/login/ui/LoginForm.test.tsx
@@ -1,0 +1,57 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '@tests/render/render-with-providers';
+import { authStore } from '@/entities/auth';
+import { LoginForm } from './LoginForm';
+
+/**
+ * Regression test for the Input forwardRef bug: typing into the rendered form
+ * fields must reach React Hook Form so the submitted credentials are non-empty.
+ * Before the fix, Input dropped RHF's ref → values were never captured → submit
+ * fired with empty fields (or Zod blocked it) and no request was made.
+ */
+describe('LoginForm (rendered)', () => {
+  it('captures typed credentials and logs in', async () => {
+    const onLoggedIn = vi.fn();
+    renderWithProviders(<LoginForm onLoggedIn={onLoggedIn} />);
+
+    const inputs = screen.getAllByRole('textbox');
+    // email is the only role=textbox; password is type=password (not a textbox role)
+    const emailInput = inputs[0];
+    expect(emailInput).toBeDefined();
+
+    await userEvent.type(emailInput as HTMLElement, 'admin@example.com');
+
+    // Password field — query by placeholder since type=password has no textbox role
+    const passwordInput = document.querySelector('input[type="password"]');
+    expect(passwordInput).not.toBeNull();
+    await userEvent.type(passwordInput as HTMLElement, 'secret');
+
+    const submit = screen.getByRole('button', { name: /log|ログイン/i });
+    await userEvent.click(submit);
+
+    await waitFor(() => {
+      expect(onLoggedIn).toHaveBeenCalledTimes(1);
+    });
+    expect(authStore.getToken()).toBe('test-jwt-token');
+  });
+
+  it('shows an error and does not log in with wrong credentials', async () => {
+    const onLoggedIn = vi.fn();
+    renderWithProviders(<LoginForm onLoggedIn={onLoggedIn} />);
+
+    await userEvent.type(screen.getAllByRole('textbox')[0] as HTMLElement, 'admin@example.com');
+    await userEvent.type(
+      document.querySelector('input[type="password"]') as HTMLElement,
+      'wrong-password',
+    );
+    await userEvent.click(screen.getByRole('button', { name: /log|ログイン/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/正しくありません|incorrect|invalid/i)).toBeInTheDocument();
+    });
+    expect(onLoggedIn).not.toHaveBeenCalled();
+    expect(authStore.getToken()).toBeNull();
+  });
+});

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -14,7 +14,7 @@ createRoot(rootElement).render(
   <StrictMode>
     <RootErrorBoundary>
       <Providers>
-        <RouterProvider router={router} />
+        <RouterProvider router={router} future={{ v7_startTransition: true }} />
       </Providers>
     </RootErrorBoundary>
   </StrictMode>,

--- a/frontend/src/shared/ui/primitives/Input.test.tsx
+++ b/frontend/src/shared/ui/primitives/Input.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
@@ -7,6 +8,12 @@ describe('Input', () => {
   it('renders an input element', () => {
     render(<Input />);
     expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  it('forwards its ref to the underlying input (required by React Hook Form)', () => {
+    const ref = createRef<HTMLInputElement>();
+    render(<Input ref={ref} />);
+    expect(ref.current).toBeInstanceOf(HTMLInputElement);
   });
 
   it('forwards type prop', () => {

--- a/frontend/src/shared/ui/primitives/Input.tsx
+++ b/frontend/src/shared/ui/primitives/Input.tsx
@@ -1,12 +1,19 @@
-import type { InputHTMLAttributes } from 'react';
+import { forwardRef, type InputHTMLAttributes } from 'react';
 
 export type InputProps = InputHTMLAttributes<HTMLInputElement>;
 
-export function Input({ className, ...rest }: InputProps) {
+// forwardRef so React Hook Form's register() can attach its ref and read the
+// field value. Without this the input is uncontrolled-but-unregistered and the
+// form submits empty values.
+export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
+  { className, ...rest },
+  ref,
+) {
   return (
     <input
+      ref={ref}
       className={`rounded-md border border-border bg-surface-raised px-inline-md py-stack-sm font-sans text-body text-text-primary ${className ?? ''}`}
       {...rest}
     />
   );
-}
+});


### PR DESCRIPTION
## Symptom
Login form submitted but **no request reached the API**. Console warning:
`Function components cannot be given refs ... Check the render method of LoginForm`.

## Root cause
`shared/ui/primitives/Input` was a plain function component. React Hook Form's `register()` spreads a `ref`; React drops it for non-forwardRef components. Without the ref, RHF never captured the field value → Zod saw empty `email`/`password` → the mutation never fired → no `POST /admin/auth/login` (app logs showed only health probes).

The existing `use-login` test passed because it calls `submit({email,password})` with explicit values, bypassing the rendered inputs — so the bug slipped through `npm run check`.

## Fix
- `Input` → `forwardRef<HTMLInputElement>`
- **Regression tests** (fail against the pre-fix Input):
  - `Input` forwards its ref to the underlying `<input>`
  - `LoginForm` rendered: type credentials → submit → `onLoggedIn` called + token stored

## Drive-by console cleanup
- `public/favicon.svg` added + linked (was 404)
- React Router future flags `v7_startTransition` / `v7_relativeSplatPath`

## Verification
`npm run check` green (165 tests). Verified live against the running Docker stack (login via the Vite proxy returns a JWT).

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)