### PR TITLE
feat(mcp): write tools + OCR/export + integration guide + CLAUDE.md (#79)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "nene-vault": {
+      "command": "php",
+      "args": ["tools/local-mcp-server.php"],
+      "env": {
+        "NENE2_LOCAL_API_BASE_URL": "http://localhost:8080",
+        "NENE2_LOCAL_JWT_SECRET": "${NENE2_LOCAL_JWT_SECRET}"
+      }
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,47 @@
+# NeNe Vault — Claude Code Guide
+
+**Received-document archive for Japan SMB (電子帳簿保存法).** Built on PHP 8.4 + NENE2.
+
+## Start here
+
+- **Scope (binding):** `docs/explanation/scope-contract.md` — what Vault does and does NOT do
+- **Canonical terms:** `docs/terms.md` — single source of truth for all identifiers
+- **Compliance (binding):** `docs/explanation/received-document-compliance.md`
+- **Current work:** `docs/todo/current.md`
+- **Roadmap:** `docs/roadmap.md`
+- **Full agent guide:** `AGENTS.md`
+
+## Quick orientation
+
+```
+src/           PHP application (NeneVault\)
+tests/         PHPUnit tests (mirrors src/)
+frontend/      React + Vite admin UI
+docs/          ADRs, OpenAPI, operator guide, MCP catalog
+docs/mcp/      MCP tool catalog + integration guide
+tools/         CLI scripts (MCP server, email inbound, release builder)
+locales/       ja.json + en.json (single source of truth for all UI text)
+```
+
+## Commands
+
+```bash
+composer check          # test + PHPStan + CS + locales + openapi + mcp
+npm run check --prefix frontend  # type-check + lint + test + build
+composer mcp:server     # start MCP server (stdio JSON-RPC)
+```
+
+## Hard rules (never violate without an ADR)
+
+- **No hard-delete** of documents during the retention window
+- **No byte overwrite** of stored files — new version only
+- **SHA-256** verified on every download
+- **Every mutation** goes through `AuditRecorder` in the same DB transaction
+- **Every repository query** on a tenant table must include `organization_id`
+- **Storage path** must never appear in API responses
+- **No invoice issuance, reconciliation, bank CSV, or expense workflows** — see `AGENTS.md`
+
+## MCP tools (read + write)
+
+The MCP server at `tools/local-mcp-server.php` exposes 9 tools.
+See `docs/mcp/README.md` for setup and `docs/mcp/tools.json` for the catalog.

--- a/docs/development/naming-conventions.md
+++ b/docs/development/naming-conventions.md
@@ -194,11 +194,11 @@ Compliance-critical tests (retention block, hash verification, audit write, org 
 
 | Item | Rule | Example |
 | --- | --- | --- |
-| Tool `name` | Same as OpenAPI `operationId` | `searchDocuments`, `getDocumentById` |
-| Tool `title` | Short English Title Case | `Search Documents`, `Get Document` |
-| `safety` | `read` or `write` | `read` for search/get; `write` for upload/void |
+| Tool `name` | `{verb}VaultDocument{Noun}` or `{verb}Vault{Resource}` | `searchVaultDocuments`, `voidVaultDocument` |
+| Tool `title` | Short English Title Case | `Search Vault Documents`, `Void Vault Document` |
+| `safety` | `read` or `write` | `read` for search/get/ocr/export; `write` for metadata/void/restore |
 
-Catalog: `docs/mcp/tools.json`. Phase 4+ (read tools first per roadmap).
+Catalog: `docs/mcp/tools.json` (9 tools: 6 read, 3 write). Integration guide: `docs/mcp/README.md`.
 
 ---
 

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -1,0 +1,128 @@
+# NeNe Vault MCP Integration
+
+NeNe Vault exposes its document archive through the
+[Model Context Protocol (MCP)](https://modelcontextprotocol.io/), allowing
+Claude and other MCP-compatible AI assistants to search, read, and update
+received documents directly.
+
+## Available tools
+
+| Tool | Type | Purpose |
+|---|---|---|
+| `searchVaultDocuments` | read | Search by date / amount / counterparty (電帳法 §4) |
+| `getVaultDocumentById` | read | Get document detail + SHA-256 |
+| `getVaultDocumentHistory` | read | Full audit trail (versions + events) |
+| `listVaultAuditEvents` | read | Browse compliance log |
+| `ocrSuggestVaultDocument` | read | OCR → suggest metadata (never auto-applied) |
+| `exportVaultDocumentsCsv` | read | Export manifest CSV for tax audit |
+| `updateVaultDocumentMetadata` | **write** | Update date / amount / counterparty / category |
+| `voidVaultDocument` | **write** | Void with mandatory reason (audit-logged) |
+| `restoreVaultDocument` | **write** | Restore a voided document |
+
+Write tools require `NENE2_LOCAL_JWT_SECRET` to be set in the server environment.
+
+---
+
+## Prerequisites
+
+1. NeNe Vault running at a reachable URL (e.g. `http://localhost:8080`)
+2. A bearer token — generate one with:
+
+```sh
+php vendor/hideyukimori/nene2/tools/issue-jwt.php \
+  --secret "$NENE2_LOCAL_JWT_SECRET" \
+  --sub mcp \
+  --role admin \
+  --org-id 1 \
+  --ttl 315360000
+```
+
+---
+
+## Claude Desktop
+
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json`
+(macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+
+```json
+{
+  "mcpServers": {
+    "nene-vault": {
+      "command": "php",
+      "args": ["/absolute/path/to/nene-vault/tools/local-mcp-server.php"],
+      "env": {
+        "NENE2_LOCAL_API_BASE_URL": "http://localhost:8080",
+        "NENE2_LOCAL_JWT_SECRET": "your-vault-jwt-secret"
+      }
+    }
+  }
+}
+```
+
+Restart Claude Desktop. The vault tools appear in the tool selector.
+
+---
+
+## Claude Code
+
+Add `.mcp.json` to the project root (already present in NeNe Vault):
+
+```json
+{
+  "mcpServers": {
+    "nene-vault": {
+      "command": "php",
+      "args": ["tools/local-mcp-server.php"],
+      "env": {
+        "NENE2_LOCAL_API_BASE_URL": "http://localhost:8080",
+        "NENE2_LOCAL_JWT_SECRET": "your-vault-jwt-secret"
+      }
+    }
+  }
+}
+```
+
+Claude Code picks up `.mcp.json` automatically when you open the project.
+
+---
+
+## Smoke test
+
+```sh
+# List available tools
+echo '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
+  | NENE2_LOCAL_API_BASE_URL=http://localhost:8080 \
+    NENE2_LOCAL_JWT_SECRET=your-secret \
+    php tools/local-mcp-server.php
+
+# Search documents (read-only, no JWT secret required for read tools)
+echo '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"searchVaultDocuments","arguments":{"counterparty_name":"ACME","limit":5}}}' \
+  | NENE2_LOCAL_API_BASE_URL=http://localhost:8080 \
+    NENE2_LOCAL_JWT_SECRET=your-secret \
+    php tools/local-mcp-server.php
+```
+
+---
+
+## Example prompts
+
+Once connected, you can ask Claude:
+
+- 「2026年5月の請求書をすべて検索して、合計金額を教えて」
+- 「書類ID `01JXXX...` の変更履歴を見せて」
+- "Search for documents from ACME Corp in Q1 2026 and export as CSV"
+- "The document `01JXXX...` was registered by mistake — void it with reason 'Duplicate entry'"
+- "Run OCR on document `01JXXX...` and suggest the correct transaction date and amount"
+
+---
+
+## Security notes
+
+- The MCP server issues a JWT derived from `NENE2_LOCAL_JWT_SECRET`. Keep this
+  value confidential and do not commit it to the repository.
+- Read tools work without authentication (but the server still needs the secret
+  to proxy requests to the authenticated API). Write tools explicitly require it.
+- The server runs locally; no external network access is made beyond the
+  configured `NENE2_LOCAL_API_BASE_URL`.
+- Storage paths are never exposed through MCP tool responses (enforced at the
+  API layer — `file_path` is excluded from all API responses).

--- a/docs/mcp/tools.json
+++ b/docs/mcp/tools.json
@@ -159,6 +159,171 @@
         }
       },
       "responseSchemaRef": "#/components/schemas/AuditEventListResponse"
+    },
+    {
+      "name": "ocrSuggestVaultDocument",
+      "title": "OCR Suggest Document Metadata",
+      "description": "Run OCR on a document's current file and return suggested metadata (取引年月日, 取引金額, 取引先名). Suggestions are never applied automatically — the operator confirms via the metadata edit form. Returns null fields when not detected. Requires Tesseract on the server.",
+      "safety": "read",
+      "source": {
+        "type": "openapi",
+        "operationId": "ocrSuggestDocument",
+        "method": "GET",
+        "path": "/admin/vault/documents/{id}/ocr-suggest"
+      },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Document ULID"
+          }
+        }
+      },
+      "responseSchemaRef": "#/components/schemas/OcrSuggestionResponse"
+    },
+    {
+      "name": "exportVaultDocumentsCsv",
+      "title": "Export Vault Documents CSV",
+      "description": "Export a manifest CSV of matched received documents. Returns CSV text with columns: document_id, version, transaction_date, amount_cents, counterparty_name, category, file_sha256, uploaded_at, voided_at. Suitable for tax audit responses (電帳法 §10). Each exported document is recorded in the audit log.",
+      "safety": "read",
+      "source": {
+        "type": "openapi",
+        "operationId": "exportDocuments",
+        "method": "POST",
+        "path": "/admin/vault/export"
+      },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "transaction_date_from": {
+            "type": "string",
+            "format": "date",
+            "description": "取引年月日 range start (YYYY-MM-DD)"
+          },
+          "transaction_date_to": {
+            "type": "string",
+            "format": "date",
+            "description": "取引年月日 range end (YYYY-MM-DD)"
+          },
+          "counterparty_name": {
+            "type": "string",
+            "description": "取引先名 partial match"
+          },
+          "include_voided": {
+            "type": "boolean",
+            "default": false
+          }
+        }
+      },
+      "responseSchemaRef": null
+    },
+    {
+      "name": "updateVaultDocumentMetadata",
+      "title": "Update Vault Document Metadata",
+      "description": "Update transaction_date, amount_cents, counterparty_name, category, or tags on a received document. File bytes are never changed. Records a document.metadata_changed audit event with before/after state. Requires NENE2_LOCAL_JWT_SECRET (write tool).",
+      "safety": "write",
+      "source": {
+        "type": "openapi",
+        "operationId": "updateDocumentMetadata",
+        "method": "PATCH",
+        "path": "/admin/vault/documents/{id}/metadata"
+      },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "counterparty_name", "category"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Document ULID"
+          },
+          "counterparty_name": {
+            "type": "string",
+            "description": "取引先名"
+          },
+          "category": {
+            "type": "string",
+            "enum": ["invoice_received", "contract", "receipt", "delivery_note", "other"],
+            "description": "Document category"
+          },
+          "transaction_date": {
+            "type": "string",
+            "format": "date",
+            "description": "取引年月日 (YYYY-MM-DD); null to clear"
+          },
+          "amount_cents": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "取引金額 in integer JPY; null to clear"
+          },
+          "tags": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Tag list (replaces existing tags)"
+          }
+        }
+      },
+      "responseSchemaRef": "#/components/schemas/VaultDocumentResponse"
+    },
+    {
+      "name": "voidVaultDocument",
+      "title": "Void Vault Document",
+      "description": "Logically deactivate a received document with a mandatory reason. The file and metadata are retained for the full retention period — this is a logical void, not a delete. Records a document.voided audit event. Requires NENE2_LOCAL_JWT_SECRET (write tool).",
+      "safety": "write",
+      "source": {
+        "type": "openapi",
+        "operationId": "voidDocument",
+        "method": "POST",
+        "path": "/admin/vault/documents/{id}/void"
+      },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "void_reason"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Document ULID"
+          },
+          "void_reason": {
+            "type": "string",
+            "description": "Mandatory reason for voiding (recorded in audit log)"
+          },
+          "void_note": {
+            "type": "string",
+            "description": "Optional extended context"
+          }
+        }
+      },
+      "responseSchemaRef": "#/components/schemas/VaultDocumentResponse"
+    },
+    {
+      "name": "restoreVaultDocument",
+      "title": "Restore Voided Vault Document",
+      "description": "Return a voided document to active status. Records a document.restored audit event. Requires NENE2_LOCAL_JWT_SECRET (write tool).",
+      "safety": "write",
+      "source": {
+        "type": "openapi",
+        "operationId": "restoreDocument",
+        "method": "POST",
+        "path": "/admin/vault/documents/{id}/restore"
+      },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Document ULID"
+          }
+        }
+      },
+      "responseSchemaRef": "#/components/schemas/VaultDocumentResponse"
     }
   ]
 }

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -44,7 +44,7 @@
 
 - [x] MCP read tools — `searchVaultDocuments`, `getVaultDocumentById`, `getVaultDocumentHistory`, `listVaultAuditEvents` (PR #70)
 - [x] S3-compatible storage adapter — `S3DocumentStorage` + Sig V4, select via `NENE_VAULT_STORAGE_ADAPTER=s3` (PR #72)
-- [ ] Optional email inbound (mailbox → auto-upload via IMAP/MIME parser)
+- [x] Optional email inbound (mailbox → auto-upload via IMAP/MIME parser) — `src/Email/` + `tools/email-inbound.php` (PR #74)
 - [x] OCR assist — suggest metadata from PDF/image, human confirm (PR #76)
 
 Last updated: 2026-05-31


### PR DESCRIPTION
## Summary

Expands the MCP tool catalog from 4 read-only tools to 9 tools (6 read + 3 write), adds a complete integration guide, and adds Claude Code project configuration.

## New tools

| Tool | Type | Endpoint |
|---|---|---|
| `ocrSuggestVaultDocument` | read | GET `/admin/vault/documents/{id}/ocr-suggest` |
| `exportVaultDocumentsCsv` | read | POST `/admin/vault/export` (returns CSV text) |
| `updateVaultDocumentMetadata` | **write** | PATCH `/admin/vault/documents/{id}/metadata` |
| `voidVaultDocument` | **write** | POST `/admin/vault/documents/{id}/void` |
| `restoreVaultDocument` | **write** | POST `/admin/vault/documents/{id}/restore` |

## New files

| File | Purpose |
|---|---|
| `docs/mcp/README.md` | Claude Desktop + Claude Code setup, smoke test, example prompts, security notes |
| `.mcp.json` | Claude Code project-level MCP config (auto-loaded when project is open) |
| `CLAUDE.md` | Claude Code entry point: scope, commands, hard rules, MCP summary |

## Other fixes

- `docs/todo/current.md` — email inbound checkbox was incorrectly `[ ]`, now `[x]`
- `naming-conventions.md` §8 — updated tool naming pattern to reflect current catalog

## Test plan

- [x] `composer check` — all gates including `mcp` validation green

Closes #79
🤖 Generated with [Claude Code](https://claude.com/claude-code)