### PR TITLE
docs: ドキュメントの陳腐化と情報不整合を解消する (#61)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ See [ADR 0009](docs/adr/0009-separate-from-billing-and-reconciliation.md).
 - **Canonical terms — single source of truth (binding):** `docs/terms.md` ← **START HERE for any identifier**
 - **Scope contract (binding):** `docs/explanation/scope-contract.md`
 - **Compliance (binding):** `docs/explanation/received-document-compliance.md`
-- **Compliance review gate:** `docs/compliance-review/` (税理士 sign-off blocks Phase 2 UI)
+- **Compliance review gate:** `docs/compliance-review/` (Phase 2 dev unblocked by maintainer; licensed 税理士 sign-off still required before production use — see `signoff-record.md`)
 - **No competitor names (binding):** `docs/adr/0013-no-third-party-product-names.md`
 - **Naming rules:** `docs/development/naming-conventions.md`
 - **Backend standards:** `docs/development/backend-standards.md`
@@ -49,4 +49,4 @@ See [ADR 0009](docs/adr/0009-separate-from-billing-and-reconciliation.md).
 
 ## Framework
 
-[NENE2](https://github.com/hideyukiMORI/NENE2) via Composer when runtime lands.
+[NENE2](https://github.com/hideyukiMORI/NENE2) via Composer (`vendor/hideyukimori/nene2/`). Runtime is fully implemented; see `docs/inheritance-from-nene2.md`.

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ NENE_VAULT_PORT=8090 NENE_VAULT_FRONTEND_PORT=5180 docker compose up
 
 ## Status
 
-**Phase 0 complete** — governance and product design done (PR #1, #2 merged 2026-05-30).
-Phase 1 (API) and Phase 2 (Admin UI) implemented; Docker development environment available.
+**Phase 1 (Document API) complete** — Auth, Organization, User, VaultSettings, Document upload/search/void/restore/history/download, Export CSV, Audit logging (PR #8–#26, 2026-05-30).
+**Phase 2 (Admin UI) in progress** — React/Vite scaffold implemented; page-level UI under development. Docker development environment available.
 
 ## Ecosystem
 

--- a/docs/development/backend-standards.md
+++ b/docs/development/backend-standards.md
@@ -150,7 +150,6 @@ Use `final readonly` classes and `declare(strict_types=1);` in every PHP file.
 ```bash
 composer check
 composer openapi
-composer mcp
 ```
 
 Self-review checklists: [`docs/review/compliance.md`](../review/compliance.md), [`docs/review/backend-api.md`](../review/backend-api.md), [`docs/review/database.md`](../review/database.md).

--- a/docs/development/naming-conventions.md
+++ b/docs/development/naming-conventions.md
@@ -242,7 +242,7 @@ for these roles.
 | API client | snake_case JSON passed through — **do not rename** API fields to camelCase |
 | Problem Details | parsed to `AppError` in `shared/api/errors.ts`; base `https://nene-vault.dev/problems/` |
 | Locale keys | dot-notation from `locales/*.json` (e.g. `document.list.title`); ja+en only (ADR 0005) |
-| Auth token | **not** in `localStorage` (httpOnly cookie or ADR) |
+| Auth token | JWT in `entities/auth` `authStore` (localStorage, same as NeNe Records); sent as `Authorization: Bearer` + `credentials: 'include'`. Migration to httpOnly cookie requires an ADR. |
 
 Full frontend standards: [`frontend-standards.md`](./frontend-standards.md).
 Self-review: [`../review/frontend.md`](../review/frontend.md).
@@ -287,7 +287,6 @@ If it is a product concept with a meaning, also update [`docs/explanation/glossa
 ```bash
 composer check
 composer openapi
-composer mcp
 ```
 
 Review checklists: [`docs/review/`](../review/).

--- a/docs/inheritance-from-nene2.md
+++ b/docs/inheritance-from-nene2.md
@@ -85,15 +85,14 @@ Record these in ADRs or product docs when they stabilize:
 3. If the conflict touches compliance behavior, treat it as a P0 issue — do not resolve by guessing.
 4. Keep `.cursor/rules/` as a short summary; do not duplicate full policy text there.
 
-## Verification commands (once runtime is scaffolded)
+## Verification commands
 
 ```bash
 composer check
 composer openapi
-composer mcp
 ```
 
-When `frontend/` exists (Phase 2+):
+Frontend (Phase 2+):
 
 ```bash
 npm run check --prefix frontend

--- a/docs/milestones/2026-05-governance-and-foundation.md
+++ b/docs/milestones/2026-05-governance-and-foundation.md
@@ -18,7 +18,8 @@ before runtime code.
 
 ## Follow-up
 
-Phase 1 — Document upload API + search + storage adapter (Issue #4+).
-税理士 review gate before Phase 2 Admin UI.
+Phase 1 (Document API) — complete (PR #8–#26).
+Phase 2 (Admin UI) — scaffold implemented; page-level UI in progress.
+Compliance review gate — maintainer-approved to proceed with Phase 2 development; licensed 税理士 sign-off required before production use.
 
-Last updated: 2026-05-30
+Last updated: 2026-05-31

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -61,4 +61,4 @@ Operators self-host Vault to store and search **received** vendor documents with
 
 See [`docs/explanation/scope-boundary.md`](./explanation/scope-boundary.md).
 
-Last updated: 2026-05-29
+Last updated: 2026-05-31

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -72,4 +72,4 @@ If a user explicitly says investigation only, no commit, no PR, or another narro
 
 ## Initial Issues Backlog
 
-Phase 0 bootstrap Issues are tracked in `docs/todo/current.md`. After governance lands, use GitHub Issues for all work — no direct `main` commits.
+Use GitHub Issues for all work. Current work board: `docs/todo/current.md`. No direct `main` commits.


### PR DESCRIPTION
## Summary

- Phase 2 進行中の現状に合わせて 8 ファイルの陳腐化・矛盾を解消
- 最大の実害: `naming-conventions.md` §9 の auth token 行が `frontend-standards.md` と正反対の内容になっていた（「not in localStorage」→ localStorage 承認済みに修正）
- 存在しない `composer mcp` コマンドを 3 箇所から削除
- Status / 見出し / Follow-up など Phase 0 時代の記述を現状（Phase 1 完了・Phase 2 進行中）に更新

## Changes

| File | What changed |
|---|---|
| `README.md` | Status: Phase 1 完了 / Phase 2 進行中に整理 |
| `AGENTS.md` | 税理士ゲート状態・Framework の記述を現状に合わせる |
| `naming-conventions.md` | auth token 矛盾解消、`composer mcp` 削除 |
| `backend-standards.md` | `composer mcp` 削除 |
| `inheritance-from-nene2.md` | 陳腐化した見出し整理、`composer mcp` 削除 |
| `milestones/2026-05-*` | Follow-up を Phase 1 完了・Phase 2 進行中・ゲート状況に更新 |
| `workflow.md` | 「Phase 0 bootstrap Issues」表現を削除 |
| `roadmap.md` | Last updated 更新 |

## Test plan

- [ ] `docs/review/docs-policy.md` — ドキュメント変更のセルフレビュー適用
- [ ] 8 ファイルの差分目視確認

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)