### PR TITLE
feat(installer): web installer + release ZIP for Tier A shared hosting (#67)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /vendor/
+/dist/
 /var/*.sqlite
 /var/*.cache
 /.env

--- a/docs/operator/installation.md
+++ b/docs/operator/installation.md
@@ -87,8 +87,62 @@ NENE_VAULT_PORT=8090 NENE_VAULT_FRONTEND_PORT=5180 docker compose up -d
 
 ## Tier A — Shared hosting
 
-Tier A support (release ZIP + web installer) is planned for Phase 3. Until then,
-the Docker Compose setup above is the supported deployment path.
+For operators on shared hosting without Docker access.
+
+### 1. Build the release ZIP
+
+On a machine with Docker/Node.js/Composer:
+
+```sh
+git clone https://github.com/hideyukiMORI/nene-vault.git
+cd nene-vault
+bash tools/build-release.sh 1.0.0
+# → dist/nene-vault-1.0.0.zip
+```
+
+Or download a pre-built release ZIP from the GitHub Releases page.
+
+### 2. Upload and extract
+
+Upload `nene-vault-1.0.0.zip` to your server and extract it:
+
+```sh
+unzip nene-vault-1.0.0.zip
+```
+
+### 3. Set document root
+
+Configure your web server's document root (or virtual host) to point to
+`public_html/` inside the extracted directory:
+
+```
+DocumentRoot /path/to/nene-vault-1.0.0/public_html
+```
+
+If you cannot change the document root, copy the contents of `public_html/`
+to your `public_html/` or `htdocs/` directory and update the paths in
+`public_html/index.php` accordingly.
+
+### 4. Run the web installer
+
+Visit `http://your-domain.example.com/install.php` in a browser. The installer
+walks you through:
+
+1. **Requirements check** — PHP 8.4, ext-zip, writable directories
+2. **Database** — SQLite (default) or MySQL credentials
+3. **Application settings** — JWT secret, storage path, admin email/password
+4. **Setup** — writes `.env`, runs migrations, seeds initial data
+5. **Done** — deletes `install.php`
+
+### 5. Fix permissions
+
+```sh
+chmod 755 var/
+chmod 755 storage/
+```
+
+The PHP process must be able to write to `var/` (SQLite DB) and
+`storage/vault/` (uploaded files).
 
 ---
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -37,6 +37,6 @@
 
 - [x] Operator guide (storage, backup, retention, search, export) — `docs/operator/` (PR #66)
 - [x] 事務処理規程 template — `docs/operator/jimu-shokirei-template.md` (PR #66)
-- [ ] Web installer + release ZIP (Tier A shared hosting)
+- [x] Web installer + release ZIP (Tier A shared hosting) — `install.php` + `tools/build-release.sh` (PR #68)
 
 Last updated: 2026-05-31

--- a/install.php
+++ b/install.php
@@ -1,0 +1,539 @@
+<?php
+
+/**
+ * NeNe Vault — Web Installer
+ *
+ * Place this file in the project root and visit it in a browser.
+ * The installer writes .env, runs the database bootstrap, seeds the initial
+ * admin user, and then deletes itself.
+ *
+ * Security: after the installer completes (or if you abort), delete this file
+ * manually if the automatic cleanup fails.
+ */
+
+declare(strict_types=1);
+
+const INSTALLER_VERSION = '1.0';
+const MIN_PHP = '8.4.1';
+
+// ── Bootstrap ────────────────────────────────────────────────────────────────
+
+session_start();
+
+$step = (int) ($_POST['step'] ?? $_GET['step'] ?? 1);
+$errors = [];
+$info = [];
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function h(string $v): string
+{
+    return htmlspecialchars($v, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+}
+
+function post(string $key, string $default = ''): string
+{
+    return is_string($_POST[$key] ?? null) ? trim((string) $_POST[$key]) : $default;
+}
+
+function randomSecret(int $bytes = 32): string
+{
+    return bin2hex(random_bytes($bytes));
+}
+
+function projectRoot(): string
+{
+    return dirname(__FILE__);
+}
+
+function envPath(): string
+{
+    return projectRoot() . '/.env';
+}
+
+/** @return array<string, string> */
+function readEnvFile(): array
+{
+    $path = envPath();
+    if (!file_exists($path)) {
+        return [];
+    }
+
+    $result = [];
+    foreach (file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) ?: [] as $line) {
+        if (str_starts_with(trim($line), '#')) {
+            continue;
+        }
+
+        $parts = explode('=', $line, 2);
+        if (count($parts) === 2) {
+            $result[trim($parts[0])] = trim($parts[1]);
+        }
+    }
+
+    return $result;
+}
+
+// ── Step 1: Requirements check ───────────────────────────────────────────────
+
+/** @return array<string, array{ok: bool, label: string, detail: string}> */
+function checkRequirements(): array
+{
+    $root = projectRoot();
+    $checks = [];
+
+    // PHP version
+    $phpOk = version_compare(PHP_VERSION, MIN_PHP, '>=');
+    $checks['php'] = [
+        'ok'     => $phpOk,
+        'label'  => 'PHP >= ' . MIN_PHP,
+        'detail' => 'Found PHP ' . PHP_VERSION,
+    ];
+
+    // Extensions
+    foreach (['pdo', 'pdo_sqlite', 'zip', 'mbstring', 'json'] as $ext) {
+        $checks['ext_' . $ext] = [
+            'ok'     => extension_loaded($ext),
+            'label'  => 'ext-' . $ext,
+            'detail' => extension_loaded($ext) ? 'loaded' : 'MISSING',
+        ];
+    }
+
+    // Vendor autoloader
+    $checks['vendor'] = [
+        'ok'     => file_exists($root . '/vendor/autoload.php'),
+        'label'  => 'vendor/autoload.php',
+        'detail' => file_exists($root . '/vendor/autoload.php')
+            ? 'found'
+            : 'MISSING — run composer install first',
+    ];
+
+    // Writable var/ directory
+    $varDir = $root . '/var';
+    if (!is_dir($varDir)) {
+        @mkdir($varDir, 0755, true);
+    }
+
+    $checks['var_writable'] = [
+        'ok'     => is_writable($varDir),
+        'label'  => 'var/ writable',
+        'detail' => is_writable($varDir) ? 'writable' : 'NOT writable — fix permissions',
+    ];
+
+    // Writable root for .env
+    $checks['root_writable'] = [
+        'ok'     => is_writable($root),
+        'label'  => 'Project root writable',
+        'detail' => is_writable($root) ? 'writable' : 'NOT writable — fix permissions',
+    ];
+
+    return $checks;
+}
+
+// ── Step 3: Write .env ────────────────────────────────────────────────────────
+
+/** @param array<string, string> $values */
+function writeEnvFile(array $values): bool
+{
+    $lines = [];
+    foreach ($values as $key => $val) {
+        $lines[] = $key . '=' . $val;
+    }
+
+    return file_put_contents(envPath(), implode("\n", $lines) . "\n") !== false;
+}
+
+// ── Step 4: Run setup ─────────────────────────────────────────────────────────
+
+/** @return array{ok: bool, messages: list<string>} */
+function runSetup(): array
+{
+    $root = projectRoot();
+    $messages = [];
+    $env = readEnvFile();
+
+    // Load env vars into environment
+    foreach ($env as $k => $v) {
+        putenv($k . '=' . $v);
+        $_ENV[$k] = $v;
+    }
+
+    // Bootstrap schema
+    $adapter = $env['DB_ADAPTER'] ?? 'sqlite';
+
+    if ($adapter === 'sqlite') {
+        $dbName = $env['DB_NAME'] ?? 'var/nene_vault.sqlite';
+
+        if (!str_starts_with($dbName, '/')) {
+            $dbPath = $root . '/' . $dbName;
+        } else {
+            $dbPath = $dbName;
+        }
+
+        $dir = dirname($dbPath);
+
+        if (!is_dir($dir)) {
+            mkdir($dir, 0755, true);
+        }
+
+        $messages[] = 'Bootstrapping SQLite schema at ' . $dbPath;
+
+        try {
+            $bootstrapScript = $root . '/docker/bootstrap-schema.php';
+
+            if (!file_exists($bootstrapScript)) {
+                return ['ok' => false, 'messages' => array_merge($messages, ['bootstrap-schema.php not found'])];
+            }
+
+            require $bootstrapScript;
+            $messages[] = 'Schema bootstrapped.';
+        } catch (Throwable $e) {
+            return ['ok' => false, 'messages' => array_merge($messages, ['Schema error: ' . $e->getMessage()])];
+        }
+    } else {
+        $messages[] = 'Running Phinx migrations (MySQL)...';
+
+        $cmd = escapeshellcmd($root . '/vendor/bin/phinx')
+            . ' migrate -c ' . escapeshellarg($root . '/phinx.php')
+            . ' -e ' . escapeshellarg($env['DB_ENV'] ?? 'local');
+
+        exec($cmd . ' 2>&1', $output, $code);
+        $messages = array_merge($messages, $output);
+
+        if ($code !== 0) {
+            return ['ok' => false, 'messages' => $messages];
+        }
+
+        $messages[] = 'Migrations complete.';
+    }
+
+    // Seed initial data
+    $messages[] = 'Seeding initial data...';
+
+    try {
+        $seedScript = $root . '/docker/seed-initial.php';
+
+        if (!file_exists($seedScript)) {
+            return ['ok' => false, 'messages' => array_merge($messages, ['seed-initial.php not found'])];
+        }
+
+        require $seedScript;
+        $messages[] = 'Seed complete.';
+    } catch (Throwable $e) {
+        return ['ok' => false, 'messages' => array_merge($messages, ['Seed error: ' . $e->getMessage()])];
+    }
+
+    return ['ok' => true, 'messages' => $messages];
+}
+
+// ── Process POST ─────────────────────────────────────────────────────────────
+
+$setupResult = null;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if ($step === 2) {
+        // Validate DB settings
+        $dbAdapter = post('db_adapter', 'sqlite');
+
+        if ($dbAdapter === 'mysql') {
+            if (post('db_host') === '') {
+                $errors[] = 'DB host is required for MySQL.';
+            }
+
+            if (post('db_name') === '') {
+                $errors[] = 'DB name is required for MySQL.';
+            }
+
+            if (post('db_user') === '') {
+                $errors[] = 'DB user is required for MySQL.';
+            }
+        }
+
+        if (empty($errors)) {
+            $_SESSION['db'] = [
+                'adapter'  => $dbAdapter,
+                'host'     => post('db_host', '127.0.0.1'),
+                'port'     => post('db_port', '3306'),
+                'name'     => post('db_name', 'var/nene_vault.sqlite'),
+                'user'     => post('db_user'),
+                'password' => post('db_password'),
+            ];
+            $step = 3;
+        }
+    } elseif ($step === 3) {
+        // Validate app settings
+        $adminEmail    = post('admin_email', 'admin@example.com');
+        $adminPassword = post('admin_password');
+        $orgName       = post('org_name', 'My Organization');
+        $orgSlug       = post('org_slug', 'default');
+
+        if (!filter_var($adminEmail, FILTER_VALIDATE_EMAIL)) {
+            $errors[] = 'Invalid admin email address.';
+        }
+
+        if (strlen($adminPassword) < 8) {
+            $errors[] = 'Admin password must be at least 8 characters.';
+        }
+
+        if (!preg_match('/^[a-z0-9-]+$/', $orgSlug)) {
+            $errors[] = 'Organization slug must be lowercase letters, digits, and hyphens only.';
+        }
+
+        if (empty($errors)) {
+            $db = $_SESSION['db'] ?? [];
+            $jwtSecret = post('jwt_secret') ?: randomSecret();
+            $storagePath = post('storage_path', 'storage/vault');
+
+            $env = [
+                'APP_ENV'                    => 'production',
+                'APP_DEBUG'                  => 'false',
+                'APP_NAME'                   => 'NeNe Vault',
+                'NENE2_LOCAL_JWT_SECRET'     => $jwtSecret,
+                'PROBLEM_DETAILS_BASE_URL'   => 'https://nene-vault.dev/problems/',
+                'NENE_VAULT_STORAGE_PATH'    => $storagePath,
+                'NENE_VAULT_MAX_FILE_SIZE_MB' => '20',
+                'TENANT_RESOLUTION'          => 'single',
+                'ORG_SLUG'                   => $orgSlug,
+                'DB_ENV'                     => 'production',
+                'DB_ADAPTER'                 => $db['adapter'] ?? 'sqlite',
+                'DB_HOST'                    => $db['host'] ?? '127.0.0.1',
+                'DB_PORT'                    => $db['port'] ?? '3306',
+                'DB_NAME'                    => ($db['adapter'] ?? 'sqlite') === 'sqlite'
+                    ? ($db['name'] ?: 'var/nene_vault.sqlite')
+                    : ($db['name'] ?? 'nene_vault'),
+                'DB_USER'                    => $db['user'] ?? '',
+                'DB_PASSWORD'               => $db['password'] ?? '',
+                'DB_CHARSET'                 => 'utf8mb4',
+                'ORG_NAME'                   => $orgName,
+                'ADMIN_EMAIL'                => $adminEmail,
+                'ADMIN_PASSWORD'             => $adminPassword,
+            ];
+
+            if (writeEnvFile($env)) {
+                $setupResult = runSetup();
+
+                if ($setupResult['ok']) {
+                    $step = 5;
+                } else {
+                    $step = 4;
+                }
+            } else {
+                $errors[] = 'Failed to write .env file. Check directory permissions.';
+            }
+        }
+    }
+}
+
+// ── UI ────────────────────────────────────────────────────────────────────────
+
+$requirements = ($step === 1) ? checkRequirements() : [];
+$allRequirementsMet = empty(array_filter($requirements, static fn ($c) => !$c['ok']));
+
+$prefilledJwtSecret = randomSecret();
+
+?><!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>NeNe Vault — Installer</title>
+<style>
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+body { font: 15px/1.6 system-ui, sans-serif; background: #f4f5f7; color: #1a1a2e; }
+.wrap { max-width: 640px; margin: 48px auto; padding: 0 16px 80px; }
+h1 { font-size: 22px; font-weight: 700; margin-bottom: 4px; }
+.subtitle { color: #666; font-size: 13px; margin-bottom: 32px; }
+.card { background: #fff; border: 1px solid #e0e0e0; border-radius: 8px; padding: 28px 32px; margin-bottom: 20px; }
+h2 { font-size: 16px; font-weight: 600; margin-bottom: 16px; }
+.step-bar { display: flex; gap: 8px; margin-bottom: 28px; }
+.step-bar span { flex: 1; height: 4px; border-radius: 2px; background: #e0e0e0; }
+.step-bar span.done { background: #22c55e; }
+.step-bar span.active { background: #3b82f6; }
+label { display: block; font-size: 13px; font-weight: 500; margin-bottom: 4px; color: #333; }
+input, select { width: 100%; padding: 8px 10px; border: 1px solid #d0d0d0; border-radius: 5px; font-size: 14px; }
+input:focus, select:focus { outline: 2px solid #3b82f6; border-color: #3b82f6; }
+.field { margin-bottom: 16px; }
+.hint { font-size: 12px; color: #888; margin-top: 3px; }
+.btn { display: inline-block; padding: 10px 20px; background: #3b82f6; color: #fff; border: none; border-radius: 5px; font-size: 14px; font-weight: 600; cursor: pointer; text-decoration: none; }
+.btn:hover { background: #2563eb; }
+.btn-secondary { background: #e5e7eb; color: #374151; }
+.btn-secondary:hover { background: #d1d5db; }
+.check { display: flex; align-items: center; gap: 8px; padding: 6px 0; font-size: 13px; }
+.check .ok { color: #22c55e; }
+.check .fail { color: #ef4444; }
+.errors { background: #fef2f2; border: 1px solid #fecaca; border-radius: 5px; padding: 12px 16px; margin-bottom: 16px; }
+.errors p { color: #dc2626; font-size: 13px; }
+.logs { background: #f8f8f8; border: 1px solid #e0e0e0; border-radius: 5px; padding: 12px; font: 12px/1.5 monospace; max-height: 200px; overflow-y: auto; margin-bottom: 16px; }
+.success-icon { font-size: 48px; text-align: center; margin-bottom: 16px; }
+.warning { background: #fffbeb; border: 1px solid #fde68a; border-radius: 5px; padding: 10px 14px; font-size: 13px; color: #92400e; margin-top: 12px; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>NeNe Vault Installer</h1>
+  <p class="subtitle">v<?= INSTALLER_VERSION ?> — Self-hosted received-document archive</p>
+
+  <div class="step-bar">
+    <?php foreach ([1, 2, 3, 5] as $s): ?>
+      <span class="<?= $s < $step ? 'done' : ($s === $step ? 'active' : '') ?>"></span>
+    <?php endforeach ?>
+  </div>
+
+<?php if ($step === 1): ?>
+  <div class="card">
+    <h2>Step 1: Requirements Check</h2>
+    <?php foreach ($requirements as $check): ?>
+      <div class="check">
+        <span class="<?= $check['ok'] ? 'ok' : 'fail' ?>"><?= $check['ok'] ? '✓' : '✗' ?></span>
+        <span><?= h($check['label']) ?></span>
+        <span style="color:#888;margin-left:auto;font-size:12px"><?= h($check['detail']) ?></span>
+      </div>
+    <?php endforeach ?>
+    <?php if (!$allRequirementsMet): ?>
+      <p style="margin-top:16px;color:#ef4444;font-size:13px">
+        Fix the items marked ✗ before continuing.
+      </p>
+    <?php else: ?>
+      <form method="post" action="install.php?step=2" style="margin-top:20px">
+        <input type="hidden" name="step" value="2">
+        <button type="submit" class="btn">Continue →</button>
+      </form>
+    <?php endif ?>
+  </div>
+
+<?php elseif ($step === 2): ?>
+  <div class="card">
+    <h2>Step 2: Database</h2>
+    <?php if (!empty($errors)): ?>
+      <div class="errors"><?php foreach ($errors as $e): ?><p>• <?= h($e) ?></p><?php endforeach ?></div>
+    <?php endif ?>
+    <form method="post" action="install.php">
+      <input type="hidden" name="step" value="2">
+      <div class="field">
+        <label>Database adapter</label>
+        <select name="db_adapter" id="db_adapter" onchange="toggleMysql(this.value)">
+          <option value="sqlite" <?= post('db_adapter', 'sqlite') === 'sqlite' ? 'selected' : '' ?>>SQLite (recommended for small installs)</option>
+          <option value="mysql" <?= post('db_adapter') === 'mysql' ? 'selected' : '' ?>>MySQL</option>
+        </select>
+      </div>
+      <div id="sqlite_fields">
+        <div class="field">
+          <label>SQLite file path</label>
+          <input type="text" name="db_name" value="<?= h(post('db_name', 'var/nene_vault.sqlite')) ?>">
+          <p class="hint">Relative to project root, or an absolute path.</p>
+        </div>
+      </div>
+      <div id="mysql_fields" style="display:none">
+        <div class="field"><label>Host</label><input type="text" name="db_host" value="<?= h(post('db_host', '127.0.0.1')) ?>"></div>
+        <div class="field"><label>Port</label><input type="text" name="db_port" value="<?= h(post('db_port', '3306')) ?>"></div>
+        <div class="field"><label>Database name</label><input type="text" name="db_name" id="db_name_mysql" value="<?= h(post('db_name', 'nene_vault')) ?>"></div>
+        <div class="field"><label>User</label><input type="text" name="db_user" value="<?= h(post('db_user')) ?>"></div>
+        <div class="field"><label>Password</label><input type="password" name="db_password" value="<?= h(post('db_password')) ?>"></div>
+      </div>
+      <button type="submit" class="btn">Continue →</button>
+    </form>
+  </div>
+  <script>
+  function toggleMysql(v) {
+    document.getElementById('sqlite_fields').style.display = v === 'sqlite' ? '' : 'none';
+    document.getElementById('mysql_fields').style.display = v === 'mysql' ? '' : 'none';
+  }
+  toggleMysql(document.getElementById('db_adapter').value);
+  </script>
+
+<?php elseif ($step === 3): ?>
+  <div class="card">
+    <h2>Step 3: Application Settings</h2>
+    <?php if (!empty($errors)): ?>
+      <div class="errors"><?php foreach ($errors as $e): ?><p>• <?= h($e) ?></p><?php endforeach ?></div>
+    <?php endif ?>
+    <form method="post" action="install.php">
+      <input type="hidden" name="step" value="3">
+      <div class="field">
+        <label>JWT secret key</label>
+        <input type="text" name="jwt_secret" value="<?= h(post('jwt_secret', $prefilledJwtSecret)) ?>">
+        <p class="hint">A random 32+ character string. Keep it secret — changing it invalidates all sessions.</p>
+      </div>
+      <div class="field">
+        <label>File storage path</label>
+        <input type="text" name="storage_path" value="<?= h(post('storage_path', 'storage/vault')) ?>">
+        <p class="hint">Where uploaded PDFs and images are stored. Relative to project root or absolute.</p>
+      </div>
+      <div class="field">
+        <label>Organization name</label>
+        <input type="text" name="org_name" value="<?= h(post('org_name', 'My Organization')) ?>">
+      </div>
+      <div class="field">
+        <label>Organization slug</label>
+        <input type="text" name="org_slug" value="<?= h(post('org_slug', 'default')) ?>">
+        <p class="hint">Lowercase letters, digits, hyphens. Used for tenant resolution.</p>
+      </div>
+      <div class="field">
+        <label>Admin email</label>
+        <input type="email" name="admin_email" value="<?= h(post('admin_email', 'admin@example.com')) ?>">
+      </div>
+      <div class="field">
+        <label>Admin password</label>
+        <input type="password" name="admin_password" placeholder="Min 8 characters" value="<?= h(post('admin_password')) ?>">
+      </div>
+      <button type="submit" class="btn">Install →</button>
+    </form>
+  </div>
+
+<?php elseif ($step === 4): ?>
+  <div class="card">
+    <h2>Setup failed</h2>
+    <?php if ($setupResult !== null): ?>
+      <div class="logs">
+        <?php foreach ($setupResult['messages'] as $msg): ?>
+          <?= h($msg) ?><br>
+        <?php endforeach ?>
+      </div>
+    <?php endif ?>
+    <p style="color:#ef4444;font-size:13px;margin-bottom:16px">
+      Review the errors above. Fix the issue and try again.
+    </p>
+    <a href="install.php?step=3" class="btn btn-secondary">← Back</a>
+  </div>
+
+<?php elseif ($step === 5): ?>
+  <?php
+    // Attempt to delete installer
+    $deleted = @unlink(__FILE__);
+  ?>
+  <div class="card">
+    <div class="success-icon">✅</div>
+    <h2 style="text-align:center">Installation complete!</h2>
+    <p style="text-align:center;color:#666;margin-top:8px;margin-bottom:20px">
+      NeNe Vault is ready. Log in with the admin credentials you set.
+    </p>
+
+    <?php if ($setupResult !== null): ?>
+      <div class="logs">
+        <?php foreach ($setupResult['messages'] as $msg): ?>
+          <?= h($msg) ?><br>
+        <?php endforeach ?>
+      </div>
+    <?php endif ?>
+
+    <div style="text-align:center;margin-top:20px">
+      <a href="public_html/" class="btn">Open NeNe Vault →</a>
+    </div>
+
+    <?php if (!$deleted): ?>
+      <div class="warning">
+        ⚠ Could not delete <code>install.php</code> automatically.
+        <strong>Delete it manually</strong> before using the system in production.
+      </div>
+    <?php else: ?>
+      <p style="font-size:12px;color:#888;text-align:center;margin-top:12px">
+        install.php has been deleted.
+      </p>
+    <?php endif ?>
+  </div>
+
+<?php endif ?>
+
+</div>
+</body>
+</html>

--- a/public_html/.htaccess
+++ b/public_html/.htaccess
@@ -1,6 +1,14 @@
 Options -MultiViews -Indexes
 RewriteEngine On
 
-# Route all requests through the front controller
-RewriteCond %{REQUEST_FILENAME} !-f
+# Serve existing static files (JS, CSS, images, fonts) directly
+RewriteCond %{REQUEST_FILENAME} -f
+RewriteRule ^ - [L]
+
+# API and health routes → PHP front controller
+RewriteRule ^(admin|health) index.php [QSA,L]
+
+# All other routes → SPA index.html (if present) or PHP front controller
+RewriteCond %{DOCUMENT_ROOT}/index.html -f
+RewriteRule ^ index.html [L]
 RewriteRule ^ index.php [QSA,L]

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# NeNe Vault — Release ZIP builder for Tier A shared hosting
+#
+# Usage:
+#   bash tools/build-release.sh [version]
+#   bash tools/build-release.sh 1.2.0
+#
+# Output:
+#   dist/nene-vault-{version}.zip
+#
+# Requirements:
+#   - Composer installed globally
+#   - Node.js + npm
+#   - zip (CLI utility)
+
+set -euo pipefail
+
+VERSION="${1:-$(git describe --tags --always 2>/dev/null || echo 'dev')}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DIST="$ROOT/dist"
+STAGING="$DIST/nene-vault-$VERSION"
+ZIP_FILE="$DIST/nene-vault-$VERSION.zip"
+
+echo "==> Building NeNe Vault $VERSION"
+
+# ── Cleanup ───────────────────────────────────────────────────────────────────
+rm -rf "$STAGING" "$ZIP_FILE"
+mkdir -p "$STAGING"
+
+# ── Frontend build ────────────────────────────────────────────────────────────
+echo "--> Building frontend..."
+cd "$ROOT/frontend"
+npm ci --silent
+npm run build --silent
+cd "$ROOT"
+
+echo "--> Frontend built to frontend/dist/"
+
+# ── PHP dependencies (no-dev) ─────────────────────────────────────────────────
+echo "--> Installing production Composer dependencies..."
+composer install --no-dev --optimize-autoloader --quiet
+
+# ── Stage files ───────────────────────────────────────────────────────────────
+echo "--> Staging release files..."
+
+# PHP application source
+rsync -a --exclude='*.test.*' \
+    "$ROOT/src/"       "$STAGING/src/"
+rsync -a \
+    "$ROOT/vendor/"    "$STAGING/vendor/"
+rsync -a \
+    "$ROOT/locales/"   "$STAGING/locales/"
+rsync -a \
+    "$ROOT/database/"  "$STAGING/database/"
+rsync -a \
+    "$ROOT/docker/"    "$STAGING/docker/"
+
+# Public HTML (PHP front controller + .htaccess + built frontend)
+rsync -a \
+    "$ROOT/public_html/"          "$STAGING/public_html/"
+rsync -a \
+    "$ROOT/frontend/dist/"        "$STAGING/public_html/"
+
+# Config files
+cp "$ROOT/phinx.php"        "$STAGING/phinx.php"
+cp "$ROOT/.env.example"     "$STAGING/.env.example"
+cp "$ROOT/phpstan.neon.dist" "$STAGING/phpstan.neon.dist" 2>/dev/null || true
+
+# Installer
+cp "$ROOT/install.php" "$STAGING/install.php"
+
+# var/ placeholder (empty, writable)
+mkdir -p "$STAGING/var"
+touch "$STAGING/var/.gitkeep"
+
+# Storage placeholder
+mkdir -p "$STAGING/storage/vault"
+touch "$STAGING/storage/vault/.gitkeep"
+
+# ── Create ZIP ────────────────────────────────────────────────────────────────
+echo "--> Creating ZIP archive..."
+cd "$DIST"
+zip -r "nene-vault-$VERSION.zip" "nene-vault-$VERSION/" -x "*/\.*" -q
+
+echo ""
+echo "==> Release ZIP: $ZIP_FILE"
+echo "    Contents: $(du -sh "$STAGING" | cut -f1) uncompressed"
+echo ""
+echo "Tier A installation:"
+echo "  1. Upload and extract nene-vault-$VERSION.zip to your web root"
+echo "  2. Set document root to public_html/"
+echo "  3. Visit install.php to complete setup"
+
+# ── Restore dev dependencies ──────────────────────────────────────────────────
+echo "--> Restoring dev Composer dependencies..."
+composer install --quiet
+
+echo "==> Done."


### PR DESCRIPTION
## Summary

Completes Phase 3 Tier A shared hosting deliverable.

## Changes

| File | Purpose |
|---|---|
| `install.php` | 5-step browser-based setup wizard |
| `tools/build-release.sh` | Packages a production release ZIP |
| `public_html/.htaccess` | SPA + API routing on single Apache vhost |
| `docs/operator/installation.md` | Tier A section added |
| `.gitignore` | Exclude `/dist/` (build output) |

## Installer steps

1. **Requirements** — PHP 8.4, ext-zip, writable var/
2. **Database** — SQLite (default) or MySQL credentials
3. **Application settings** — JWT secret, storage path, admin email/password, org name/slug
4. **Setup** — writes `.env`, bootstraps schema, seeds initial admin user
5. **Done** — auto-deletes `install.php`; warns if deletion fails

## Release ZIP contents

- PHP source + `vendor/` (no-dev, optimized)
- Frontend production build in `public_html/`
- `install.php`, `.env.example`, migrations, seeder
- `var/` and `storage/vault/` placeholder directories

## Test plan

- [x] `composer check` green (PHP lint, PHPStan, CS, locales, OpenAPI)
- [x] `php -l install.php` — no syntax errors
- [ ] Manual: run `docker compose up` and verify existing Docker path works (htaccess change)
- [ ] Manual: run `bash tools/build-release.sh` and verify ZIP structure
- [ ] Manual: extract ZIP, visit `install.php`, complete setup

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)