### PR TITLE
feat(mcp): MCP read tools — searchVaultDocuments, getVaultDocumentById, history, audit (#69)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,12 +34,15 @@
         "migrations:rollback": "phinx rollback -c phinx.php",
         "locales": "php tools/validate-locales.php",
         "openapi": "php tools/validate-openapi.php",
+        "mcp": "php vendor/hideyukimori/nene2/tools/validate-mcp-tools.php",
+        "mcp:server": "php tools/local-mcp-server.php",
         "check": [
             "@test",
             "@analyse",
             "@cs",
             "@locales",
-            "@openapi"
+            "@openapi",
+            "@mcp"
         ]
     },
     "config": {

--- a/docs/mcp/tools.json
+++ b/docs/mcp/tools.json
@@ -1,0 +1,164 @@
+{
+  "version": 1,
+  "source": "docs/openapi/openapi.yaml",
+  "tools": [
+    {
+      "name": "searchVaultDocuments",
+      "title": "Search Vault Documents",
+      "description": "Search received documents by 取引年月日 (date range), 取引金額 (amount range), 取引先名 (counterparty partial), and category. Satisfies 電帳法施行規則 第4条第1項第3号 search requirements. Voided documents are excluded by default.",
+      "safety": "read",
+      "source": {
+        "type": "openapi",
+        "operationId": "searchDocuments",
+        "method": "GET",
+        "path": "/admin/vault/documents"
+      },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "transaction_date_from": {
+            "type": "string",
+            "format": "date",
+            "description": "取引年月日 range start (inclusive, YYYY-MM-DD)"
+          },
+          "transaction_date_to": {
+            "type": "string",
+            "format": "date",
+            "description": "取引年月日 range end (inclusive, YYYY-MM-DD)"
+          },
+          "amount_min_cents": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Minimum 取引金額 in integer JPY"
+          },
+          "amount_max_cents": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Maximum 取引金額 in integer JPY"
+          },
+          "counterparty_name": {
+            "type": "string",
+            "description": "取引先名 partial match"
+          },
+          "category": {
+            "type": "string",
+            "enum": ["invoice_received", "contract", "receipt", "other"],
+            "description": "Document category filter"
+          },
+          "include_voided": {
+            "type": "boolean",
+            "default": false,
+            "description": "Include voided documents in results"
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 20
+          },
+          "offset": {
+            "type": "integer",
+            "minimum": 0,
+            "default": 0
+          }
+        }
+      },
+      "responseSchemaRef": "#/components/schemas/VaultDocumentListResponse"
+    },
+    {
+      "name": "getVaultDocumentById",
+      "title": "Get Vault Document",
+      "description": "Retrieve a single received document by ID, including metadata, SHA-256, retention expiry, and current version number.",
+      "safety": "read",
+      "source": {
+        "type": "openapi",
+        "operationId": "getDocumentById",
+        "method": "GET",
+        "path": "/admin/vault/documents/{id}"
+      },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Document ULID"
+          }
+        }
+      },
+      "responseSchemaRef": "#/components/schemas/VaultDocumentResponse"
+    },
+    {
+      "name": "getVaultDocumentHistory",
+      "title": "Get Vault Document History",
+      "description": "Retrieve the full audit trail and version history for a received document. Returns all file versions and every audit event (upload, metadata edit, void, restore) with before/after state.",
+      "safety": "read",
+      "source": {
+        "type": "openapi",
+        "operationId": "getDocumentHistory",
+        "method": "GET",
+        "path": "/admin/vault/documents/{id}/history"
+      },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Document ULID"
+          }
+        }
+      },
+      "responseSchemaRef": "#/components/schemas/DocumentHistoryResponse"
+    },
+    {
+      "name": "listVaultAuditEvents",
+      "title": "List Vault Audit Events",
+      "description": "Browse the append-only audit event log. Filter by entity type, entity ID, action, or actor. Useful for compliance review and tax audit responses.",
+      "safety": "read",
+      "source": {
+        "type": "openapi",
+        "operationId": "listAuditEvents",
+        "method": "GET",
+        "path": "/admin/audit-events"
+      },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "entity_type": {
+            "type": "string",
+            "description": "Filter by entity type (e.g. vault_document)"
+          },
+          "entity_id": {
+            "type": "string",
+            "description": "Filter by entity ID"
+          },
+          "action": {
+            "type": "string",
+            "description": "Filter by action (e.g. document.uploaded)"
+          },
+          "actor_user_id": {
+            "type": "integer",
+            "description": "Filter by actor user ID"
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 20
+          },
+          "offset": {
+            "type": "integer",
+            "minimum": 0,
+            "default": 0
+          }
+        }
+      },
+      "responseSchemaRef": "#/components/schemas/AuditEventListResponse"
+    }
+  ]
+}

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -33,10 +33,17 @@
 - [x] Docker Compose dev environment (PR #57, #58)
 - [x] Export ZIP bundling — manifest CSV + document files in single archive (PR #64)
 
-## Phase 3 — In progress
+## Phase 3 — Done
 
 - [x] Operator guide (storage, backup, retention, search, export) — `docs/operator/` (PR #66)
 - [x] 事務処理規程 template — `docs/operator/jimu-shokirei-template.md` (PR #66)
 - [x] Web installer + release ZIP (Tier A shared hosting) — `install.php` + `tools/build-release.sh` (PR #68)
+
+## Phase 4 — In progress
+
+- [x] MCP read tools — `searchVaultDocuments`, `getVaultDocumentById`, `getVaultDocumentHistory`, `listVaultAuditEvents` (PR #70)
+- [ ] Optional S3 storage adapter
+- [ ] Optional email inbound
+- [ ] OCR assist (suggest-only, human confirm)
 
 Last updated: 2026-05-31

--- a/tools/local-mcp-server.php
+++ b/tools/local-mcp-server.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NeNe Vault — Local MCP server entry point.
+ *
+ * Reads JSON-RPC 2.0 messages from STDIN and writes responses to STDOUT.
+ * Tool catalog: docs/mcp/tools.json
+ * OpenAPI contract: docs/openapi/openapi.yaml
+ *
+ * Environment variables:
+ *   NENE2_LOCAL_API_BASE_URL   API base URL (default: http://localhost:8080)
+ *   NENE2_LOCAL_JWT_SECRET     JWT secret — required for authenticated tools
+ *
+ * Usage (Claude Desktop claude_desktop_config.json):
+ * {
+ *   "mcpServers": {
+ *     "nene-vault": {
+ *       "command": "php",
+ *       "args": ["/path/to/nene-vault/tools/local-mcp-server.php"],
+ *       "env": {
+ *         "NENE2_LOCAL_API_BASE_URL": "http://localhost:8080",
+ *         "NENE2_LOCAL_JWT_SECRET": "your-vault-jwt-secret"
+ *       }
+ *     }
+ *   }
+ * }
+ */
+
+use Nene2\Auth\LocalBearerTokenVerifier;
+use Nene2\Mcp\LocalMcpException;
+use Nene2\Mcp\LocalMcpServer;
+use Nene2\Mcp\LocalMcpToolCatalog;
+use Nene2\Mcp\NativeLocalMcpHttpClient;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+$root = dirname(__DIR__);
+$apiBaseUrl = (string) (getenv('NENE2_LOCAL_API_BASE_URL') ?: 'http://localhost:8080');
+
+$bearerToken = null;
+$jwtSecret = getenv('NENE2_LOCAL_JWT_SECRET');
+
+if (is_string($jwtSecret) && $jwtSecret !== '') {
+    $v = new LocalBearerTokenVerifier($jwtSecret);
+    $bearerToken = $v->issue([
+        'sub'  => 'mcp-server',
+        'role' => 'admin',
+        'iat'  => time(),
+        'exp'  => time() + 86400,
+    ]);
+}
+
+$server = new LocalMcpServer(
+    new LocalMcpToolCatalog($root . '/docs/mcp/tools.json'),
+    new NativeLocalMcpHttpClient($bearerToken),
+    $apiBaseUrl,
+);
+
+while (($line = fgets(STDIN)) !== false) {
+    $line = trim($line);
+
+    if ($line === '') {
+        continue;
+    }
+
+    try {
+        $message = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+
+        if (!is_array($message)) {
+            throw new LocalMcpException('JSON-RPC message must be an object.');
+        }
+
+        $response = $server->handle($message);
+
+        if ($response === null) {
+            continue;
+        }
+    } catch (Throwable $exception) {
+        $response = [
+            'jsonrpc' => '2.0',
+            'id'      => null,
+            'error'   => [
+                'code'    => -32700,
+                'message' => $exception->getMessage(),
+            ],
+        ];
+    }
+
+    fwrite(STDOUT, json_encode($response, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . PHP_EOL);
+}


### PR DESCRIPTION
## Summary

Phase 4 first item: Claude can now search and read documents from NeNe Vault via MCP.

## Tools

| Tool | Endpoint | Use case |
|---|---|---|
| `searchVaultDocuments` | `GET /admin/vault/documents` | Search by 取引年月日/取引金額/取引先名 |
| `getVaultDocumentById` | `GET /admin/vault/documents/{id}` | Get document detail + SHA-256 |
| `getVaultDocumentHistory` | `GET /admin/vault/documents/{id}/history` | Full audit trail |
| `listVaultAuditEvents` | `GET /admin/audit-events` | Browse compliance log |

## Usage (Claude Desktop)

```json
{
  "mcpServers": {
    "nene-vault": {
      "command": "php",
      "args": ["/path/to/nene-vault/tools/local-mcp-server.php"],
      "env": {
        "NENE2_LOCAL_API_BASE_URL": "http://localhost:8080",
        "NENE2_LOCAL_JWT_SECRET": "your-vault-jwt-secret"
      }
    }
  }
}
```

## Changes

- `docs/mcp/tools.json` — tool catalog (4 read tools)
- `tools/local-mcp-server.php` — vault MCP server entry point
- `composer.json` — `mcp` (validate) + `mcp:server` (run); `mcp` added to `check` gate

## Test plan

- [x] `composer check` — all gates green including new `mcp` validation
- [x] `composer mcp` — `MCP tool catalog is valid.`
- [ ] Manual smoke: `echo '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | NENE2_LOCAL_JWT_SECRET=... php tools/local-mcp-server.php`

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)