### PR TITLE
feat(email): email inbound — MIME parsing + maildir dropbox → auto-upload (#73)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,13 @@ PROBLEM_DETAILS_BASE_URL=https://nene-vault.dev/problems/
 NENE_VAULT_STORAGE_PATH=storage/vault
 NENE_VAULT_MAX_FILE_SIZE_MB=20
 
+# --- Email inbound (optional) ---
+# NENE_VAULT_EMAIL_MAILDIR=/var/mail/vault        Directory containing .eml files
+# NENE_VAULT_EMAIL_API_BASE_URL=http://localhost:8080
+# NENE_VAULT_EMAIL_API_TOKEN=                     Bearer token (run tools/issue-jwt.php to generate)
+# NENE_VAULT_EMAIL_CATEGORY=invoice_received      Default category for email uploads
+# NENE_VAULT_EMAIL_DRY_RUN=false                  Set true to test without uploading
+
 # --- Storage adapter (local or s3) ---
 NENE_VAULT_STORAGE_ADAPTER=local
 # S3 / S3-compatible settings (required when NENE_VAULT_STORAGE_ADAPTER=s3):

--- a/docs/operator/README.md
+++ b/docs/operator/README.md
@@ -13,6 +13,7 @@ This directory covers everything an operator needs to run NeNe Vault in producti
 | [search.md](./search.md) | 電帳法 search fields, UI walkthrough, quick-search guide |
 | [export.md](./export.md) | CSV/ZIP export, tax audit response (電帳法 §10) |
 | [jimu-shokirei-template.md](./jimu-shokirei-template.md) | 事務処理規程 template (customize and adopt) |
+| [email-inbound.md](./email-inbound.md) | Automatic import of email attachments (optional) |
 
 ## Compliance note
 

--- a/docs/operator/email-inbound.md
+++ b/docs/operator/email-inbound.md
@@ -1,0 +1,144 @@
+# Email Inbound
+
+NeNe Vault can automatically receive and archive vendor invoices and receipts
+delivered by email. PDF, JPEG, and PNG attachments are extracted and uploaded
+to the vault with `source: email_inbound`.
+
+---
+
+## How it works
+
+1. Your MTA (mail server) delivers incoming emails as `.eml` files to a watched
+   directory (maildir dropbox).
+2. `tools/email-inbound.php` scans the directory, parses MIME, and uploads
+   allowed attachments via the REST API.
+3. Processed files are moved to `{maildir}/processed/`.
+
+The processor runs on demand (CLI) or via cron. No `ext-imap` dependency.
+
+---
+
+## Setup
+
+### 1. Create a dedicated email address
+
+Create a mailbox like `vault@yourdomain.example` or a simple alias that
+delivers to the dropbox directory.
+
+### 2. Configure MTA delivery
+
+**Postfix example** — deliver to a directory using `local_destination_concurrency_limit`
+and a `.forward` or `master.cf` pipe rule:
+
+```
+# /etc/aliases (or ~/.forward for user delivery)
+vault: "|/usr/bin/tee /var/mail/vault/$(date +%s%N).eml > /dev/null"
+```
+
+Or use `procmail`:
+```
+# ~/.procmailrc
+:0c
+/var/mail/vault/${UNIQUE}.eml
+```
+
+Make the directory writable by the mail user:
+```sh
+mkdir -p /var/mail/vault
+chown mail:mail /var/mail/vault
+chmod 770 /var/mail/vault
+```
+
+### 3. Generate a bearer token
+
+```sh
+php vendor/hideyukimori/nene2/tools/issue-jwt.php \
+  --secret "$NENE2_LOCAL_JWT_SECRET" \
+  --sub email-inbound \
+  --role admin \
+  --org-id 1 \
+  --ttl 315360000
+```
+
+This generates a long-lived token (10 years) for the inbound processor. Store
+it securely (not in `.env` if shared).
+
+### 4. Configure environment
+
+```env
+NENE_VAULT_EMAIL_MAILDIR=/var/mail/vault
+NENE_VAULT_EMAIL_API_BASE_URL=http://localhost:8080
+NENE_VAULT_EMAIL_API_TOKEN=your-bearer-token-here
+NENE_VAULT_EMAIL_CATEGORY=invoice_received
+```
+
+### 5. Test with dry run
+
+```sh
+NENE_VAULT_EMAIL_DRY_RUN=true php tools/email-inbound.php
+```
+
+Output:
+```
+[email-inbound] Found 2 email(s) to process.
+[email-inbound] Processing: 1748672400123456789.eml (from=billing@vendor.example, attachments=1, allowed=1)
+[email-inbound]   [DRY-RUN] Would upload: invoice_2026_05.pdf (application/pdf, 45123 bytes)
+[email-inbound] Done. uploaded=1 skipped=0 errors=0
+```
+
+### 6. Run manually or via cron
+
+```sh
+# Manual
+php tools/email-inbound.php
+
+# Cron — every 5 minutes
+*/5 * * * * /usr/bin/php /path/to/nene-vault/tools/email-inbound.php \
+  >> /var/log/nene-vault-email.log 2>&1
+```
+
+---
+
+## Metadata extraction
+
+| Field | Source |
+|---|---|
+| `counterparty_name` | Sender display name (`From: ACME Corp <...>`) or email address |
+| `transaction_date` | Email `Date:` header (sender's local date) |
+| `category` | `NENE_VAULT_EMAIL_CATEGORY` (default `invoice_received`) |
+| `source` | Always `email_inbound` |
+
+The operator should review and confirm the metadata in the admin UI after
+import. Documents uploaded via email have `is_metadata_confirmed: false`.
+
+---
+
+## Supported attachment types
+
+| MIME type | Extensions |
+|---|---|
+| `application/pdf` | `.pdf` |
+| `image/jpeg` | `.jpg`, `.jpeg` |
+| `image/png` | `.png` |
+
+Other attachment types (`.xlsx`, `.csv`, etc.) are silently skipped. Emails
+with no allowed attachments are moved to `processed/` without uploading.
+
+---
+
+## Duplicate detection
+
+If the same file (same SHA-256) has already been uploaded within the
+organization, the API returns `409`. The CLI logs the conflict and continues
+with remaining attachments. Duplicates do NOT block processing of other files.
+
+---
+
+## Troubleshooting
+
+| Problem | Check |
+|---|---|
+| No .eml files found | Confirm MTA delivery is writing to `NENE_VAULT_EMAIL_MAILDIR` |
+| HTTP 401 | `NENE_VAULT_EMAIL_API_TOKEN` missing or expired |
+| HTTP 403 | Token's org_id does not match the API's resolved organization |
+| No attachments extracted | Attachment MIME type not in the allowed list; check email source |

--- a/src/Email/EmailAttachment.php
+++ b/src/Email/EmailAttachment.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Email;
+
+final readonly class EmailAttachment
+{
+    /** @var list<string> */
+    private const ALLOWED_MIME_TYPES = ['application/pdf', 'image/jpeg', 'image/png'];
+
+    public function __construct(
+        public string $filename,
+        public string $mimeType,
+        public string $bytes,
+    ) {
+    }
+
+    public function isAllowed(): bool
+    {
+        return in_array($this->mimeType, self::ALLOWED_MIME_TYPES, true);
+    }
+}

--- a/src/Email/InboundEmail.php
+++ b/src/Email/InboundEmail.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Email;
+
+final readonly class InboundEmail
+{
+    /**
+     * @param list<EmailAttachment> $attachments
+     */
+    public function __construct(
+        public string $messageId,
+        public string $from,
+        public string $subject,
+        public ?string $date,
+        public array $attachments,
+    ) {
+    }
+
+    /** @return list<EmailAttachment> */
+    public function allowedAttachments(): array
+    {
+        return array_values(array_filter(
+            $this->attachments,
+            static fn (EmailAttachment $a) => $a->isAllowed(),
+        ));
+    }
+}

--- a/src/Email/MaildirPoller.php
+++ b/src/Email/MaildirPoller.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Email;
+
+use RuntimeException;
+
+/**
+ * Scans a directory for .eml files (maildir dropbox or MTA delivery).
+ *
+ * Operators can configure their MTA (Postfix, Sendmail, etc.) or a mail
+ * forwarding rule to deliver incoming emails as .eml files to the watched
+ * directory. The poller reads new files, parses them, and optionally moves
+ * them to a processed/ subdirectory.
+ *
+ * Environment:
+ *   NENE_VAULT_EMAIL_MAILDIR   Directory to scan (required)
+ */
+final class MaildirPoller
+{
+    public function __construct(
+        private readonly string $maildir,
+        private readonly MimeParser $parser,
+    ) {
+    }
+
+    /**
+     * Yield InboundEmail objects for each unprocessed .eml file.
+     * Moves processed files to {maildir}/processed/.
+     *
+     * @return list<array{email: InboundEmail, path: string}>
+     */
+    public function poll(): array
+    {
+        if (!is_dir($this->maildir)) {
+            throw new RuntimeException('Email maildir does not exist: ' . $this->maildir);
+        }
+
+        $files = glob($this->maildir . '/*.eml') ?: [];
+        $results = [];
+
+        foreach ($files as $path) {
+            $raw = file_get_contents($path);
+
+            if ($raw === false) {
+                continue;
+            }
+
+            $email = $this->parser->parse($raw);
+            $results[] = ['email' => $email, 'path' => $path];
+        }
+
+        return $results;
+    }
+
+    public function markProcessed(string $path): void
+    {
+        $processedDir = $this->maildir . '/processed';
+
+        if (!is_dir($processedDir)) {
+            mkdir($processedDir, 0755, true);
+        }
+
+        $dest = $processedDir . '/' . basename($path);
+
+        if (file_exists($dest)) {
+            $dest = $processedDir . '/' . uniqid('', true) . '_' . basename($path);
+        }
+
+        rename($path, $dest);
+    }
+}

--- a/src/Email/MimeParser.php
+++ b/src/Email/MimeParser.php
@@ -1,0 +1,276 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Email;
+
+/**
+ * Lightweight RFC 2822 / MIME parser for extracting attachments from .eml files.
+ *
+ * Supports:
+ *   - multipart/mixed, multipart/related, multipart/alternative
+ *   - Content-Transfer-Encoding: base64, quoted-printable, 7bit, 8bit
+ *   - RFC 2047 encoded-word headers (=?charset?B/Q?...?=)
+ *   - Nested multipart (recursive)
+ *
+ * No external dependencies; no ext-imap required.
+ */
+final class MimeParser
+{
+    public function parse(string $raw): InboundEmail
+    {
+        [$headerBlock, $body] = $this->splitHeadersBody($raw);
+        $headers = $this->parseHeaders($headerBlock);
+
+        $messageId = $this->header($headers, 'message-id') ?? ('generated-' . hash('sha256', $raw));
+        $from = $this->header($headers, 'from') ?? '';
+        $subject = $this->decodeWords($this->header($headers, 'subject') ?? '');
+        $date = $this->header($headers, 'date');
+
+        $attachments = $this->extractAttachments($headers, $body);
+
+        return new InboundEmail(
+            messageId: trim($messageId, '<> '),
+            from: $from,
+            subject: $subject,
+            date: $date !== null ? $this->parseDate($date) : null,
+            attachments: $attachments,
+        );
+    }
+
+    // ── Part extraction ────────────────────────────────────────────────────────
+
+    /**
+     * @param array<string, list<string>> $headers
+     * @return list<EmailAttachment>
+     */
+    private function extractAttachments(array $headers, string $body): array
+    {
+        $contentType = $this->header($headers, 'content-type') ?? 'text/plain';
+        $mimeType = $this->mimeType($contentType);
+
+        if (str_starts_with($mimeType, 'multipart/')) {
+            $boundary = $this->param($contentType, 'boundary');
+
+            if ($boundary === null) {
+                return [];
+            }
+
+            return $this->extractFromMultipart($body, $boundary);
+        }
+
+        return $this->extractFromPart($headers, $body);
+    }
+
+    /**
+     * @return list<EmailAttachment>
+     */
+    private function extractFromMultipart(string $body, string $boundary): array
+    {
+        $attachments = [];
+        $parts = $this->splitMultipart($body, $boundary);
+
+        foreach ($parts as $part) {
+            [$partHeaderBlock, $partBody] = $this->splitHeadersBody($part);
+            $partHeaders = $this->parseHeaders($partHeaderBlock);
+            $partAttachments = $this->extractAttachments($partHeaders, $partBody);
+            $attachments = array_merge($attachments, $partAttachments);
+        }
+
+        return $attachments;
+    }
+
+    /**
+     * @param array<string, list<string>> $headers
+     * @return list<EmailAttachment>
+     */
+    private function extractFromPart(array $headers, string $body): array
+    {
+        $contentType = $this->header($headers, 'content-type') ?? 'text/plain';
+        $disposition = $this->header($headers, 'content-disposition') ?? '';
+        $mimeType = $this->mimeType($contentType);
+
+        // Only collect if it's an attachment (by disposition or by type)
+        $isAttachment = str_contains(strtolower($disposition), 'attachment')
+            || in_array($mimeType, ['application/pdf', 'image/jpeg', 'image/png'], true);
+
+        if (!$isAttachment) {
+            return [];
+        }
+
+        $filename = $this->param($disposition, 'filename')
+            ?? $this->param($contentType, 'name')
+            ?? 'attachment';
+
+        $filename = $this->decodeWords($filename);
+
+        $encoding = strtolower($this->header($headers, 'content-transfer-encoding') ?? '7bit');
+        $decoded = $this->decodeBody($body, $encoding);
+
+        return [new EmailAttachment(
+            filename: $filename,
+            mimeType: $mimeType,
+            bytes: $decoded,
+        )];
+    }
+
+    // ── MIME helpers ───────────────────────────────────────────────────────────
+
+    /**
+     * @return list<string>
+     */
+    private function splitMultipart(string $body, string $boundary): array
+    {
+        $parts = [];
+        $pattern = '/--' . preg_quote($boundary, '/') . '(?:--)?[\r\n]*/';
+        $segments = preg_split($pattern, $body);
+
+        if ($segments === false) {
+            return [];
+        }
+
+        foreach ($segments as $segment) {
+            $trimmed = trim($segment);
+
+            if ($trimmed !== '' && $trimmed !== '--') {
+                $parts[] = $trimmed;
+            }
+        }
+
+        return $parts;
+    }
+
+    private function decodeBody(string $body, string $encoding): string
+    {
+        return match ($encoding) {
+            'base64'           => base64_decode(preg_replace('/\s+/', '', $body) ?? '', true) ?: '',
+            'quoted-printable' => quoted_printable_decode($body),
+            default            => $body,
+        };
+    }
+
+    // ── Header parsing ─────────────────────────────────────────────────────────
+
+    /**
+     * @return array{string, string}
+     */
+    private function splitHeadersBody(string $raw): array
+    {
+        $pos = strpos($raw, "\r\n\r\n");
+
+        if ($pos !== false) {
+            return [substr($raw, 0, $pos), substr($raw, $pos + 4)];
+        }
+
+        $pos = strpos($raw, "\n\n");
+
+        if ($pos !== false) {
+            return [substr($raw, 0, $pos), substr($raw, $pos + 2)];
+        }
+
+        return [$raw, ''];
+    }
+
+    /**
+     * @return array<string, list<string>>
+     */
+    private function parseHeaders(string $block): array
+    {
+        // Unfold continuation lines
+        $block = preg_replace("/\r\n([ \t])/", ' $1', $block) ?? $block;
+        $block = preg_replace("/\n([ \t])/", ' $1', $block) ?? $block;
+
+        $headers = [];
+        $lines = preg_split('/\r?\n/', $block) ?: [];
+
+        foreach ($lines as $line) {
+            if ($line === '') {
+                continue;
+            }
+
+            $colon = strpos($line, ':');
+
+            if ($colon === false) {
+                continue;
+            }
+
+            $name = strtolower(trim(substr($line, 0, $colon)));
+            $value = trim(substr($line, $colon + 1));
+
+            if (!isset($headers[$name])) {
+                $headers[$name] = [];
+            }
+
+            $headers[$name][] = $value;
+        }
+
+        return $headers;
+    }
+
+    /**
+     * @param array<string, list<string>> $headers
+     */
+    private function header(array $headers, string $name): ?string
+    {
+        return isset($headers[$name][0]) ? $headers[$name][0] : null;
+    }
+
+    private function mimeType(string $contentType): string
+    {
+        $parts = explode(';', $contentType, 2);
+
+        return strtolower(trim($parts[0]));
+    }
+
+    private function param(string $headerValue, string $name): ?string
+    {
+        $pattern = '/' . preg_quote($name, '/') . '\s*=\s*"?([^";]+)"?/i';
+
+        if (preg_match($pattern, $headerValue, $m)) {
+            return trim($m[1], '"');
+        }
+
+        return null;
+    }
+
+    // ── RFC 2047 encoded-word ─────────────────────────────────────────────────
+
+    private function decodeWords(string $s): string
+    {
+        return (string) preg_replace_callback(
+            '/=\?([^?]+)\?([BbQq])\?([^?]*)\?=/',
+            static function (array $m): string {
+                $charset = $m[1];
+                $encoding = strtoupper($m[2]);
+                $encoded = $m[3];
+
+                $decoded = match ($encoding) {
+                    'B' => (base64_decode($encoded, true) ?: $encoded),
+                    default => quoted_printable_decode(str_replace('_', ' ', $encoded)),
+                };
+
+                if (strtolower($charset) !== 'utf-8') {
+                    $converted = mb_convert_encoding($decoded, 'UTF-8', $charset);
+                    $decoded = $converted !== false ? $converted : $decoded;
+                }
+
+                return $decoded;
+            },
+            $s,
+        ) ?: $s;
+    }
+
+    // ── Date parsing ──────────────────────────────────────────────────────────
+
+    private function parseDate(string $dateStr): ?string
+    {
+        // Use DateTimeImmutable to respect the timezone in the Date header.
+        // This preserves the calendar date as seen in the sender's timezone.
+        try {
+            $dt = new \DateTimeImmutable($dateStr);
+            return $dt->format('Y-m-d');
+        } catch (\Exception) {
+            return null;
+        }
+    }
+}

--- a/tests/Email/MimeParserTest.php
+++ b/tests/Email/MimeParserTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Tests\Email;
+
+use NeneVault\Email\MimeParser;
+use PHPUnit\Framework\TestCase;
+
+final class MimeParserTest extends TestCase
+{
+    private MimeParser $parser;
+    private string $fixtureDir;
+
+    protected function setUp(): void
+    {
+        $this->parser = new MimeParser();
+        $this->fixtureDir = dirname(__DIR__) . '/fixtures/email';
+    }
+
+    public function test_parse_multipart_pdf_attachment(): void
+    {
+        $raw = (string) file_get_contents($this->fixtureDir . '/invoice_with_pdf.eml');
+        $email = $this->parser->parse($raw);
+
+        $this->assertSame('ACME Corp <billing@acme.example>', $email->from);
+        $this->assertSame('20260531100000.abc123@acme.example', $email->messageId);
+        $this->assertSame('2026-05-31', $email->date);
+
+        $this->assertCount(1, $email->attachments);
+        $this->assertSame('invoice_2026_05.pdf', $email->attachments[0]->filename);
+        $this->assertSame('application/pdf', $email->attachments[0]->mimeType);
+        $this->assertTrue($email->attachments[0]->isAllowed());
+    }
+
+    public function test_parse_rfc2047_subject_base64(): void
+    {
+        $raw = (string) file_get_contents($this->fixtureDir . '/invoice_with_pdf.eml');
+        $email = $this->parser->parse($raw);
+
+        // =?UTF-8?B?6K2w5qCh5pu4?= decodes to 請求書
+        $this->assertSame('請求書 2026-05', $email->subject);
+    }
+
+    public function test_parse_no_attachment(): void
+    {
+        $raw = (string) file_get_contents($this->fixtureDir . '/no_attachment.eml');
+        $email = $this->parser->parse($raw);
+
+        $this->assertSame('newsletter@example.com', $email->from);
+        $this->assertCount(0, $email->attachments);
+        $this->assertCount(0, $email->allowedAttachments());
+    }
+
+    public function test_parse_jpeg_attachment(): void
+    {
+        $raw = (string) file_get_contents($this->fixtureDir . '/multipart_with_jpeg.eml');
+        $email = $this->parser->parse($raw);
+
+        // =?UTF-8?Q?...?= decodes to 領収書
+        $this->assertStringContainsString('領収書', $email->subject);
+
+        $allowed = $email->allowedAttachments();
+        $this->assertCount(1, $allowed);
+        $this->assertSame('receipt.jpg', $allowed[0]->filename);
+        $this->assertSame('image/jpeg', $allowed[0]->mimeType);
+    }
+
+    public function test_rfc2047_quoted_printable_subject(): void
+    {
+        $raw = "From: test@example.com\r\n"
+            . "Subject: =?UTF-8?Q?=E9=A0=98=E5=8F=8E=E6=9B=B8?=\r\n"
+            . "Message-ID: <test@example.com>\r\n"
+            . "\r\n"
+            . 'body';
+
+        $email = $this->parser->parse($raw);
+        $this->assertSame('領収書', $email->subject);
+    }
+
+    public function test_text_plain_is_not_attachment(): void
+    {
+        $raw = "From: test@example.com\r\n"
+            . "Subject: test\r\n"
+            . "Message-ID: <test2@example.com>\r\n"
+            . "Content-Type: text/plain\r\n"
+            . "\r\n"
+            . 'just text';
+
+        $email = $this->parser->parse($raw);
+        $this->assertCount(0, $email->attachments);
+    }
+
+    public function test_allowed_attachments_filters_disallowed(): void
+    {
+        $raw = "From: test@example.com\r\n"
+            . "Subject: test\r\n"
+            . "Message-ID: <test3@example.com>\r\n"
+            . "MIME-Version: 1.0\r\n"
+            . "Content-Type: multipart/mixed; boundary=\"b\"\r\n"
+            . "\r\n"
+            . "--b\r\n"
+            . "Content-Type: text/csv; name=\"data.csv\"\r\n"
+            . "Content-Disposition: attachment; filename=\"data.csv\"\r\n"
+            . "\r\n"
+            . "col1,col2\r\n"
+            . "--b\r\n"
+            . "Content-Type: application/pdf; name=\"invoice.pdf\"\r\n"
+            . "Content-Disposition: attachment; filename=\"invoice.pdf\"\r\n"
+            . "\r\n"
+            . "fake pdf bytes\r\n"
+            . "--b--\r\n";
+
+        $email = $this->parser->parse($raw);
+        $this->assertCount(2, $email->attachments);
+
+        $allowed = $email->allowedAttachments();
+        $this->assertCount(1, $allowed);
+        $this->assertSame('invoice.pdf', $allowed[0]->filename);
+    }
+}

--- a/tests/fixtures/email/invoice_with_pdf.eml
+++ b/tests/fixtures/email/invoice_with_pdf.eml
@@ -1,0 +1,23 @@
+From: ACME Corp <billing@acme.example>
+To: vault@example.com
+Subject: =?UTF-8?B?6KuL5rGC5pu4IDIwMjYtMDU=?=
+Date: Sun, 31 May 2026 10:00:00 +0900
+Message-ID: <20260531100000.abc123@acme.example>
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="boundary-abc123"
+
+--boundary-abc123
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+請求書を添付いたします。よろしくお願いいたします。
+
+--boundary-abc123
+Content-Type: application/pdf; name="invoice_2026_05.pdf"
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename="invoice_2026_05.pdf"
+
+JVBERi0xLjQKJcOkw7zDtsO8CjIgMCBvYmoKPDwgL0xlbmd0aCAzIDAgUiAvRmlsdGVyIC9GbGF0
+ZURlY29kZSA+PgpzdHJlYW0KeJxjYGBg+M9AAAQEAQIDAQQFBgcICQoLDA0ODxAREhMUFRYXGBka
+Gxwd
+--boundary-abc123--

--- a/tests/fixtures/email/multipart_with_jpeg.eml
+++ b/tests/fixtures/email/multipart_with_jpeg.eml
@@ -1,0 +1,25 @@
+From: "山田 太郎" <yamada@supplier.example>
+To: vault@example.com
+Subject: =?UTF-8?B?6aCY5Y+O5pu4?=
+Date: Sat, 30 May 2026 15:30:00 +0900
+Message-ID: <abc.def.ghi@supplier.example>
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="==boundary=="
+
+--==boundary==
+Content-Type: text/plain; charset=utf-8
+
+領収書をお送りします。
+
+--==boundary==
+Content-Type: image/jpeg; name="receipt.jpg"
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename="receipt.jpg"
+
+/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAABAAEDASIA
+AhEBAxEB/8QAFAABAAAAAAAAAAAAAAAAAAAACf/EABQQAQAAAAAAAAAAAAAAAAAAAAD/xAAUAQEAAAAA
+AAAAAAAAAAAAAAAA/8QAFBEBAAAAAAAAAAAAAAAAAAAAAP/aAAwDAQACEQMRAD8AJQAB/9k=
+
+--==boundary==--

--- a/tests/fixtures/email/no_attachment.eml
+++ b/tests/fixtures/email/no_attachment.eml
@@ -1,0 +1,10 @@
+From: newsletter@example.com
+To: vault@example.com
+Subject: Weekly Newsletter
+Date: Mon, 31 May 2026 09:00:00 +0900
+Message-ID: <20260531090000.xyz456@example.com>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+This is a plain-text newsletter with no attachments.

--- a/tools/email-inbound.php
+++ b/tools/email-inbound.php
@@ -1,0 +1,222 @@
+<?php
+
+/**
+ * NeNe Vault — Email inbound processor
+ *
+ * Scans a maildir directory for .eml files and uploads PDF/JPEG/PNG
+ * attachments to the vault via the REST API.
+ *
+ * Environment variables (set in .env or export before running):
+ *   NENE_VAULT_EMAIL_MAILDIR        Directory containing .eml files (required)
+ *   NENE_VAULT_EMAIL_API_BASE_URL   API base URL (default: http://localhost:8080)
+ *   NENE_VAULT_EMAIL_API_TOKEN      Bearer token for API auth (required)
+ *   NENE_VAULT_EMAIL_CATEGORY       Document category (default: invoice_received)
+ *   NENE_VAULT_EMAIL_DRY_RUN        Set to 'true' to parse only without uploading
+ *
+ * Usage (manual):
+ *   php tools/email-inbound.php
+ *
+ * Usage (cron — every 5 minutes):
+ *   * /5 * * * * /usr/bin/php /path/to/nene-vault/tools/email-inbound.php >> /var/log/nene-vault-email.log 2>&1
+ *
+ * MTA delivery (Postfix example):
+ *   Create /etc/aliases or .forward to pipe to a script that saves .eml files:
+ *     vault: "|/usr/bin/tee /var/mail/vault/$(date +%s%N).eml"
+ *   Then set NENE_VAULT_EMAIL_MAILDIR=/var/mail/vault
+ */
+
+declare(strict_types=1);
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+use NeneVault\Email\MaildirPoller;
+use NeneVault\Email\MimeParser;
+
+$maildir = (string) (getenv('NENE_VAULT_EMAIL_MAILDIR') ?: '');
+$apiBase = rtrim((string) (getenv('NENE_VAULT_EMAIL_API_BASE_URL') ?: 'http://localhost:8080'), '/');
+$token = (string) (getenv('NENE_VAULT_EMAIL_API_TOKEN') ?: '');
+$category = (string) (getenv('NENE_VAULT_EMAIL_CATEGORY') ?: 'invoice_received');
+$dryRun = getenv('NENE_VAULT_EMAIL_DRY_RUN') === 'true';
+
+// ── Validation ────────────────────────────────────────────────────────────────
+
+if ($maildir === '') {
+    fwrite(STDERR, "[email-inbound] ERROR: NENE_VAULT_EMAIL_MAILDIR is not set.\n");
+    exit(1);
+}
+
+if (!$dryRun && $token === '') {
+    fwrite(STDERR, "[email-inbound] ERROR: NENE_VAULT_EMAIL_API_TOKEN is not set.\n");
+    exit(1);
+}
+
+// ── Poll ──────────────────────────────────────────────────────────────────────
+
+$poller = new MaildirPoller($maildir, new MimeParser());
+
+try {
+    $items = $poller->poll();
+} catch (Throwable $e) {
+    fwrite(STDERR, '[email-inbound] ERROR: ' . $e->getMessage() . "\n");
+    exit(1);
+}
+
+if ($items === []) {
+    echo "[email-inbound] No new .eml files found in {$maildir}\n";
+    exit(0);
+}
+
+echo '[email-inbound] Found ' . count($items) . " email(s) to process.\n";
+
+$uploaded = 0;
+$skipped = 0;
+$errors = 0;
+
+foreach ($items as ['email' => $email, 'path' => $path]) {
+    $allowed = $email->allowedAttachments();
+
+    echo sprintf(
+        "[email-inbound] Processing: %s (from=%s, attachments=%d, allowed=%d)\n",
+        basename($path),
+        $email->from,
+        count($email->attachments),
+        count($allowed),
+    );
+
+    if ($allowed === []) {
+        echo "[email-inbound]   No allowed attachments — skipping.\n";
+        $skipped++;
+        $poller->markProcessed($path);
+        continue;
+    }
+
+    foreach ($allowed as $attachment) {
+        if ($dryRun) {
+            echo sprintf(
+                "[email-inbound]   [DRY-RUN] Would upload: %s (%s, %d bytes)\n",
+                $attachment->filename,
+                $attachment->mimeType,
+                strlen($attachment->bytes),
+            );
+            $uploaded++;
+            continue;
+        }
+
+        $result = uploadAttachment(
+            apiBase: $apiBase,
+            token: $token,
+            attachment: $attachment,
+            email: $email,
+            category: $category,
+        );
+
+        if ($result['ok']) {
+            echo sprintf(
+                "[email-inbound]   Uploaded: %s → document %s\n",
+                $attachment->filename,
+                $result['id'] ?? '(unknown)',
+            );
+            $uploaded++;
+        } else {
+            fwrite(STDERR, sprintf(
+                "[email-inbound]   ERROR uploading %s: %s\n",
+                $attachment->filename,
+                $result['error'] ?? 'unknown error',
+            ));
+            $errors++;
+        }
+    }
+
+    $poller->markProcessed($path);
+}
+
+echo sprintf(
+    "[email-inbound] Done. uploaded=%d skipped=%d errors=%d\n",
+    $uploaded,
+    $skipped,
+    $errors,
+);
+
+exit($errors > 0 ? 1 : 0);
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * @return array{ok: bool, id?: string, error?: string}
+ */
+function uploadAttachment(
+    string $apiBase,
+    string $token,
+    \NeneVault\Email\EmailAttachment $attachment,
+    \NeneVault\Email\InboundEmail $email,
+    string $category,
+): array {
+    $tmp = tempnam(sys_get_temp_dir(), 'vault_email_');
+
+    if ($tmp === false) {
+        return ['ok' => false, 'error' => 'Failed to create temp file.'];
+    }
+
+    file_put_contents($tmp, $attachment->bytes);
+
+    try {
+        $ch = curl_init($apiBase . '/admin/vault/documents');
+
+        $postFields = [
+            'file'             => new CURLFile($tmp, $attachment->mimeType, $attachment->filename),
+            'counterparty_name' => extractCounterparty($email->from),
+            'category'         => $category,
+            'source'           => 'email_inbound',
+        ];
+
+        if ($email->date !== null) {
+            $postFields['transaction_date'] = $email->date;
+        }
+
+        curl_setopt_array($ch, [
+            CURLOPT_POST           => true,
+            CURLOPT_POSTFIELDS     => $postFields,
+            CURLOPT_HTTPHEADER     => ['Authorization: Bearer ' . $token],
+            CURLOPT_RETURNTRANSFER => true,
+        ]);
+
+        $body = curl_exec($ch);
+        $status = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
+        if (!is_string($body)) {
+            return ['ok' => false, 'error' => 'curl returned non-string response.'];
+        }
+
+        if ($status === 201) {
+            $data = json_decode($body, true);
+            return ['ok' => true, 'id' => is_array($data) ? (string) ($data['id'] ?? '') : ''];
+        }
+
+        return ['ok' => false, 'error' => "HTTP {$status}: {$body}"];
+    } finally {
+        @unlink($tmp);
+    }
+}
+
+/**
+ * Extract a display name or email address from a From: header value.
+ * "ACME Corp <billing@acme.example>" → "ACME Corp"
+ * "billing@acme.example"             → "billing@acme.example"
+ */
+function extractCounterparty(string $from): string
+{
+    if (preg_match('/^([^<]+)</', $from, $m)) {
+        $name = trim($m[1], ' "\'');
+
+        if ($name !== '') {
+            return $name;
+        }
+    }
+
+    if (preg_match('/<([^>]+)>/', $from, $m)) {
+        return $m[1];
+    }
+
+    return $from !== '' ? $from : 'Unknown';
+}


### PR DESCRIPTION
## Summary

Phase 4 email inbound: operators can receive vendor invoices/receipts via email and have attachments auto-uploaded to the vault.

## Architecture

```
MTA → delivers .eml to /var/mail/vault/
        ↓
tools/email-inbound.php (cron / manual)
        ↓
MaildirPoller → scans *.eml files
        ↓
MimeParser → extracts PDF/JPEG/PNG attachments
        ↓
REST API POST /admin/vault/documents (source=email_inbound)
        ↓
.eml moved to processed/
```

## New files

| File | Purpose |
|---|---|
| `src/Email/MimeParser.php` | RFC 2822/MIME parser (multipart, base64, QP, RFC 2047) |
| `src/Email/InboundEmail.php` | Value object for parsed email |
| `src/Email/EmailAttachment.php` | Value object for attachment |
| `src/Email/MaildirPoller.php` | Scan maildir directory, move processed files |
| `tools/email-inbound.php` | CLI entry point |
| `docs/operator/email-inbound.md` | Setup guide (MTA, cron, metadata, troubleshooting) |
| `tests/Email/MimeParserTest.php` | 7 tests with .eml fixtures |

## Test plan

- [x] `composer check` — all gates green including 7 new MIME parser tests
- [ ] Manual: drop a real vendor invoice .eml into a test directory and run `NENE_VAULT_EMAIL_DRY_RUN=true php tools/email-inbound.php`

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)