### PR TITLE
test(backend): thick boundary tests for all domains + fix void/restore state machine (#81)

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -572,6 +572,12 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/DocumentNotFound'
+        '409':
+          description: Document is not active (already voided).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
         '422':
           $ref: '#/components/responses/ValidationFailed'
 
@@ -598,6 +604,12 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/DocumentNotFound'
+        '409':
+          description: Document is not voided (already active).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
 
   /admin/vault/documents/{id}/history:
     parameters:

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -18,6 +18,7 @@ use NeneVault\Document\DocumentServiceProvider;
 use NeneVault\Document\DuplicateFileExceptionHandler;
 use NeneVault\Document\FileIntegrityExceptionHandler;
 use NeneVault\Document\FileTooLargeExceptionHandler;
+use NeneVault\Document\InvalidDocumentStateExceptionHandler;
 use NeneVault\Document\MimeTypeNotAllowedExceptionHandler;
 use NeneVault\Document\VaultDocumentNotFoundExceptionHandler;
 use NeneVault\Export\ExportRouteRegistrar;
@@ -159,6 +160,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $c->get(MimeTypeNotAllowedExceptionHandler::class),
                     $c->get(FileTooLargeExceptionHandler::class),
                     $c->get(FileIntegrityExceptionHandler::class),
+                    $c->get(InvalidDocumentStateExceptionHandler::class),
                     $c->get(UserNotFoundExceptionHandler::class),
                     $c->get(UserEmailConflictExceptionHandler::class),
                     $c->get(InvalidUserRoleExceptionHandler::class),

--- a/src/Document/DocumentServiceProvider.php
+++ b/src/Document/DocumentServiceProvider.php
@@ -289,6 +289,18 @@ final readonly class DocumentServiceProvider implements ServiceProviderInterface
                 },
             )
             ->set(
+                InvalidDocumentStateExceptionHandler::class,
+                static function (ContainerInterface $c): InvalidDocumentStateExceptionHandler {
+                    $pd = $c->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$pd instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('ProblemDetailsResponseFactory service is invalid.');
+                    }
+
+                    return new InvalidDocumentStateExceptionHandler($pd);
+                },
+            )
+            ->set(
                 SearchDocumentsHandler::class,
                 static function (ContainerInterface $c): SearchDocumentsHandler {
                     $uc = $c->get(SearchDocumentsUseCaseInterface::class);

--- a/src/Document/InvalidDocumentStateException.php
+++ b/src/Document/InvalidDocumentStateException.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+use RuntimeException;
+
+/**
+ * Thrown when a lifecycle transition is attempted from an incompatible state —
+ * e.g. voiding an already-voided document, or restoring an active one.
+ *
+ * Re-voiding would overwrite the original voided_at / void_reason and corrupt
+ * the audit trail, so the operation is rejected (409 Conflict).
+ */
+final class InvalidDocumentStateException extends RuntimeException
+{
+    public function __construct(
+        public readonly string $documentId,
+        public readonly string $currentStatus,
+        public readonly string $attemptedTransition,
+    ) {
+        parent::__construct(sprintf(
+            'Document %s cannot be %s from status "%s".',
+            $documentId,
+            $attemptedTransition,
+            $currentStatus,
+        ));
+    }
+}

--- a/src/Document/InvalidDocumentStateExceptionHandler.php
+++ b/src/Document/InvalidDocumentStateExceptionHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class InvalidDocumentStateExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $e): bool
+    {
+        return $e instanceof InvalidDocumentStateException;
+    }
+
+    public function handle(Throwable $e, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'invalid-document-state', 'Invalid Document State', 409, $e->getMessage());
+    }
+}

--- a/src/Document/RestoreDocumentUseCase.php
+++ b/src/Document/RestoreDocumentUseCase.php
@@ -28,6 +28,10 @@ final readonly class RestoreDocumentUseCase implements RestoreDocumentUseCaseInt
             throw new VaultDocumentNotFoundException($documentId);
         }
 
+        if ($document->status !== 'voided') {
+            throw new InvalidDocumentStateException($documentId, $document->status, 'restored');
+        }
+
         $beforeJson = ['status' => $document->status];
 
         $this->documents->restore($documentId, $organizationId);

--- a/src/Document/VoidDocumentUseCase.php
+++ b/src/Document/VoidDocumentUseCase.php
@@ -33,6 +33,10 @@ final readonly class VoidDocumentUseCase implements VoidDocumentUseCaseInterface
             throw new VaultDocumentNotFoundException($documentId);
         }
 
+        if ($document->status !== 'active') {
+            throw new InvalidDocumentStateException($documentId, $document->status, 'voided');
+        }
+
         $beforeJson = ['status' => $document->status];
 
         $this->documents->void($documentId, $organizationId, $actorUserId ?? 0, $voidReason, $voidNote);

--- a/tests/Audit/AuditBoundaryTest.php
+++ b/tests/Audit/AuditBoundaryTest.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Tests\Audit;
+
+use NeneVault\Tests\Support\ApiTestCase;
+
+/**
+ * Audit event listing boundary tests: filter combinations, pagination,
+ * ordering, append-only guarantee, tenant scoping.
+ */
+final class AuditBoundaryTest extends ApiTestCase
+{
+    private static string $adminToken = '';
+    private static string $superToken = '';
+    private static int    $orgId      = 0;
+    private static bool   $seeded     = false;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::bootContainer();
+        self::$orgId      = self::ensureOrg('test-org');
+        self::$adminToken = self::issueToken('admin', self::$orgId, userId: 180);
+        self::$superToken = self::issueSuperadminToken(userId: 181);
+    }
+
+    protected function setUp(): void
+    {
+        if (!self::$seeded) {
+            // Generate a known mix of audit events
+            $h  = $this->handler();
+            $id = $this->uploadDoc($h, self::$adminToken, 'AuditSeed', '2026-01-01', '5000');
+            $h->handle($this->request('PATCH', "/admin/vault/documents/{$id}/metadata", self::$adminToken, [
+                'counterparty_name' => 'AuditSeed Updated',
+                'category'          => 'contract',
+            ]));
+            $h->handle($this->request('POST', "/admin/vault/documents/{$id}/void", self::$adminToken, ['void_reason' => 'audit seed void']));
+            self::$seeded = true;
+        }
+    }
+
+    // ── Filters ────────────────────────────────────────────────────────────────
+
+    public function test_filter_by_entity_type(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request('GET', '/admin/audit-events?entity_type=vault_document', self::$adminToken),
+        );
+        $this->assertSame(200, $resp->getStatusCode());
+        $body = json_decode((string) $resp->getBody(), true);
+        foreach ($body['items'] as $event) {
+            $this->assertSame('vault_document', $event['entity_type']);
+        }
+    }
+
+    public function test_filter_by_action_uploaded(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request('GET', '/admin/audit-events?action=document.uploaded', self::$adminToken),
+        );
+        $body = json_decode((string) $resp->getBody(), true);
+        $this->assertGreaterThanOrEqual(1, $body['total']);
+        foreach ($body['items'] as $event) {
+            $this->assertSame('document.uploaded', $event['action']);
+        }
+    }
+
+    public function test_filter_by_action_voided(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request('GET', '/admin/audit-events?action=document.voided', self::$adminToken),
+        );
+        $body = json_decode((string) $resp->getBody(), true);
+        foreach ($body['items'] as $event) {
+            $this->assertSame('document.voided', $event['action']);
+        }
+    }
+
+    public function test_filter_by_nonexistent_action_returns_empty(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request('GET', '/admin/audit-events?action=document.nonexistent_action', self::$adminToken),
+        );
+        $body = json_decode((string) $resp->getBody(), true);
+        $this->assertSame(0, $body['total']);
+    }
+
+    public function test_combined_entity_type_and_action_filter(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request('GET', '/admin/audit-events?entity_type=vault_document&action=document.metadata_changed', self::$adminToken),
+        );
+        $body = json_decode((string) $resp->getBody(), true);
+        foreach ($body['items'] as $event) {
+            $this->assertSame('vault_document', $event['entity_type']);
+            $this->assertSame('document.metadata_changed', $event['action']);
+        }
+    }
+
+    // ── Pagination ─────────────────────────────────────────────────────────────
+
+    public function test_pagination_limit_1(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request('GET', '/admin/audit-events?limit=1', self::$adminToken),
+        );
+        $body = json_decode((string) $resp->getBody(), true);
+        $this->assertCount(1, $body['items']);
+        $this->assertSame(1, $body['limit']);
+    }
+
+    public function test_pagination_offset_returns_different_event(): void
+    {
+        $page1 = json_decode((string) $this->handler()->handle(
+            $this->request('GET', '/admin/audit-events?limit=1&offset=0', self::$adminToken),
+        )->getBody(), true);
+        $page2 = json_decode((string) $this->handler()->handle(
+            $this->request('GET', '/admin/audit-events?limit=1&offset=1', self::$adminToken),
+        )->getBody(), true);
+
+        if ($page1['total'] >= 2) {
+            $this->assertNotSame($page1['items'][0]['id'], $page2['items'][0]['id']);
+        } else {
+            $this->markTestSkipped('Not enough audit events for offset comparison');
+        }
+    }
+
+    // ── Ordering (most recent first) ───────────────────────────────────────────
+
+    public function test_events_ordered_most_recent_first(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request('GET', '/admin/audit-events?limit=10', self::$adminToken),
+        );
+        $body = json_decode((string) $resp->getBody(), true);
+        $createdAts = array_column($body['items'], 'created_at');
+        $sorted = $createdAts;
+        rsort($sorted);
+        $this->assertSame($sorted, $createdAts, 'Audit events must be ordered most-recent-first');
+    }
+
+    // ── Response shape ───────────────────────────────────────────────────────
+
+    public function test_event_contains_required_fields(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request('GET', '/admin/audit-events?action=document.metadata_changed&limit=1', self::$adminToken),
+        );
+        $body = json_decode((string) $resp->getBody(), true);
+        if ($body['total'] === 0) {
+            $this->markTestSkipped('No metadata_changed events to inspect');
+        }
+        $event = $body['items'][0];
+        foreach (['id', 'action', 'entity_type', 'entity_id', 'created_at', 'before_json', 'after_json'] as $field) {
+            $this->assertArrayHasKey($field, $event);
+        }
+    }
+
+    // ── Auth ──────────────────────────────────────────────────────────────────
+
+    public function test_unauthenticated_returns_401(): void
+    {
+        $resp = $this->handler()->handle($this->request('GET', '/admin/audit-events'));
+        $this->assertSame(401, $resp->getStatusCode());
+    }
+
+    public function test_superadmin_can_list_all_events(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request('GET', '/admin/audit-events', self::$superToken),
+        );
+        $this->assertSame(200, $resp->getStatusCode());
+    }
+}

--- a/tests/Auth/LoginBoundaryTest.php
+++ b/tests/Auth/LoginBoundaryTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Tests\Auth;
+
+use NeneVault\Tests\Support\ApiTestCase;
+
+/**
+ * HTTP-level login boundary tests: missing fields, wrong password,
+ * unknown email, successful token issuance.
+ */
+final class LoginBoundaryTest extends ApiTestCase
+{
+    private static int    $orgId = 0;
+    private static string $email = '';
+    private const PASSWORD = 'correct-horse-battery';
+
+    public static function setUpBeforeClass(): void
+    {
+        self::bootContainer();
+        self::$orgId = self::ensureOrg('test-org');
+        self::$email = 'login-bnd-' . uniqid() . '@example.com';
+
+        // Insert a user with a known bcrypt hash.
+        $hash = password_hash(self::PASSWORD, PASSWORD_BCRYPT);
+        $pdo  = self::pdo();
+        $stmt = $pdo->prepare(
+            "INSERT INTO users (email, password_hash, role, organization_id, status, created_at, updated_at)
+             VALUES (?, ?, 'admin', ?, 'active', datetime('now'), datetime('now'))",
+        );
+        $stmt->execute([self::$email, $hash, self::$orgId]);
+    }
+
+    // ── Validation ─────────────────────────────────────────────────────────────
+
+    public function test_login_missing_email_returns_422(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request('POST', '/admin/auth/login', null, ['password' => self::PASSWORD]),
+        );
+        $this->assertSame(422, $resp->getStatusCode());
+    }
+
+    public function test_login_missing_password_returns_422(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request('POST', '/admin/auth/login', null, ['email' => self::$email]),
+        );
+        $this->assertSame(422, $resp->getStatusCode());
+    }
+
+    public function test_login_empty_body_returns_400(): void
+    {
+        // An empty JSON array is a malformed body (not an object) → 400 at parse time.
+        $resp = $this->handler()->handle(
+            $this->request('POST', '/admin/auth/login', null, []),
+        );
+        $this->assertSame(400, $resp->getStatusCode());
+    }
+
+    // ── Credentials ────────────────────────────────────────────────────────────
+
+    public function test_login_wrong_password_returns_401(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request('POST', '/admin/auth/login', null, ['email' => self::$email, 'password' => 'wrong-password']),
+        );
+        $this->assertSame(401, $resp->getStatusCode());
+    }
+
+    public function test_login_unknown_email_returns_401(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request('POST', '/admin/auth/login', null, ['email' => 'nobody-' . uniqid() . '@example.com', 'password' => self::PASSWORD]),
+        );
+        $this->assertSame(401, $resp->getStatusCode());
+    }
+
+    // ── Success ────────────────────────────────────────────────────────────────
+
+    public function test_login_success_returns_token(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request('POST', '/admin/auth/login', null, ['email' => self::$email, 'password' => self::PASSWORD]),
+        );
+        $this->assertSame(200, $resp->getStatusCode(), (string) $resp->getBody());
+        $body = json_decode((string) $resp->getBody(), true);
+        $this->assertArrayHasKey('token', $body);
+        $this->assertNotEmpty($body['token']);
+        $this->assertSame(self::$email, $body['email']);
+        $this->assertSame('admin', $body['role']);
+        $this->assertSame(self::$orgId, $body['org_id']);
+        $this->assertArrayHasKey('expires_at', $body);
+    }
+
+    public function test_login_response_excludes_password_hash(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request('POST', '/admin/auth/login', null, ['email' => self::$email, 'password' => self::PASSWORD]),
+        );
+        $body = json_decode((string) $resp->getBody(), true);
+        $this->assertArrayNotHasKey('password_hash', $body);
+        $this->assertArrayNotHasKey('password', $body);
+    }
+
+    public function test_issued_token_is_accepted_by_protected_route(): void
+    {
+        $login = $this->handler()->handle(
+            $this->request('POST', '/admin/auth/login', null, ['email' => self::$email, 'password' => self::PASSWORD]),
+        );
+        $token = json_decode((string) $login->getBody(), true)['token'];
+
+        $resp = $this->handler()->handle(
+            $this->request('GET', '/admin/vault/documents', $token),
+        );
+        $this->assertSame(200, $resp->getStatusCode(), 'Token from login must authenticate against a protected route');
+    }
+}

--- a/tests/Document/DocumentLifecycleBoundaryTest.php
+++ b/tests/Document/DocumentLifecycleBoundaryTest.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Tests\Document;
+
+use NeneVault\Tests\Support\ApiTestCase;
+
+/**
+ * Void/Restore state-machine boundary tests.
+ *
+ * State transitions:
+ *   active --void--> voided --restore--> active
+ *
+ * Invalid transitions tested:
+ *   active  --restore--> error (can't restore active)
+ *   voided  --void-->    error (can't re-void)
+ */
+final class DocumentLifecycleBoundaryTest extends ApiTestCase
+{
+    private static string $adminToken  = '';
+    private static string $memberToken = '';
+    private static string $viewerToken = '';
+    private static int    $orgId       = 0;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::bootContainer();
+        self::$orgId        = self::ensureOrg('test-org');
+        self::$adminToken   = self::issueToken('admin', self::$orgId, userId: 130);
+        self::$memberToken  = self::issueToken('member', self::$orgId, userId: 131);
+        self::$viewerToken  = self::issueToken('viewer', self::$orgId, userId: 132);
+    }
+
+    // ── Void ─────────────────────────────────────────────────────────────────
+
+    public function test_void_active_document_succeeds(): void
+    {
+        $id      = $this->uploadDoc($this->handler(), self::$adminToken, 'VoidMe');
+        $handler = $this->handler();
+
+        $resp = $handler->handle(
+            $this->request('POST', "/admin/vault/documents/{$id}/void", self::$adminToken, [
+                'void_reason' => 'Registered by mistake',
+            ]),
+        );
+
+        $this->assertSame(200, $resp->getStatusCode());
+        $body = json_decode((string) $resp->getBody(), true);
+        $this->assertSame('voided', $body['status']);
+        $this->assertSame('Registered by mistake', $body['void_reason']);
+        $this->assertNotNull($body['voided_at']);
+    }
+
+    public function test_void_requires_reason(): void
+    {
+        $id   = $this->uploadDoc($this->handler(), self::$adminToken, 'VoidNoReason');
+        $resp = $this->handler()->handle(
+            $this->request('POST', "/admin/vault/documents/{$id}/void", self::$adminToken, [
+                'void_note' => 'only a note, no reason',
+            ]),
+        );
+        $this->assertSame(422, $resp->getStatusCode());
+    }
+
+    public function test_void_accepts_optional_void_note(): void
+    {
+        $id   = $this->uploadDoc($this->handler(), self::$adminToken, 'VoidNote');
+        $resp = $this->handler()->handle(
+            $this->request('POST', "/admin/vault/documents/{$id}/void", self::$adminToken, [
+                'void_reason' => 'Incorrect amount',
+                'void_note'   => 'Will re-upload with correct amount after confirmation from vendor.',
+            ]),
+        );
+        $this->assertSame(200, $resp->getStatusCode());
+    }
+
+    public function test_cannot_re_void_already_voided_document(): void
+    {
+        $id      = $this->uploadDoc($this->handler(), self::$adminToken, 'ReVoid');
+        $handler = $this->handler();
+
+        $handler->handle($this->request('POST', "/admin/vault/documents/{$id}/void", self::$adminToken, ['void_reason' => 'First void']));
+
+        $resp = $handler->handle(
+            $this->request('POST', "/admin/vault/documents/{$id}/void", self::$adminToken, ['void_reason' => 'Second void attempt']),
+        );
+
+        $this->assertSame(409, $resp->getStatusCode(), 'Re-voiding a voided document must return 409');
+    }
+
+    public function test_re_void_leaves_single_void_audit_event(): void
+    {
+        $id      = $this->uploadDoc($this->handler(), self::$adminToken, 'PreserveReason');
+        $handler = $this->handler();
+
+        $handler->handle($this->request('POST', "/admin/vault/documents/{$id}/void", self::$adminToken, ['void_reason' => 'Original reason']));
+        $handler->handle($this->request('POST', "/admin/vault/documents/{$id}/void", self::$adminToken, ['void_reason' => 'Overwrite attempt']));
+
+        $history = $handler->handle($this->request('GET', "/admin/vault/documents/{$id}/history", self::$adminToken));
+        $events  = array_filter(
+            json_decode((string) $history->getBody(), true)['audit_events'],
+            static fn ($e) => $e['action'] === 'document.voided',
+        );
+        $this->assertCount(1, $events, 'Re-void is rejected, so exactly one void event must exist');
+    }
+
+    public function test_void_nonexistent_document_returns_404(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request('POST', '/admin/vault/documents/00000000000000000000000000/void', self::$adminToken, [
+                'void_reason' => 'Test',
+            ]),
+        );
+        $this->assertSame(404, $resp->getStatusCode());
+    }
+
+    // ── Restore ───────────────────────────────────────────────────────────────
+
+    public function test_restore_voided_document_succeeds(): void
+    {
+        $id      = $this->uploadDoc($this->handler(), self::$adminToken, 'RestoreMe');
+        $handler = $this->handler();
+
+        $handler->handle($this->request('POST', "/admin/vault/documents/{$id}/void", self::$adminToken, ['void_reason' => 'Will restore']));
+
+        $resp = $handler->handle(
+            $this->request('POST', "/admin/vault/documents/{$id}/restore", self::$adminToken),
+        );
+        $this->assertSame(200, $resp->getStatusCode());
+        $body = json_decode((string) $resp->getBody(), true);
+        $this->assertSame('active', $body['status']);
+        $this->assertNull($body['voided_at']);
+    }
+
+    public function test_cannot_restore_active_document(): void
+    {
+        $id   = $this->uploadDoc($this->handler(), self::$adminToken, 'RestoreActive');
+        $resp = $this->handler()->handle(
+            $this->request('POST', "/admin/vault/documents/{$id}/restore", self::$adminToken),
+        );
+        $this->assertSame(409, $resp->getStatusCode(), 'Restoring an active document must return 409');
+    }
+
+    public function test_restore_then_void_cycle(): void
+    {
+        $id      = $this->uploadDoc($this->handler(), self::$adminToken, 'VoidRestoreCycle');
+        $handler = $this->handler();
+
+        $handler->handle($this->request('POST', "/admin/vault/documents/{$id}/void", self::$adminToken, ['void_reason' => 'Cycle test 1']));
+        $handler->handle($this->request('POST', "/admin/vault/documents/{$id}/restore", self::$adminToken));
+        $resp = $handler->handle($this->request('POST', "/admin/vault/documents/{$id}/void", self::$adminToken, ['void_reason' => 'Cycle test 2']));
+
+        $this->assertSame(200, $resp->getStatusCode());
+        $this->assertSame('voided', json_decode((string) $resp->getBody(), true)['status']);
+    }
+
+    // ── RBAC ─────────────────────────────────────────────────────────────────
+
+    public function test_member_cannot_void(): void
+    {
+        $id   = $this->uploadDoc($this->handler(), self::$adminToken, 'MemberVoid');
+        $resp = $this->handler()->handle(
+            $this->request('POST', "/admin/vault/documents/{$id}/void", self::$memberToken, ['void_reason' => 'Test']),
+        );
+        $this->assertSame(403, $resp->getStatusCode());
+    }
+
+    public function test_member_cannot_restore(): void
+    {
+        $id      = $this->uploadDoc($this->handler(), self::$adminToken, 'MemberRestore');
+        $handler = $this->handler();
+
+        $handler->handle($this->request('POST', "/admin/vault/documents/{$id}/void", self::$adminToken, ['void_reason' => 'Setup']));
+
+        $resp = $handler->handle(
+            $this->request('POST', "/admin/vault/documents/{$id}/restore", self::$memberToken),
+        );
+        $this->assertSame(403, $resp->getStatusCode());
+    }
+
+    public function test_viewer_cannot_void(): void
+    {
+        $id   = $this->uploadDoc($this->handler(), self::$adminToken, 'ViewerVoid');
+        $resp = $this->handler()->handle(
+            $this->request('POST', "/admin/vault/documents/{$id}/void", self::$viewerToken, ['void_reason' => 'Test']),
+        );
+        $this->assertSame(403, $resp->getStatusCode());
+    }
+
+    // ── Audit trail ───────────────────────────────────────────────────────────
+
+    public function test_void_restore_both_appear_in_history(): void
+    {
+        $id      = $this->uploadDoc($this->handler(), self::$adminToken, 'LifecycleAudit');
+        $handler = $this->handler();
+
+        $handler->handle($this->request('POST', "/admin/vault/documents/{$id}/void", self::$adminToken, ['void_reason' => 'Audit test']));
+        $handler->handle($this->request('POST', "/admin/vault/documents/{$id}/restore", self::$adminToken));
+
+        $history = $handler->handle($this->request('GET', "/admin/vault/documents/{$id}/history", self::$adminToken));
+        $events  = array_column(json_decode((string) $history->getBody(), true)['audit_events'], 'action');
+
+        $this->assertContains('document.uploaded', $events);
+        $this->assertContains('document.voided', $events);
+        $this->assertContains('document.restored', $events);
+    }
+}

--- a/tests/Document/DocumentMetadataBoundaryTest.php
+++ b/tests/Document/DocumentMetadataBoundaryTest.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Tests\Document;
+
+use NeneVault\Tests\Support\ApiTestCase;
+
+/**
+ * Metadata edit boundary tests: field clearing, required fields,
+ * category enum, retention recalculation, and is_metadata_confirmed flag.
+ */
+final class DocumentMetadataBoundaryTest extends ApiTestCase
+{
+    private static string $adminToken  = '';
+    private static string $memberToken = '';
+    private static string $viewerToken = '';
+    private static int    $orgId       = 0;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::bootContainer();
+        self::$orgId        = self::ensureOrg('test-org');
+        self::$adminToken   = self::issueToken('admin', self::$orgId, userId: 120);
+        self::$memberToken  = self::issueToken('member', self::$orgId, userId: 121);
+        self::$viewerToken  = self::issueToken('viewer', self::$orgId, userId: 122);
+    }
+
+    // ── Happy path ────────────────────────────────────────────────────────────
+
+    public function test_metadata_edit_sets_confirmed_flag(): void
+    {
+        $id   = $this->uploadDoc($this->handler(), self::$adminToken, 'MetaBnd', '2026-01-01', '1000');
+        $resp = $this->handler()->handle(
+            $this->request('PATCH', "/admin/vault/documents/{$id}/metadata", self::$adminToken, [
+                'counterparty_name' => 'MetaBnd Updated',
+                'category'          => 'contract',
+                'transaction_date'  => '2026-01-15',
+                'amount_cents'      => 2000,
+            ]),
+        );
+        $this->assertSame(200, $resp->getStatusCode());
+        $body = json_decode((string) $resp->getBody(), true);
+        $this->assertTrue($body['is_metadata_confirmed']);
+        $this->assertSame('MetaBnd Updated', $body['counterparty_name']);
+        $this->assertSame(2000, $body['amount_cents']);
+    }
+
+    public function test_metadata_edit_clears_transaction_date_with_null(): void
+    {
+        $id   = $this->uploadDoc($this->handler(), self::$adminToken, 'ClearDate', '2026-03-01', '500');
+        $resp = $this->handler()->handle(
+            $this->request('PATCH', "/admin/vault/documents/{$id}/metadata", self::$adminToken, [
+                'counterparty_name' => 'ClearDate',
+                'category'          => 'receipt',
+                'transaction_date'  => null,
+            ]),
+        );
+        $this->assertSame(200, $resp->getStatusCode());
+        $body = json_decode((string) $resp->getBody(), true);
+        $this->assertNull($body['transaction_date']);
+    }
+
+    public function test_metadata_edit_clears_amount_with_null(): void
+    {
+        $id   = $this->uploadDoc($this->handler(), self::$adminToken, 'ClearAmt', '2026-04-01', '9999');
+        $resp = $this->handler()->handle(
+            $this->request('PATCH', "/admin/vault/documents/{$id}/metadata", self::$adminToken, [
+                'counterparty_name' => 'ClearAmt',
+                'category'          => 'receipt',
+                'transaction_date'  => '2026-04-01',
+                'amount_cents'      => null,
+            ]),
+        );
+        $this->assertSame(200, $resp->getStatusCode());
+        $body = json_decode((string) $resp->getBody(), true);
+        $this->assertNull($body['amount_cents']);
+    }
+
+    public function test_metadata_edit_replaces_tags(): void
+    {
+        $id   = $this->uploadDoc($this->handler(), self::$adminToken, 'TagReplace', '2026-05-01', '100');
+        $this->handler()->handle(
+            $this->request('PATCH', "/admin/vault/documents/{$id}/metadata", self::$adminToken, [
+                'counterparty_name' => 'TagReplace',
+                'category'          => 'receipt',
+                'tags'              => ['old-tag'],
+            ]),
+        );
+        $resp = $this->handler()->handle(
+            $this->request('PATCH', "/admin/vault/documents/{$id}/metadata", self::$adminToken, [
+                'counterparty_name' => 'TagReplace',
+                'category'          => 'receipt',
+                'tags'              => ['new-tag', 'another'],
+            ]),
+        );
+        $body = json_decode((string) $resp->getBody(), true);
+        $this->assertContains('new-tag', $body['tags']);
+        $this->assertNotContains('old-tag', $body['tags']);
+    }
+
+    public function test_metadata_edit_all_categories_accepted(): void
+    {
+        foreach (['invoice_received', 'contract', 'receipt', 'delivery_note', 'other'] as $cat) {
+            $id   = $this->uploadDoc($this->handler(), self::$adminToken, "Cat-{$cat}", '2026-01-01', '1');
+            $resp = $this->handler()->handle(
+                $this->request('PATCH', "/admin/vault/documents/{$id}/metadata", self::$adminToken, [
+                    'counterparty_name' => "Cat-{$cat}",
+                    'category'          => $cat,
+                ]),
+            );
+            $this->assertSame(200, $resp->getStatusCode(), "Category '{$cat}' must be accepted");
+        }
+    }
+
+    // ── Validation failures ───────────────────────────────────────────────────
+
+    public function test_metadata_edit_missing_counterparty_returns_422(): void
+    {
+        $id   = $this->uploadDoc($this->handler(), self::$adminToken, 'RequiredCP', '2026-01-01', '1');
+        $resp = $this->handler()->handle(
+            $this->request('PATCH', "/admin/vault/documents/{$id}/metadata", self::$adminToken, [
+                'category' => 'receipt',
+            ]),
+        );
+        $this->assertSame(422, $resp->getStatusCode());
+    }
+
+    public function test_metadata_edit_missing_category_returns_422(): void
+    {
+        $id   = $this->uploadDoc($this->handler(), self::$adminToken, 'RequiredCat', '2026-01-01', '1');
+        $resp = $this->handler()->handle(
+            $this->request('PATCH', "/admin/vault/documents/{$id}/metadata", self::$adminToken, [
+                'counterparty_name' => 'RequiredCat',
+            ]),
+        );
+        $this->assertSame(422, $resp->getStatusCode());
+    }
+
+    public function test_metadata_edit_invalid_category_returns_422(): void
+    {
+        $id   = $this->uploadDoc($this->handler(), self::$adminToken, 'BadCat', '2026-01-01', '1');
+        $resp = $this->handler()->handle(
+            $this->request('PATCH', "/admin/vault/documents/{$id}/metadata", self::$adminToken, [
+                'counterparty_name' => 'BadCat',
+                'category'          => 'INVALID_CATEGORY',
+            ]),
+        );
+        $this->assertSame(422, $resp->getStatusCode());
+    }
+
+    public function test_metadata_edit_nonexistent_document_returns_404(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request('PATCH', '/admin/vault/documents/00000000000000000000000000/metadata', self::$adminToken, [
+                'counterparty_name' => 'X',
+                'category'          => 'receipt',
+            ]),
+        );
+        $this->assertSame(404, $resp->getStatusCode());
+    }
+
+    // ── RBAC ─────────────────────────────────────────────────────────────────
+
+    public function test_viewer_cannot_edit_metadata(): void
+    {
+        $id   = $this->uploadDoc($this->handler(), self::$adminToken, 'ViewerEdit', '2026-01-01', '1');
+        $resp = $this->handler()->handle(
+            $this->request('PATCH', "/admin/vault/documents/{$id}/metadata", self::$viewerToken, [
+                'counterparty_name' => 'ViewerEdit',
+                'category'          => 'receipt',
+            ]),
+        );
+        $this->assertSame(403, $resp->getStatusCode());
+    }
+
+    public function test_member_can_edit_metadata(): void
+    {
+        $id   = $this->uploadDoc($this->handler(), self::$adminToken, 'MemberEdit', '2026-01-01', '1');
+        $resp = $this->handler()->handle(
+            $this->request('PATCH', "/admin/vault/documents/{$id}/metadata", self::$memberToken, [
+                'counterparty_name' => 'MemberEdit Updated',
+                'category'          => 'receipt',
+            ]),
+        );
+        $this->assertSame(200, $resp->getStatusCode());
+    }
+
+    // ── Audit trail ───────────────────────────────────────────────────────────
+
+    public function test_metadata_edit_generates_audit_event_with_before_after(): void
+    {
+        $id      = $this->uploadDoc($this->handler(), self::$adminToken, 'AuditCheck', '2026-06-01', '5000');
+        $handler = $this->handler();
+
+        $handler->handle(
+            $this->request('PATCH', "/admin/vault/documents/{$id}/metadata", self::$adminToken, [
+                'counterparty_name' => 'AuditCheck Updated',
+                'category'          => 'contract',
+                'amount_cents'      => 9999,
+            ]),
+        );
+
+        $history = $handler->handle(
+            $this->request('GET', "/admin/vault/documents/{$id}/history", self::$adminToken),
+        );
+        $hBody  = json_decode((string) $history->getBody(), true);
+        $events = array_filter($hBody['audit_events'], static fn ($e) => $e['action'] === 'document.metadata_changed');
+        $this->assertNotEmpty($events, 'document.metadata_changed audit event must exist');
+        $event = array_values($events)[0];
+        $this->assertSame('AuditCheck', $event['before_json']['counterparty_name']);
+        $this->assertSame('AuditCheck Updated', $event['after_json']['counterparty_name']);
+    }
+}

--- a/tests/Document/DocumentSearchBoundaryTest.php
+++ b/tests/Document/DocumentSearchBoundaryTest.php
@@ -1,0 +1,343 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Tests\Document;
+
+use NeneVault\Tests\Support\ApiTestCase;
+
+/**
+ * Search boundary tests: each filter individually, combinations, pagination,
+ * include_voided, empty results, default limit.
+ */
+final class DocumentSearchBoundaryTest extends ApiTestCase
+{
+    private static string $token   = '';
+    private static int    $orgId   = 0;
+    private static string $_marker = '';
+    private static bool   $seeded  = false;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::bootContainer();
+        self::$orgId   = self::ensureOrg('test-org');
+        self::$token   = self::issueToken('admin', self::$orgId, userId: 110);
+        self::$_marker = 'SrchBnd-' . uniqid();
+    }
+
+    protected function setUp(): void
+    {
+        // Seed a deterministic set once, using instance upload helpers.
+        if (!self::$seeded) {
+            $h = $this->handler();
+            $this->uploadDoc($h, self::$token, self::$_marker . '-Alpha', '2026-02-10', '50000', 'invoice_received');
+            $this->uploadDoc($h, self::$token, self::$_marker . '-Beta', '2026-08-20', '75000', 'contract');
+            $this->uploadDoc($h, self::$token, self::$_marker . '-Gamma', '2026-11-01', '999', 'receipt');
+            self::$seeded = true;
+        }
+    }
+
+    // ── Counterparty filter ───────────────────────────────────────────────────
+
+    public function test_counterparty_partial_match(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request('GET', '/admin/vault/documents?counterparty_name=' . urlencode(self::$_marker . '-Alpha'), self::$token),
+        );
+        $this->assertSame(200, $resp->getStatusCode());
+        $body = json_decode((string) $resp->getBody(), true);
+        $this->assertGreaterThanOrEqual(1, $body['total']);
+        foreach ($body['items'] as $item) {
+            $this->assertStringContainsString(self::$_marker . '-Alpha', $item['counterparty_name']);
+        }
+    }
+
+    public function test_counterparty_no_match_returns_empty(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request('GET', '/admin/vault/documents?counterparty_name=NORESULT_' . uniqid(), self::$token),
+        );
+        $this->assertSame(200, $resp->getStatusCode());
+        $body = json_decode((string) $resp->getBody(), true);
+        $this->assertSame(0, $body['total']);
+        $this->assertCount(0, $body['items']);
+    }
+
+    // ── Date range filter ─────────────────────────────────────────────────────
+
+    public function test_date_from_filter(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request(
+                'GET',
+                '/admin/vault/documents?transaction_date_from=2026-08-01&counterparty_name=' . urlencode(self::$_marker),
+                self::$token,
+            ),
+        );
+        $body = json_decode((string) $resp->getBody(), true);
+        foreach ($body['items'] as $item) {
+            $this->assertGreaterThanOrEqual('2026-08-01', $item['transaction_date']);
+        }
+    }
+
+    public function test_date_to_filter(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request(
+                'GET',
+                '/admin/vault/documents?transaction_date_to=2026-06-30&counterparty_name=' . urlencode(self::$_marker),
+                self::$token,
+            ),
+        );
+        $body = json_decode((string) $resp->getBody(), true);
+        foreach ($body['items'] as $item) {
+            $this->assertLessThanOrEqual('2026-06-30', $item['transaction_date']);
+        }
+    }
+
+    public function test_date_range_no_overlap_returns_empty(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request(
+                'GET',
+                '/admin/vault/documents?transaction_date_from=2000-01-01&transaction_date_to=2000-12-31&counterparty_name=' . urlencode(self::$_marker),
+                self::$token,
+            ),
+        );
+        $body = json_decode((string) $resp->getBody(), true);
+        $this->assertSame(0, $body['total']);
+    }
+
+    // ── Amount range filter ───────────────────────────────────────────────────
+
+    public function test_amount_min_filter(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request(
+                'GET',
+                '/admin/vault/documents?amount_min_cents=50000&counterparty_name=' . urlencode(self::$_marker),
+                self::$token,
+            ),
+        );
+        $body = json_decode((string) $resp->getBody(), true);
+        foreach ($body['items'] as $item) {
+            $this->assertGreaterThanOrEqual(50000, $item['amount_cents']);
+        }
+    }
+
+    public function test_amount_max_filter(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request(
+                'GET',
+                '/admin/vault/documents?amount_max_cents=1000&counterparty_name=' . urlencode(self::$_marker),
+                self::$token,
+            ),
+        );
+        $body = json_decode((string) $resp->getBody(), true);
+        foreach ($body['items'] as $item) {
+            $this->assertLessThanOrEqual(1000, $item['amount_cents']);
+        }
+    }
+
+    public function test_amount_exact_match(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request(
+                'GET',
+                '/admin/vault/documents?amount_min_cents=75000&amount_max_cents=75000&counterparty_name=' . urlencode(self::$_marker),
+                self::$token,
+            ),
+        );
+        $body = json_decode((string) $resp->getBody(), true);
+        $this->assertGreaterThanOrEqual(1, $body['total']);
+        foreach ($body['items'] as $item) {
+            $this->assertSame(75000, $item['amount_cents']);
+        }
+    }
+
+    // ── Category filter ───────────────────────────────────────────────────────
+
+    public function test_category_filter_contract(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request(
+                'GET',
+                '/admin/vault/documents?category=contract&counterparty_name=' . urlencode(self::$_marker),
+                self::$token,
+            ),
+        );
+        $body = json_decode((string) $resp->getBody(), true);
+        $this->assertGreaterThanOrEqual(1, $body['total']);
+        foreach ($body['items'] as $item) {
+            $this->assertSame('contract', $item['category']);
+        }
+    }
+
+    public function test_category_filter_receipt(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request(
+                'GET',
+                '/admin/vault/documents?category=receipt&counterparty_name=' . urlencode(self::$_marker),
+                self::$token,
+            ),
+        );
+        $body = json_decode((string) $resp->getBody(), true);
+        foreach ($body['items'] as $item) {
+            $this->assertSame('receipt', $item['category']);
+        }
+    }
+
+    // ── Combined filters ──────────────────────────────────────────────────────
+
+    public function test_counterparty_and_date_combination(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request(
+                'GET',
+                '/admin/vault/documents?counterparty_name=' . urlencode(self::$_marker . '-Beta') . '&transaction_date_from=2026-07-01',
+                self::$token,
+            ),
+        );
+        $body = json_decode((string) $resp->getBody(), true);
+        $this->assertGreaterThanOrEqual(1, $body['total']);
+        foreach ($body['items'] as $item) {
+            $this->assertStringContainsString(self::$_marker . '-Beta', $item['counterparty_name']);
+        }
+    }
+
+    public function test_three_filter_combination(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request(
+                'GET',
+                '/admin/vault/documents?counterparty_name=' . urlencode(self::$_marker) . '&transaction_date_from=2026-01-01&amount_min_cents=1',
+                self::$token,
+            ),
+        );
+        $this->assertSame(200, $resp->getStatusCode());
+        $body = json_decode((string) $resp->getBody(), true);
+        $this->assertGreaterThanOrEqual(3, $body['total']);
+    }
+
+    // ── Voided documents ──────────────────────────────────────────────────────
+
+    public function test_voided_excluded_by_default(): void
+    {
+        $marker  = 'VoidSrch-' . uniqid();
+        $handler = $this->handler();
+        $id      = $this->uploadDoc($handler, self::$token, $marker, '2026-05-01', '1000');
+
+        $handler->handle($this->request('POST', "/admin/vault/documents/{$id}/void", self::$token, ['void_reason' => 'test']));
+
+        $resp = $handler->handle(
+            $this->request('GET', '/admin/vault/documents?counterparty_name=' . urlencode($marker), self::$token),
+        );
+        $body = json_decode((string) $resp->getBody(), true);
+        $ids  = array_column($body['items'], 'id');
+        $this->assertNotContains($id, $ids, 'Voided document must not appear without include_voided=true');
+    }
+
+    public function test_include_voided_true_shows_voided(): void
+    {
+        $marker  = 'VoidShow-' . uniqid();
+        $handler = $this->handler();
+        $id      = $this->uploadDoc($handler, self::$token, $marker, '2026-05-01', '1000');
+
+        $handler->handle($this->request('POST', "/admin/vault/documents/{$id}/void", self::$token, ['void_reason' => 'test']));
+
+        $resp = $handler->handle(
+            $this->request('GET', '/admin/vault/documents?counterparty_name=' . urlencode($marker) . '&include_voided=true', self::$token),
+        );
+        $body = json_decode((string) $resp->getBody(), true);
+        $ids  = array_column($body['items'], 'id');
+        $this->assertContains($id, $ids);
+    }
+
+    // ── Pagination ────────────────────────────────────────────────────────────
+
+    public function test_pagination_limit_1(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request(
+                'GET',
+                '/admin/vault/documents?counterparty_name=' . urlencode(self::$_marker) . '&limit=1',
+                self::$token,
+            ),
+        );
+        $body = json_decode((string) $resp->getBody(), true);
+        $this->assertCount(1, $body['items']);
+        $this->assertGreaterThanOrEqual(3, $body['total']);
+        $this->assertSame(1, $body['limit']);
+        $this->assertSame(0, $body['offset']);
+    }
+
+    public function test_pagination_offset_beyond_total_returns_empty_items(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request(
+                'GET',
+                '/admin/vault/documents?counterparty_name=' . urlencode(self::$_marker) . '&limit=10&offset=99999',
+                self::$token,
+            ),
+        );
+        $body = json_decode((string) $resp->getBody(), true);
+        $this->assertCount(0, $body['items']);
+        $this->assertGreaterThanOrEqual(3, $body['total'], 'Total must still reflect full count even when offset exceeds it');
+    }
+
+    public function test_pagination_offset_page_2(): void
+    {
+        $resp1 = $this->handler()->handle(
+            $this->request(
+                'GET',
+                '/admin/vault/documents?counterparty_name=' . urlencode(self::$_marker) . '&limit=1&offset=0',
+                self::$token,
+            ),
+        );
+        $resp2 = $this->handler()->handle(
+            $this->request(
+                'GET',
+                '/admin/vault/documents?counterparty_name=' . urlencode(self::$_marker) . '&limit=1&offset=1',
+                self::$token,
+            ),
+        );
+
+        $id1 = json_decode((string) $resp1->getBody(), true)['items'][0]['id'];
+        $id2 = json_decode((string) $resp2->getBody(), true)['items'][0]['id'];
+
+        $this->assertNotSame($id1, $id2, 'Offset=1 must return a different document than offset=0');
+    }
+
+    // ── Response shape ────────────────────────────────────────────────────────
+
+    public function test_response_contains_required_fields(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request(
+                'GET',
+                '/admin/vault/documents?counterparty_name=' . urlencode(self::$_marker) . '&limit=1',
+                self::$token,
+            ),
+        );
+        $body = json_decode((string) $resp->getBody(), true);
+        $item = $body['items'][0];
+
+        foreach (['id', 'status', 'counterparty_name', 'category', 'transaction_date', 'amount_cents', 'retention_expires_at', 'version_number', 'file_sha256'] as $field) {
+            $this->assertArrayHasKey($field, $item, "Response must contain field: {$field}");
+        }
+
+        $this->assertArrayNotHasKey('file_path', $item, 'file_path must never appear in API responses');
+    }
+
+    // ── Auth ──────────────────────────────────────────────────────────────────
+
+    public function test_unauthenticated_returns_401(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request('GET', '/admin/vault/documents'),
+        );
+        $this->assertSame(401, $resp->getStatusCode());
+    }
+}

--- a/tests/Document/DocumentUploadBoundaryTest.php
+++ b/tests/Document/DocumentUploadBoundaryTest.php
@@ -1,0 +1,291 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Tests\Document;
+
+use NeneVault\Tests\Support\ApiTestCase;
+use Nyholm\Psr7Server\ServerRequestCreator;
+
+/**
+ * Upload boundary tests: MIME validation, file size, duplicate detection,
+ * date_uncertain flag, and multipart edge cases.
+ */
+final class DocumentUploadBoundaryTest extends ApiTestCase
+{
+    private static string $adminToken  = '';
+    private static string $memberToken = '';
+    private static int    $orgId       = 0;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::bootContainer();
+        self::$orgId       = self::ensureOrg('test-org');
+        self::$adminToken  = self::issueToken('admin', self::$orgId, userId: 100);
+        self::$memberToken = self::issueToken('member', self::$orgId, userId: 101);
+    }
+
+    // ── MIME type ────────────────────────────────────────────────────────────
+
+    public function test_pdf_accepted(): void
+    {
+        $id = $this->uploadDoc($this->handler(), self::$adminToken, 'PDF Co', '2026-01-01', '1000');
+        $this->assertNotEmpty($id);
+    }
+
+    public function test_jpeg_accepted(): void
+    {
+        $tmp = $this->makeTempPdf('jpeg-content');
+        $req = $this->buildUploadRequest(self::$adminToken, $tmp, 'receipt.jpg', 'image/jpeg', 'JPEG Vendor', '2026-01-01', '500');
+        $resp = $this->handler()->handle($req);
+        $this->assertSame(201, $resp->getStatusCode(), (string) $resp->getBody());
+        @unlink($tmp);
+    }
+
+    public function test_png_accepted(): void
+    {
+        $tmp = $this->makeTempPdf('png-content');
+        $req = $this->buildUploadRequest(self::$adminToken, $tmp, 'scan.png', 'image/png', 'PNG Vendor', '2026-01-01', '500');
+        $resp = $this->handler()->handle($req);
+        $this->assertSame(201, $resp->getStatusCode(), (string) $resp->getBody());
+        @unlink($tmp);
+    }
+
+    public function test_text_plain_rejected_415(): void
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'vault_t_');
+        assert($tmp !== false);
+        file_put_contents($tmp, 'not a pdf');
+
+        $req = $this->buildUploadRequest(self::$adminToken, $tmp, 'note.txt', 'text/plain', 'Vendor', '2026-01-01', '0');
+        $resp = $this->handler()->handle($req);
+        $this->assertSame(415, $resp->getStatusCode());
+        @unlink($tmp);
+    }
+
+    public function test_docx_rejected_415(): void
+    {
+        $tmp = $this->makeTempPdf('docx-mock');
+        $req = $this->buildUploadRequest(self::$adminToken, $tmp, 'contract.docx', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document', 'Vendor', '2026-01-01', '0');
+        $resp = $this->handler()->handle($req);
+        $this->assertSame(415, $resp->getStatusCode());
+        @unlink($tmp);
+    }
+
+    // ── Metadata fields ───────────────────────────────────────────────────────
+
+    public function test_upload_without_transaction_date_sets_date_uncertain(): void
+    {
+        $handler = $this->handler();
+        $psr17   = $this->psr17();
+        $tmp     = $this->makeTempPdf('no-date');
+
+        $creator = new ServerRequestCreator($psr17, $psr17, $psr17, $psr17);
+        $req = $creator->fromArrays(
+            server: ['REQUEST_METHOD' => 'POST', 'REQUEST_URI' => '/admin/vault/documents'],
+            headers: ['Host' => 'localhost', 'Authorization' => 'Bearer ' . self::$adminToken],
+        )
+            ->withUploadedFiles(['file' => $this->uploadedFile($tmp, 'doc.pdf', 'application/pdf')])
+            ->withParsedBody([
+                'counterparty_name' => 'NoDate Vendor',
+                'category'          => 'receipt',
+                // no transaction_date
+            ]);
+
+        $resp = $handler->handle($req);
+        $this->assertSame(201, $resp->getStatusCode(), (string) $resp->getBody());
+
+        $body = json_decode((string) $resp->getBody(), true);
+        $this->assertTrue($body['date_uncertain'], 'date_uncertain must be true when transaction_date is omitted');
+        $this->assertNotNull($body['retention_expires_at'], 'retention_expires_at must be set even when date is uncertain');
+        @unlink($tmp);
+    }
+
+    public function test_upload_null_amount_cents_accepted(): void
+    {
+        $psr17   = $this->psr17();
+        $tmp     = $this->makeTempPdf('null-amount');
+        $creator = new ServerRequestCreator($psr17, $psr17, $psr17, $psr17);
+
+        $req = $creator->fromArrays(
+            server: ['REQUEST_METHOD' => 'POST', 'REQUEST_URI' => '/admin/vault/documents'],
+            headers: ['Host' => 'localhost', 'Authorization' => 'Bearer ' . self::$adminToken],
+        )
+            ->withUploadedFiles(['file' => $this->uploadedFile($tmp)])
+            ->withParsedBody([
+                'counterparty_name' => 'Null Amount Vendor',
+                'category'          => 'contract',
+                'transaction_date'  => '2026-03-01',
+                // no amount_cents
+            ]);
+
+        $resp = $this->handler()->handle($req);
+        $this->assertSame(201, $resp->getStatusCode());
+        $body = json_decode((string) $resp->getBody(), true);
+        $this->assertNull($body['amount_cents']);
+        @unlink($tmp);
+    }
+
+    public function test_upload_stores_tags(): void
+    {
+        $psr17   = $this->psr17();
+        $tmp     = $this->makeTempPdf('tagged');
+        $creator = new ServerRequestCreator($psr17, $psr17, $psr17, $psr17);
+
+        $req = $creator->fromArrays(
+            server: ['REQUEST_METHOD' => 'POST', 'REQUEST_URI' => '/admin/vault/documents'],
+            headers: ['Host' => 'localhost', 'Authorization' => 'Bearer ' . self::$adminToken],
+        )
+            ->withUploadedFiles(['file' => $this->uploadedFile($tmp)])
+            ->withParsedBody([
+                'counterparty_name' => 'Tagged Vendor',
+                'category'          => 'invoice_received',
+                'transaction_date'  => '2026-04-01',
+                'tags'              => 'q2,important,audit',
+            ]);
+
+        $resp = $this->handler()->handle($req);
+        $this->assertSame(201, $resp->getStatusCode());
+        $tags = json_decode((string) $resp->getBody(), true)['tags'];
+        $this->assertContains('q2', $tags);
+        $this->assertContains('important', $tags);
+        $this->assertContains('audit', $tags);
+        @unlink($tmp);
+    }
+
+    public function test_upload_missing_counterparty_returns_422(): void
+    {
+        $psr17   = $this->psr17();
+        $tmp     = $this->makeTempPdf('no-cp');
+        $creator = new ServerRequestCreator($psr17, $psr17, $psr17, $psr17);
+
+        $req = $creator->fromArrays(
+            server: ['REQUEST_METHOD' => 'POST', 'REQUEST_URI' => '/admin/vault/documents'],
+            headers: ['Host' => 'localhost', 'Authorization' => 'Bearer ' . self::$adminToken],
+        )
+            ->withUploadedFiles(['file' => $this->uploadedFile($tmp)])
+            ->withParsedBody(['category' => 'invoice_received']);
+
+        $resp = $this->handler()->handle($req);
+        $this->assertSame(422, $resp->getStatusCode());
+        @unlink($tmp);
+    }
+
+    // ── Duplicate detection ───────────────────────────────────────────────────
+
+    public function test_duplicate_sha256_rejected_unless_confirmed(): void
+    {
+        $handler = $this->handler();
+        $tmp     = $this->makeTempPdf('dup-test-' . uniqid());
+        $content = (string) file_get_contents($tmp);
+
+        // First upload — succeeds
+        $req1 = $this->buildUploadRequest(self::$adminToken, $tmp, 'doc.pdf', 'application/pdf', 'Dup Vendor', '2026-01-01', '100');
+        $resp1 = $handler->handle($req1);
+        $this->assertSame(201, $resp1->getStatusCode());
+
+        // Rebuild tmp with same content for second upload
+        $tmp2 = tempnam(sys_get_temp_dir(), 'vault_dup_');
+        assert($tmp2 !== false);
+        file_put_contents($tmp2, $content);
+
+        $req2 = $this->buildUploadRequest(self::$adminToken, $tmp2, 'doc.pdf', 'application/pdf', 'Dup Vendor', '2026-01-01', '100');
+        $resp2 = $handler->handle($req2);
+        $this->assertSame(409, $resp2->getStatusCode(), 'Duplicate SHA-256 must return 409');
+
+        @unlink($tmp);
+        @unlink($tmp2);
+    }
+
+    public function test_duplicate_accepted_with_confirm_flag(): void
+    {
+        $handler = $this->handler();
+        $psr17   = $this->psr17();
+        $creator = new ServerRequestCreator($psr17, $psr17, $psr17, $psr17);
+        $content = "%PDF-1.4\nconfirm-dup-" . bin2hex(random_bytes(4)) . "\n";
+
+        foreach ([false, true] as $second) {
+            $tmp = tempnam(sys_get_temp_dir(), 'vault_cd_');
+            assert($tmp !== false);
+            file_put_contents($tmp, $content);
+
+            $body = [
+                'counterparty_name' => 'Confirm Dup',
+                'category'          => 'invoice_received',
+                'transaction_date'  => '2026-02-01',
+            ];
+
+            if ($second) {
+                $body['confirm_duplicate'] = '1';
+            }
+
+            $req = $creator->fromArrays(
+                server: ['REQUEST_METHOD' => 'POST', 'REQUEST_URI' => '/admin/vault/documents'],
+                headers: ['Host' => 'localhost', 'Authorization' => 'Bearer ' . self::$adminToken],
+            )
+                ->withUploadedFiles(['file' => $this->uploadedFile($tmp)])
+                ->withParsedBody($body);
+
+            $resp = $handler->handle($req);
+
+            if (!$second) {
+                $this->assertSame(201, $resp->getStatusCode(), 'First upload must succeed');
+            } else {
+                $this->assertSame(201, $resp->getStatusCode(), 'Duplicate with confirm_duplicate=1 must succeed');
+            }
+
+            @unlink($tmp);
+        }
+    }
+
+    // ── Auth ──────────────────────────────────────────────────────────────────
+
+    public function test_unauthenticated_upload_returns_401(): void
+    {
+        $tmp = $this->makeTempPdf('unauth');
+        $req = $this->buildUploadRequest(null, $tmp, 'doc.pdf', 'application/pdf', 'Vendor', '2026-01-01', '0');
+        $resp = $this->handler()->handle($req);
+        $this->assertSame(401, $resp->getStatusCode());
+        @unlink($tmp);
+    }
+
+    public function test_member_can_upload(): void
+    {
+        $id = $this->uploadDoc($this->handler(), self::$memberToken, 'Member Upload', '2026-01-01', '1000');
+        $this->assertNotEmpty($id);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /** @param array<string, string> $bodyFields */
+    private function buildUploadRequest(
+        ?string $token,
+        string $tmpPath,
+        string $filename,
+        string $mime,
+        string $counterparty,
+        string $date,
+        string $amount,
+        array $bodyFields = [],
+    ): \Psr\Http\Message\ServerRequestInterface {
+        $psr17   = $this->psr17();
+        $creator = new ServerRequestCreator($psr17, $psr17, $psr17, $psr17);
+
+        $headers = ['Host' => 'localhost'];
+        if ($token !== null) {
+            $headers['Authorization'] = "Bearer {$token}";
+        }
+
+        return $creator->fromArrays(
+            server: ['REQUEST_METHOD' => 'POST', 'REQUEST_URI' => '/admin/vault/documents'],
+            headers: $headers,
+        )
+            ->withUploadedFiles(['file' => $this->uploadedFile($tmpPath, $filename, $mime)])
+            ->withParsedBody(array_merge([
+                'counterparty_name' => $counterparty,
+                'category'          => 'invoice_received',
+                'transaction_date'  => $date,
+                'amount_cents'      => $amount,
+            ], $bodyFields));
+    }
+}

--- a/tests/Document/DocumentVersionBoundaryTest.php
+++ b/tests/Document/DocumentVersionBoundaryTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Tests\Document;
+
+use NeneVault\Tests\Support\ApiTestCase;
+
+/**
+ * Version download and history boundary tests: wrong IDs, tenant isolation,
+ * SHA-256 header, Content-Disposition.
+ */
+final class DocumentVersionBoundaryTest extends ApiTestCase
+{
+    private static string $adminToken   = '';
+    private static string $foreignToken = '';
+    private static int    $orgId        = 0;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::bootContainer();
+        self::$orgId        = self::ensureOrg('test-org');
+        self::$adminToken   = self::issueToken('admin', self::$orgId, userId: 140);
+        self::$foreignToken = self::issueToken('admin', 999998, userId: 141);
+    }
+
+    // ── Download ──────────────────────────────────────────────────────────────
+
+    public function test_download_returns_correct_content_type_for_pdf(): void
+    {
+        $handler = $this->handler();
+        $id      = $this->uploadDoc($handler, self::$adminToken, 'DlPdf', '2026-01-01', '1000');
+
+        [$docId, $versionId] = $this->getVersionId($handler, $id);
+
+        $resp = $handler->handle(
+            $this->request('GET', "/admin/vault/documents/{$docId}/versions/{$versionId}/download", self::$adminToken),
+        );
+
+        $this->assertSame(200, $resp->getStatusCode());
+        $this->assertStringContainsString('application/pdf', $resp->getHeaderLine('Content-Type'));
+    }
+
+    public function test_download_content_disposition_is_attachment(): void
+    {
+        $handler = $this->handler();
+        $id      = $this->uploadDoc($handler, self::$adminToken, 'DlDisposition', '2026-01-01', '1000');
+
+        [$docId, $versionId] = $this->getVersionId($handler, $id);
+
+        $resp = $handler->handle(
+            $this->request('GET', "/admin/vault/documents/{$docId}/versions/{$versionId}/download", self::$adminToken),
+        );
+
+        $this->assertStringContainsString('attachment', $resp->getHeaderLine('Content-Disposition'));
+    }
+
+    public function test_download_unknown_version_returns_404(): void
+    {
+        $handler = $this->handler();
+        $id      = $this->uploadDoc($handler, self::$adminToken, 'DlUnknownV', '2026-01-01', '1000');
+
+        $resp = $handler->handle(
+            $this->request('GET', "/admin/vault/documents/{$id}/versions/00000000000000000000000000/download", self::$adminToken),
+        );
+        $this->assertSame(404, $resp->getStatusCode());
+    }
+
+    public function test_download_wrong_document_id_returns_404(): void
+    {
+        $handler = $this->handler();
+        $id      = $this->uploadDoc($handler, self::$adminToken, 'DlWrongDoc', '2026-01-01', '1000');
+
+        [$docId, $versionId] = $this->getVersionId($handler, $id);
+
+        $resp = $handler->handle(
+            $this->request('GET', "/admin/vault/documents/00000000000000000000000000/versions/{$versionId}/download", self::$adminToken),
+        );
+        $this->assertSame(404, $resp->getStatusCode());
+    }
+
+    public function test_download_foreign_token_returns_403(): void
+    {
+        $handler = $this->handler();
+        $id      = $this->uploadDoc($handler, self::$adminToken, 'DlForeign', '2026-01-01', '1000');
+
+        [$docId, $versionId] = $this->getVersionId($handler, $id);
+
+        $resp = $handler->handle(
+            $this->request('GET', "/admin/vault/documents/{$docId}/versions/{$versionId}/download", self::$foreignToken),
+        );
+        $this->assertSame(403, $resp->getStatusCode());
+    }
+
+    public function test_download_unauthenticated_returns_401(): void
+    {
+        $handler = $this->handler();
+        $id      = $this->uploadDoc($handler, self::$adminToken, 'DlUnauth', '2026-01-01', '1000');
+
+        [$docId, $versionId] = $this->getVersionId($handler, $id);
+
+        $resp = $handler->handle(
+            $this->request('GET', "/admin/vault/documents/{$docId}/versions/{$versionId}/download"),
+        );
+        $this->assertSame(401, $resp->getStatusCode());
+    }
+
+    public function test_download_body_starts_with_pdf_magic(): void
+    {
+        $handler = $this->handler();
+        $id      = $this->uploadDoc($handler, self::$adminToken, 'DlContent', '2026-01-01', '1000');
+
+        [$docId, $versionId] = $this->getVersionId($handler, $id);
+
+        $resp = $handler->handle(
+            $this->request('GET', "/admin/vault/documents/{$docId}/versions/{$versionId}/download", self::$adminToken),
+        );
+        $this->assertStringStartsWith('%PDF', (string) $resp->getBody());
+    }
+
+    // ── History ───────────────────────────────────────────────────────────────
+
+    public function test_history_returns_version_list(): void
+    {
+        $handler = $this->handler();
+        $id      = $this->uploadDoc($handler, self::$adminToken, 'HistVer', '2026-01-01', '1000');
+
+        $resp = $handler->handle(
+            $this->request('GET', "/admin/vault/documents/{$id}/history", self::$adminToken),
+        );
+        $this->assertSame(200, $resp->getStatusCode());
+        $body = json_decode((string) $resp->getBody(), true);
+        $this->assertArrayHasKey('versions', $body);
+        $this->assertArrayHasKey('audit_events', $body);
+        $this->assertCount(1, $body['versions']);
+        $this->assertSame(1, $body['versions'][0]['version_number']);
+    }
+
+    public function test_history_nonexistent_document_returns_404(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request('GET', '/admin/vault/documents/00000000000000000000000000/history', self::$adminToken),
+        );
+        $this->assertSame(404, $resp->getStatusCode());
+    }
+
+    public function test_history_foreign_token_returns_403(): void
+    {
+        $id   = $this->uploadDoc($this->handler(), self::$adminToken, 'HistForeign', '2026-01-01', '1000');
+        $resp = $this->handler()->handle(
+            $this->request('GET', "/admin/vault/documents/{$id}/history", self::$foreignToken),
+        );
+        $this->assertSame(403, $resp->getStatusCode());
+    }
+
+    // ── Get by ID ─────────────────────────────────────────────────────────────
+
+    public function test_get_nonexistent_document_returns_404(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request('GET', '/admin/vault/documents/00000000000000000000000000', self::$adminToken),
+        );
+        $this->assertSame(404, $resp->getStatusCode());
+    }
+
+    public function test_get_document_foreign_token_returns_403(): void
+    {
+        $id   = $this->uploadDoc($this->handler(), self::$adminToken, 'GetForeign', '2026-01-01', '1000');
+        $resp = $this->handler()->handle(
+            $this->request('GET', "/admin/vault/documents/{$id}", self::$foreignToken),
+        );
+        $this->assertSame(403, $resp->getStatusCode());
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /** @return array{string, string} [documentId, versionId] */
+    private function getVersionId(\Psr\Http\Server\RequestHandlerInterface $handler, string $docId): array
+    {
+        $resp = $handler->handle(
+            $this->request('GET', "/admin/vault/documents/{$docId}/history", self::$adminToken),
+        );
+        $body      = json_decode((string) $resp->getBody(), true);
+        $versionId = (string) $body['versions'][0]['id'];
+
+        return [$docId, $versionId];
+    }
+}

--- a/tests/Email/MaildirPollerTest.php
+++ b/tests/Email/MaildirPollerTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Tests\Email;
+
+use NeneVault\Email\MaildirPoller;
+use NeneVault\Email\MimeParser;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * MaildirPoller boundary tests: scanning, parsing, processed-file move,
+ * empty dir, missing dir.
+ */
+final class MaildirPollerTest extends TestCase
+{
+    private string $dir = '';
+
+    protected function setUp(): void
+    {
+        $this->dir = sys_get_temp_dir() . '/vault_maildir_' . uniqid();
+        mkdir($this->dir, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->dir);
+    }
+
+    private function poller(): MaildirPoller
+    {
+        return new MaildirPoller($this->dir, new MimeParser());
+    }
+
+    private function writeEml(string $name, string $content): string
+    {
+        $path = $this->dir . '/' . $name;
+        file_put_contents($path, $content);
+
+        return $path;
+    }
+
+    private function sampleEml(string $from = 'vendor@example.com'): string
+    {
+        $pdf = base64_encode('%PDF-1.4 fake');
+
+        return "From: {$from}\r\n"
+            . "Subject: Invoice\r\n"
+            . 'Message-ID: <' . uniqid() . "@example.com>\r\n"
+            . "MIME-Version: 1.0\r\n"
+            . "Content-Type: multipart/mixed; boundary=\"b\"\r\n"
+            . "\r\n"
+            . "--b\r\n"
+            . "Content-Type: application/pdf; name=\"invoice.pdf\"\r\n"
+            . "Content-Transfer-Encoding: base64\r\n"
+            . "Content-Disposition: attachment; filename=\"invoice.pdf\"\r\n"
+            . "\r\n"
+            . $pdf . "\r\n"
+            . "--b--\r\n";
+    }
+
+    // ── Scanning ───────────────────────────────────────────────────────────────
+
+    public function test_poll_empty_dir_returns_empty(): void
+    {
+        $this->assertSame([], $this->poller()->poll());
+    }
+
+    public function test_poll_finds_single_eml(): void
+    {
+        $this->writeEml('msg1.eml', $this->sampleEml());
+        $items = $this->poller()->poll();
+        $this->assertCount(1, $items);
+        $this->assertSame('vendor@example.com', $items[0]['email']->from);
+        $this->assertCount(1, $items[0]['email']->allowedAttachments());
+    }
+
+    public function test_poll_finds_multiple_eml(): void
+    {
+        $this->writeEml('a.eml', $this->sampleEml('a@example.com'));
+        $this->writeEml('b.eml', $this->sampleEml('b@example.com'));
+        $this->writeEml('c.eml', $this->sampleEml('c@example.com'));
+        $items = $this->poller()->poll();
+        $this->assertCount(3, $items);
+    }
+
+    public function test_poll_ignores_non_eml_files(): void
+    {
+        $this->writeEml('msg.eml', $this->sampleEml());
+        file_put_contents($this->dir . '/readme.txt', 'not an email');
+        file_put_contents($this->dir . '/data.json', '{}');
+        $items = $this->poller()->poll();
+        $this->assertCount(1, $items);
+    }
+
+    // ── Processed move ───────────────────────────────────────────────────────
+
+    public function test_mark_processed_moves_file(): void
+    {
+        $path = $this->writeEml('move-me.eml', $this->sampleEml());
+        $this->assertFileExists($path);
+
+        $this->poller()->markProcessed($path);
+
+        $this->assertFileDoesNotExist($path);
+        $this->assertFileExists($this->dir . '/processed/move-me.eml');
+    }
+
+    public function test_mark_processed_avoids_collision(): void
+    {
+        $poller = $this->poller();
+
+        // Pre-create a processed file with the same name
+        mkdir($this->dir . '/processed', 0755, true);
+        file_put_contents($this->dir . '/processed/dup.eml', 'existing');
+
+        $path = $this->writeEml('dup.eml', $this->sampleEml());
+        $poller->markProcessed($path);
+
+        // Original processed file must survive; new one stored under a unique name
+        $this->assertSame('existing', file_get_contents($this->dir . '/processed/dup.eml'));
+        $processedFiles = glob($this->dir . '/processed/*.eml') ?: [];
+        $this->assertGreaterThanOrEqual(2, count($processedFiles));
+    }
+
+    public function test_processed_files_excluded_from_next_poll(): void
+    {
+        $path = $this->writeEml('once.eml', $this->sampleEml());
+        $this->poller()->markProcessed($path);
+
+        // processed/ is a subdir; glob('*.eml') on the top dir must not see it
+        $this->assertCount(0, $this->poller()->poll());
+    }
+
+    // ── Missing dir ────────────────────────────────────────────────────────────
+
+    public function test_poll_missing_dir_throws(): void
+    {
+        $poller = new MaildirPoller('/nonexistent/path/xyz', new MimeParser());
+        $this->expectException(RuntimeException::class);
+        $poller->poll();
+    }
+
+    // ── Helper ────────────────────────────────────────────────────────────────
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $items = scandir($dir) ?: [];
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            is_dir($path) ? $this->removeDir($path) : @unlink($path);
+        }
+        @rmdir($dir);
+    }
+}

--- a/tests/Organization/OrganizationBoundaryTest.php
+++ b/tests/Organization/OrganizationBoundaryTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Tests\Organization;
+
+use NeneVault\Tests\Support\ApiTestCase;
+
+/**
+ * Organization boundary tests: required fields, slug format/uniqueness,
+ * superadmin-only access, 404 on unknown.
+ */
+final class OrganizationBoundaryTest extends ApiTestCase
+{
+    private static string $superToken = '';
+    private static string $adminToken = '';
+    private static int    $orgId      = 0;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::bootContainer();
+        self::$orgId      = self::ensureOrg('test-org');
+        self::$superToken = self::issueSuperadminToken(userId: 160);
+        self::$adminToken = self::issueToken('admin', self::$orgId, userId: 161);
+    }
+
+    // ── Validation ─────────────────────────────────────────────────────────────
+
+    public function test_create_missing_name_returns_422(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request('POST', '/admin/organizations', self::$superToken, ['slug' => 'no-name-' . uniqid()]),
+        );
+        $this->assertSame(422, $resp->getStatusCode());
+    }
+
+    public function test_create_missing_slug_returns_422(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request('POST', '/admin/organizations', self::$superToken, ['name' => 'No Slug Co']),
+        );
+        $this->assertSame(422, $resp->getStatusCode());
+    }
+
+    public function test_create_uppercase_slug_rejected_422(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request('POST', '/admin/organizations', self::$superToken, ['name' => 'X', 'slug' => 'Invalid-Slug']),
+        );
+        $this->assertSame(422, $resp->getStatusCode());
+    }
+
+    public function test_create_slug_with_spaces_rejected_422(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request('POST', '/admin/organizations', self::$superToken, ['name' => 'X', 'slug' => 'has spaces']),
+        );
+        $this->assertSame(422, $resp->getStatusCode());
+    }
+
+    public function test_create_slug_with_underscore_rejected_422(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request('POST', '/admin/organizations', self::$superToken, ['name' => 'X', 'slug' => 'under_score']),
+        );
+        $this->assertSame(422, $resp->getStatusCode());
+    }
+
+    public function test_create_valid_kebab_slug_accepted(): void
+    {
+        $slug = 'valid-kebab-' . substr(bin2hex(random_bytes(4)), 0, 8);
+        $resp = $this->handler()->handle(
+            $this->request('POST', '/admin/organizations', self::$superToken, ['name' => 'Valid Co', 'slug' => $slug]),
+        );
+        $this->assertSame(201, $resp->getStatusCode(), (string) $resp->getBody());
+        $this->assertSame($slug, json_decode((string) $resp->getBody(), true)['slug']);
+    }
+
+    public function test_create_duplicate_slug_returns_409(): void
+    {
+        $slug = 'dup-org-' . substr(bin2hex(random_bytes(4)), 0, 8);
+        $first = $this->handler()->handle(
+            $this->request('POST', '/admin/organizations', self::$superToken, ['name' => 'First', 'slug' => $slug]),
+        );
+        $this->assertSame(201, $first->getStatusCode());
+
+        $second = $this->handler()->handle(
+            $this->request('POST', '/admin/organizations', self::$superToken, ['name' => 'Second', 'slug' => $slug]),
+        );
+        $this->assertSame(409, $second->getStatusCode());
+    }
+
+    public function test_create_seeds_vault_settings(): void
+    {
+        $slug = 'seed-vs-' . substr(bin2hex(random_bytes(4)), 0, 8);
+        $resp = $this->handler()->handle(
+            $this->request('POST', '/admin/organizations', self::$superToken, ['name' => 'Seed VS', 'slug' => $slug]),
+        );
+        $this->assertSame(201, $resp->getStatusCode());
+
+        // Settings row should exist for the new org (verified via DB)
+        $newOrgId = (int) json_decode((string) $resp->getBody(), true)['id'];
+        $stmt = self::pdo()->query("SELECT COUNT(*) AS c FROM vault_settings WHERE organization_id = {$newOrgId}");
+        assert($stmt !== false);
+        $this->assertSame(1, (int) $stmt->fetch()['c']);
+    }
+
+    // ── RBAC ─────────────────────────────────────────────────────────────────
+
+    public function test_admin_cannot_create_organization(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request('POST', '/admin/organizations', self::$adminToken, ['name' => 'X', 'slug' => 'admin-attempt-' . uniqid()]),
+        );
+        $this->assertSame(403, $resp->getStatusCode());
+    }
+
+    public function test_admin_cannot_list_organizations(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request('GET', '/admin/organizations', self::$adminToken),
+        );
+        $this->assertSame(403, $resp->getStatusCode());
+    }
+
+    public function test_unauthenticated_returns_401(): void
+    {
+        $resp = $this->handler()->handle($this->request('GET', '/admin/organizations'));
+        $this->assertSame(401, $resp->getStatusCode());
+    }
+
+    // ── 404 ───────────────────────────────────────────────────────────────────
+
+    public function test_get_unknown_organization_returns_404(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request('GET', '/admin/organizations/99999999', self::$superToken),
+        );
+        $this->assertSame(404, $resp->getStatusCode());
+    }
+
+    public function test_update_unknown_organization_returns_404(): void
+    {
+        // name + slug are both required by the handler; supply valid values so the
+        // request passes validation and reaches the not-found check.
+        $resp = $this->handler()->handle(
+            $this->request('PATCH', '/admin/organizations/99999999', self::$superToken, ['name' => 'Ghost', 'slug' => 'ghost-org']),
+        );
+        $this->assertSame(404, $resp->getStatusCode());
+    }
+
+    public function test_update_missing_name_returns_422(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request('PATCH', '/admin/organizations/' . self::$orgId, self::$superToken, ['slug' => 'x']),
+        );
+        $this->assertSame(422, $resp->getStatusCode());
+    }
+
+    public function test_delete_unknown_organization_returns_404(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request('DELETE', '/admin/organizations/99999999', self::$superToken),
+        );
+        $this->assertSame(404, $resp->getStatusCode());
+    }
+}

--- a/tests/User/UserValidationBoundaryTest.php
+++ b/tests/User/UserValidationBoundaryTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Tests\User;
+
+use NeneVault\Tests\Support\ApiTestCase;
+
+/**
+ * User create/update validation boundary tests: email format, password length,
+ * role enum, self-delete guard, pagination, RBAC.
+ */
+final class UserValidationBoundaryTest extends ApiTestCase
+{
+    private static string $adminToken  = '';
+    private static string $memberToken = '';
+    private static int    $orgId       = 0;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::bootContainer();
+        self::$orgId       = self::ensureOrg('test-org');
+        self::$adminToken  = self::issueToken('admin', self::$orgId, userId: 170);
+        self::$memberToken = self::issueToken('member', self::$orgId, userId: 171);
+    }
+
+    // ── Email validation ───────────────────────────────────────────────────────
+
+    public function test_create_invalid_email_returns_422(): void
+    {
+        $resp = $this->create(['email' => 'not-an-email', 'password' => 'changeme123', 'role' => 'member']);
+        $this->assertSame(422, $resp->getStatusCode());
+    }
+
+    public function test_create_empty_email_returns_422(): void
+    {
+        $resp = $this->create(['email' => '', 'password' => 'changeme123', 'role' => 'member']);
+        $this->assertSame(422, $resp->getStatusCode());
+    }
+
+    public function test_create_valid_email_accepted(): void
+    {
+        $resp = $this->create(['email' => 'valid-' . uniqid() . '@example.com', 'password' => 'changeme123', 'role' => 'member']);
+        $this->assertSame(201, $resp->getStatusCode(), (string) $resp->getBody());
+    }
+
+    // ── Password validation ──────────────────────────────────────────────────
+
+    public function test_create_password_7_chars_rejected_422(): void
+    {
+        $resp = $this->create(['email' => 'pw7-' . uniqid() . '@example.com', 'password' => '1234567', 'role' => 'member']);
+        $this->assertSame(422, $resp->getStatusCode());
+    }
+
+    public function test_create_password_8_chars_accepted(): void
+    {
+        $resp = $this->create(['email' => 'pw8-' . uniqid() . '@example.com', 'password' => '12345678', 'role' => 'member']);
+        $this->assertSame(201, $resp->getStatusCode());
+    }
+
+    public function test_create_empty_password_returns_422(): void
+    {
+        $resp = $this->create(['email' => 'nopw-' . uniqid() . '@example.com', 'password' => '', 'role' => 'member']);
+        $this->assertSame(422, $resp->getStatusCode());
+    }
+
+    // ── Role validation ────────────────────────────────────────────────────────
+
+    public function test_create_each_valid_role_accepted(): void
+    {
+        foreach (['admin', 'member', 'viewer'] as $role) {
+            $resp = $this->create(['email' => "{$role}-" . uniqid() . '@example.com', 'password' => 'changeme123', 'role' => $role]);
+            $this->assertSame(201, $resp->getStatusCode(), "Role '{$role}' must be accepted: " . (string) $resp->getBody());
+        }
+    }
+
+    public function test_create_superadmin_role_rejected_422(): void
+    {
+        $resp = $this->create(['email' => 'super-' . uniqid() . '@example.com', 'password' => 'changeme123', 'role' => 'superadmin']);
+        $this->assertSame(422, $resp->getStatusCode());
+    }
+
+    public function test_create_unknown_role_rejected_422(): void
+    {
+        $resp = $this->create(['email' => 'unknown-' . uniqid() . '@example.com', 'password' => 'changeme123', 'role' => 'wizard']);
+        $this->assertSame(422, $resp->getStatusCode());
+    }
+
+    public function test_create_missing_role_returns_422(): void
+    {
+        $resp = $this->create(['email' => 'norole-' . uniqid() . '@example.com', 'password' => 'changeme123']);
+        $this->assertSame(422, $resp->getStatusCode());
+    }
+
+    // ── Duplicate email ────────────────────────────────────────────────────────
+
+    public function test_create_duplicate_email_returns_409(): void
+    {
+        $email = 'dup-' . uniqid() . '@example.com';
+        $this->assertSame(201, $this->create(['email' => $email, 'password' => 'changeme123', 'role' => 'member'])->getStatusCode());
+        $this->assertSame(409, $this->create(['email' => $email, 'password' => 'changeme123', 'role' => 'member'])->getStatusCode());
+    }
+
+    // ── Self-delete guard ──────────────────────────────────────────────────────
+
+    public function test_admin_cannot_delete_self(): void
+    {
+        // Create an admin, then issue a token for that admin and have it delete itself.
+        $email = 'selfadmin-' . uniqid() . '@example.com';
+        $created = $this->create(['email' => $email, 'password' => 'changeme123', 'role' => 'admin']);
+        $this->assertSame(201, $created->getStatusCode());
+        $userId = json_decode((string) $created->getBody(), true)['id'];
+
+        $selfToken = self::issueToken('admin', self::$orgId, userId: (int) $userId);
+        $resp = $this->handler()->handle(
+            $this->request('DELETE', "/admin/users/{$userId}", $selfToken),
+        );
+        $this->assertSame(409, $resp->getStatusCode(), 'Deleting self must be rejected with 409 Conflict');
+    }
+
+    // ── Update ─────────────────────────────────────────────────────────────────
+
+    public function test_update_role_to_viewer(): void
+    {
+        $email   = 'upd-' . uniqid() . '@example.com';
+        $created = $this->create(['email' => $email, 'password' => 'changeme123', 'role' => 'member']);
+        $userId  = json_decode((string) $created->getBody(), true)['id'];
+
+        $resp = $this->handler()->handle(
+            $this->request('PATCH', "/admin/users/{$userId}", self::$adminToken, ['role' => 'viewer']),
+        );
+        $this->assertSame(200, $resp->getStatusCode());
+        $this->assertSame('viewer', json_decode((string) $resp->getBody(), true)['role']);
+    }
+
+    public function test_update_unknown_user_returns_404(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request('PATCH', '/admin/users/99999999', self::$adminToken, ['role' => 'viewer']),
+        );
+        $this->assertSame(404, $resp->getStatusCode());
+    }
+
+    // ── Pagination ─────────────────────────────────────────────────────────────
+
+    public function test_list_pagination_limit_and_total(): void
+    {
+        // Ensure at least 2 users exist
+        $this->create(['email' => 'pag1-' . uniqid() . '@example.com', 'password' => 'changeme123', 'role' => 'member']);
+        $this->create(['email' => 'pag2-' . uniqid() . '@example.com', 'password' => 'changeme123', 'role' => 'member']);
+
+        $resp = $this->handler()->handle(
+            $this->request('GET', '/admin/users?limit=1&offset=0', self::$adminToken),
+        );
+        $body = json_decode((string) $resp->getBody(), true);
+        $this->assertCount(1, $body['items']);
+        $this->assertGreaterThanOrEqual(2, $body['total']);
+    }
+
+    // ── RBAC ─────────────────────────────────────────────────────────────────
+
+    public function test_member_cannot_create_user(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request('POST', '/admin/users', self::$memberToken, ['email' => 'x-' . uniqid() . '@example.com', 'password' => 'changeme123', 'role' => 'member']),
+        );
+        $this->assertSame(403, $resp->getStatusCode());
+    }
+
+    public function test_unauthenticated_returns_401(): void
+    {
+        $resp = $this->handler()->handle($this->request('GET', '/admin/users'));
+        $this->assertSame(401, $resp->getStatusCode());
+    }
+
+    // ── Helper ────────────────────────────────────────────────────────────────
+
+    /** @param array<string, mixed> $body */
+    private function create(array $body): \Psr\Http\Message\ResponseInterface
+    {
+        return $this->handler()->handle(
+            $this->request('POST', '/admin/users', self::$adminToken, $body),
+        );
+    }
+}

--- a/tests/VaultSettings/VaultSettingsBoundaryTest.php
+++ b/tests/VaultSettings/VaultSettingsBoundaryTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Tests\VaultSettings;
+
+use NeneVault\Tests\Support\ApiTestCase;
+
+/**
+ * VaultSettings boundary tests: retention_years range edges (7–99),
+ * sibling-link URLs, storage path override, RBAC.
+ */
+final class VaultSettingsBoundaryTest extends ApiTestCase
+{
+    private static string $adminToken  = '';
+    private static string $memberToken = '';
+    private static string $viewerToken = '';
+    private static int    $orgId       = 0;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::bootContainer();
+        self::$orgId       = self::ensureOrg('test-org');
+        self::$adminToken  = self::issueToken('admin', self::$orgId, userId: 150);
+        self::$memberToken = self::issueToken('member', self::$orgId, userId: 151);
+        self::$viewerToken = self::issueToken('viewer', self::$orgId, userId: 152);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        // This class mutates the shared test-org retention_years. Reset it to the
+        // default (10) so it does not pollute other classes' retention calculations.
+        $pdo = self::pdo();
+        $pdo->exec('UPDATE vault_settings SET retention_years = 10 WHERE organization_id = ' . self::$orgId);
+
+        parent::tearDownAfterClass();
+    }
+
+    // ── retention_years range edges ───────────────────────────────────────────
+
+    public function test_retention_years_minimum_7_accepted(): void
+    {
+        $resp = $this->patch(['retention_years' => 7]);
+        $this->assertSame(200, $resp->getStatusCode(), (string) $resp->getBody());
+        $this->assertSame(7, json_decode((string) $resp->getBody(), true)['retention_years']);
+    }
+
+    public function test_retention_years_6_rejected_422(): void
+    {
+        $resp = $this->patch(['retention_years' => 6]);
+        $this->assertSame(422, $resp->getStatusCode());
+    }
+
+    public function test_retention_years_0_rejected_422(): void
+    {
+        $resp = $this->patch(['retention_years' => 0]);
+        $this->assertSame(422, $resp->getStatusCode());
+    }
+
+    public function test_retention_years_maximum_99_accepted(): void
+    {
+        $resp = $this->patch(['retention_years' => 99]);
+        $this->assertSame(200, $resp->getStatusCode());
+        $this->assertSame(99, json_decode((string) $resp->getBody(), true)['retention_years']);
+    }
+
+    public function test_retention_years_100_rejected_422(): void
+    {
+        $resp = $this->patch(['retention_years' => 100]);
+        $this->assertSame(422, $resp->getStatusCode());
+    }
+
+    public function test_retention_years_10_default_accepted(): void
+    {
+        $resp = $this->patch(['retention_years' => 10]);
+        $this->assertSame(200, $resp->getStatusCode());
+        $this->assertSame(10, json_decode((string) $resp->getBody(), true)['retention_years']);
+    }
+
+    // ── sibling links + storage path ──────────────────────────────────────────
+
+    public function test_storage_path_override_set_and_cleared(): void
+    {
+        $set = $this->patch(['retention_years' => 10, 'storage_path_override' => '/var/custom/vault']);
+        $this->assertSame('/var/custom/vault', json_decode((string) $set->getBody(), true)['storage_path_override']);
+
+        $clear = $this->patch(['retention_years' => 10, 'storage_path_override' => '']);
+        $this->assertNull(json_decode((string) $clear->getBody(), true)['storage_path_override']);
+    }
+
+    public function test_invoice_and_clear_urls_persisted(): void
+    {
+        $resp = $this->patch([
+            'retention_years'      => 10,
+            'invoice_api_base_url' => 'https://invoice.example.com',
+            'clear_api_base_url'   => 'https://clear.example.com',
+        ]);
+        $body = json_decode((string) $resp->getBody(), true);
+        $this->assertSame('https://invoice.example.com', $body['invoice_api_base_url']);
+        $this->assertSame('https://clear.example.com', $body['clear_api_base_url']);
+    }
+
+    public function test_update_persists_to_next_get(): void
+    {
+        $this->patch(['retention_years' => 15]);
+        $get  = $this->handler()->handle($this->request('GET', '/admin/vault/settings', self::$adminToken));
+        $this->assertSame(15, json_decode((string) $get->getBody(), true)['retention_years']);
+    }
+
+    public function test_update_records_audit_event(): void
+    {
+        $this->patch(['retention_years' => 12]);
+        $audit = $this->handler()->handle(
+            $this->request('GET', '/admin/audit-events?entity_type=vault_settings&action=vault_settings.changed', self::$adminToken),
+        );
+        $body = json_decode((string) $audit->getBody(), true);
+        $this->assertGreaterThanOrEqual(1, $body['total']);
+    }
+
+    // ── RBAC ─────────────────────────────────────────────────────────────────
+
+    public function test_member_cannot_update_settings(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request('PATCH', '/admin/vault/settings', self::$memberToken, ['retention_years' => 10]),
+        );
+        $this->assertSame(403, $resp->getStatusCode());
+    }
+
+    public function test_viewer_cannot_read_settings(): void
+    {
+        // Both GET and PATCH on /admin/vault/settings require ManageVaultSettings
+        // (admin/superadmin only) — settings are an admin-only surface.
+        $resp = $this->handler()->handle(
+            $this->request('GET', '/admin/vault/settings', self::$viewerToken),
+        );
+        $this->assertSame(403, $resp->getStatusCode());
+    }
+
+    public function test_unauthenticated_get_returns_401(): void
+    {
+        $resp = $this->handler()->handle($this->request('GET', '/admin/vault/settings'));
+        $this->assertSame(401, $resp->getStatusCode());
+    }
+
+    public function test_unauthenticated_patch_returns_401(): void
+    {
+        $resp = $this->handler()->handle($this->request('PATCH', '/admin/vault/settings', null, ['retention_years' => 10]));
+        $this->assertSame(401, $resp->getStatusCode());
+    }
+
+    // ── Helper ────────────────────────────────────────────────────────────────
+
+    /** @param array<string, mixed> $body */
+    private function patch(array $body): \Psr\Http\Message\ResponseInterface
+    {
+        return $this->handler()->handle(
+            $this->request('PATCH', '/admin/vault/settings', self::$adminToken, $body),
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds comprehensive boundary-value tests across every backend domain, nearly doubling the backend suite (**142 → 284 tests**, 735 assertions). Surfaced and fixed a real compliance-relevant state-machine gap.

## New test files (11)

| File | Coverage |
|---|---|
| `DocumentUploadBoundaryTest` | MIME allowlist (415), null date→date_uncertain, null amount, tags, duplicate 409 + confirm |
| `DocumentSearchBoundaryTest` | each filter, combinations, pagination edges, include_voided, response shape (no `file_path`) |
| `DocumentMetadataBoundaryTest` | null clearing, required fields, category enum, RBAC, audit before/after |
| `DocumentLifecycleBoundaryTest` | void/restore state machine + double-operation guards |
| `DocumentVersionBoundaryTest` | download wrong org/version, SHA-256, tenant isolation, history |
| `VaultSettingsBoundaryTest` | retention_years edges (7/6/0/99/100), URLs, RBAC |
| `OrganizationBoundaryTest` | required fields, slug format, uniqueness 409, superadmin-only |
| `UserValidationBoundaryTest` | email, password length 7/8, role enum, self-delete, pagination |
| `AuditBoundaryTest` | filter combos, pagination, most-recent-first ordering |
| `LoginBoundaryTest` | missing fields, wrong password 401, token round-trip |
| `MaildirPollerTest` | scan, processed move, collision, missing dir |

## Bug fixed (surfaced by lifecycle tests)

`VoidDocumentUseCase` / `RestoreDocumentUseCase` did **not** validate current state:
- **Re-voiding** a voided document overwrote `voided_at` / `void_reason` — corrupting the 電帳法 audit trail
- **Restoring** an active document was a silent no-op generating a misleading audit event

Both now throw `InvalidDocumentStateException` → **409 Conflict**, with a new exception handler wired into the container and `409` responses documented in OpenAPI for void/restore.

## Test plan

- [x] `composer check` — 284 tests, PHPStan L8 clean, CS clean, locales/OpenAPI/MCP valid
- [x] Ran twice to confirm no cross-run state pollution (test DB is a persistent file)

Closes #81
🤖 Generated with [Claude Code](https://claude.com/claude-code)