### PR TITLE
chore(docker): fix unique local ports (8600/5186/3386) to avoid sibling conflicts (#83)

### DIFF
--- a/.cursor/rules/00-project-always.mdc
+++ b/.cursor/rules/00-project-always.mdc
@@ -12,3 +12,4 @@ alwaysApply: true
 - Compliance changes require ADR + professional review when cited by law.
 - Issue-driven; English repository docs (ADR 0008); no secrets in git.
 - New or renamed identifier → update `docs/terms.md` in the same PR. No exceptions.
+- **Fixed local Docker ports ("86 lane"): API 8600 · Frontend 5186 · MySQL 3386.** Unique across the NeNe portfolio — never reuse sibling ports (NENE2 82**/3316, Clear 83**/5173, Profile 84**/3409, Invoice 85**/5185, Records 180**). See README "Local port allocation".

--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,7 @@ NENE_VAULT_MAX_FILE_SIZE_MB=20
 
 # --- Email inbound (optional) ---
 # NENE_VAULT_EMAIL_MAILDIR=/var/mail/vault        Directory containing .eml files
-# NENE_VAULT_EMAIL_API_BASE_URL=http://localhost:8080
+# NENE_VAULT_EMAIL_API_BASE_URL=http://localhost:8600
 # NENE_VAULT_EMAIL_API_TOKEN=                     Bearer token (run tools/issue-jwt.php to generate)
 # NENE_VAULT_EMAIL_CATEGORY=invoice_received      Default category for email uploads
 # NENE_VAULT_EMAIL_DRY_RUN=false                  Set true to test without uploading
@@ -56,10 +56,12 @@ ORG_NAME=NeNe Vault
 ADMIN_EMAIL=admin@example.com
 ADMIN_PASSWORD=changeme123
 
-# --- Docker Compose port bindings ---
-NENE_VAULT_PORT=8080
-NENE_VAULT_FRONTEND_PORT=5173
-NENE_VAULT_MYSQL_PORT=3307
+# --- Docker Compose port bindings (fixed "86 lane" — unique across NeNe portfolio) ---
+# See README "Local port allocation". Do not reuse sibling ports:
+#   NENE2 82**/3316 · Clear 83**/5173 · Profile 84**/3409 · Invoice 85**/5185 · Records 180**
+NENE_VAULT_PORT=8600
+NENE_VAULT_FRONTEND_PORT=5186
+NENE_VAULT_MYSQL_PORT=3386
 
 # --- Docker Compose MySQL overrides (copy to .env and uncomment) ---
 # DB_ADAPTER=mysql

--- a/.mcp.json
+++ b/.mcp.json
@@ -4,7 +4,7 @@
       "command": "php",
       "args": ["tools/local-mcp-server.php"],
       "env": {
-        "NENE2_LOCAL_API_BASE_URL": "http://localhost:8080",
+        "NENE2_LOCAL_API_BASE_URL": "http://localhost:8600",
         "NENE2_LOCAL_JWT_SECRET": "${NENE2_LOCAL_JWT_SECRET}"
       }
     }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,13 @@ locales/       ja.json + en.json (single source of truth for all UI text)
 composer check          # test + PHPStan + CS + locales + openapi + mcp
 npm run check --prefix frontend  # type-check + lint + test + build
 composer mcp:server     # start MCP server (stdio JSON-RPC)
+docker compose up       # local stack — API :8600 · Frontend :5186 · MySQL :3386
 ```
+
+## Local ports (fixed, "86 lane")
+
+API **8600** · Frontend **5186** · MySQL **3386** — unique across the NeNe
+portfolio; never reuse sibling ports. See README "Local port allocation".
 
 ## Hard rules (never violate without an ADR)
 

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ Then open:
 
 | Service  | URL                     | Notes                                  |
 |----------|-------------------------|----------------------------------------|
-| Frontend | http://localhost:5173   | Vite dev server (proxies API to `app`) |
-| API      | http://localhost:8080   | Apache + PHP 8.4                        |
+| Frontend | http://localhost:5186   | Vite dev server (proxies API to `app`) |
+| API      | http://localhost:8600   | Apache + PHP 8.4                        |
 
 First-run admin credentials come from `.env` (`ADMIN_EMAIL` / `ADMIN_PASSWORD`,
 default `admin@example.com` / `changeme123`). A `default` organization, its
@@ -74,11 +74,33 @@ vault settings, and a superadmin user are seeded automatically.
 docker compose --profile mysql -f docker-compose.yml -f docker-compose.mysql.yml up
 ```
 
-**Port conflicts:** if 8080 / 5173 are already in use (e.g. a sibling product's
-dev server), override the host ports:
+### Local port allocation (binding)
+
+NeNe Vault runs alongside sibling products on the same developer machine, so its
+host-published ports are **fixed in the "86 lane"** to never collide:
+
+| Service          | NeNe Vault host port | Env var                     |
+|------------------|----------------------|-----------------------------|
+| API (Apache/PHP) | **8600**             | `NENE_VAULT_PORT`           |
+| Frontend (Vite)  | **5186**             | `NENE_VAULT_FRONTEND_PORT`  |
+| MySQL            | **3386**             | `NENE_VAULT_MYSQL_PORT`     |
+
+Reserved by siblings — **do not reuse**:
+
+| Product       | API   | Frontend / DB |
+|---------------|-------|---------------|
+| NENE2         | 82**  | 3316          |
+| NeNe Clear    | 83**  | 5173          |
+| NeNe Profile  | 84**  | 3409          |
+| NeNe Invoice  | 85**  | 5185          |
+| NeNe Records  | 180** | —             |
+
+Container-internal ports (8080 / 5173 / 3306) are unchanged; only the host side
+differs. If you must temporarily override (e.g. running two Vault checkouts),
+set the env vars — but keep `.env` on the fixed allocation above:
 
 ```sh
-NENE_VAULT_PORT=8090 NENE_VAULT_FRONTEND_PORT=5180 docker compose up
+NENE_VAULT_PORT=8601 NENE_VAULT_FRONTEND_PORT=5187 docker compose up
 ```
 
 ## Status

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,13 @@
 ##
 ## First-run credentials (see .env / ADMIN_EMAIL / ADMIN_PASSWORD):
 ##   Admin login: admin@example.com / changeme123
-##   API base:    http://localhost:8080
-##   Frontend:    http://localhost:5173
+##   API base:    http://localhost:8600
+##   Frontend:    http://localhost:5186
+##
+## Fixed local ports (86 lane — unique across the NeNe portfolio; see README):
+##   8600 API · 5186 Frontend · 3386 MySQL
+## Container-internal ports (8080 / 5173 / 3306) are unchanged; only the
+## host-published port differs.
 
 services:
   # ── PHP backend (Apache + PHP 8.4) ──────────────────────────────────────────
@@ -21,7 +26,7 @@ services:
       dockerfile: Dockerfile
       target: dev
     ports:
-      - "${NENE_VAULT_PORT:-8080}:8080"
+      - "${NENE_VAULT_PORT:-8600}:8080"
     volumes:
       # Source + vendor (read-only); vendor resolved by host composer install
       - .:/var/www/html:ro
@@ -62,7 +67,7 @@ services:
       dockerfile: frontend/Dockerfile
       target: dev
     ports:
-      - "${NENE_VAULT_FRONTEND_PORT:-5173}:5173"
+      - "${NENE_VAULT_FRONTEND_PORT:-5186}:5173"
     volumes:
       # Mount entire repo so @locales alias resolves to /app/locales
       - .:/app:ro
@@ -83,7 +88,7 @@ services:
     image: mysql:8.0
     profiles: [mysql]
     ports:
-      - "${NENE_VAULT_MYSQL_PORT:-3307}:3306"
+      - "${NENE_VAULT_MYSQL_PORT:-3386}:3306"
     environment:
       MYSQL_ROOT_PASSWORD: "${MYSQL_ROOT_PASSWORD:-nene_vault_root}"
       MYSQL_DATABASE: "${DB_NAME:-nene_vault}"

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -25,7 +25,7 @@ Write tools require `NENE2_LOCAL_JWT_SECRET` to be set in the server environment
 
 ## Prerequisites
 
-1. NeNe Vault running at a reachable URL (e.g. `http://localhost:8080`)
+1. NeNe Vault running at a reachable URL (e.g. `http://localhost:8600`)
 2. A bearer token — generate one with:
 
 ```sh
@@ -51,7 +51,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`
       "command": "php",
       "args": ["/absolute/path/to/nene-vault/tools/local-mcp-server.php"],
       "env": {
-        "NENE2_LOCAL_API_BASE_URL": "http://localhost:8080",
+        "NENE2_LOCAL_API_BASE_URL": "http://localhost:8600",
         "NENE2_LOCAL_JWT_SECRET": "your-vault-jwt-secret"
       }
     }
@@ -74,7 +74,7 @@ Add `.mcp.json` to the project root (already present in NeNe Vault):
       "command": "php",
       "args": ["tools/local-mcp-server.php"],
       "env": {
-        "NENE2_LOCAL_API_BASE_URL": "http://localhost:8080",
+        "NENE2_LOCAL_API_BASE_URL": "http://localhost:8600",
         "NENE2_LOCAL_JWT_SECRET": "your-vault-jwt-secret"
       }
     }
@@ -91,13 +91,13 @@ Claude Code picks up `.mcp.json` automatically when you open the project.
 ```sh
 # List available tools
 echo '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
-  | NENE2_LOCAL_API_BASE_URL=http://localhost:8080 \
+  | NENE2_LOCAL_API_BASE_URL=http://localhost:8600 \
     NENE2_LOCAL_JWT_SECRET=your-secret \
     php tools/local-mcp-server.php
 
 # Search documents (read-only, no JWT secret required for read tools)
 echo '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"searchVaultDocuments","arguments":{"counterparty_name":"ACME","limit":5}}}' \
-  | NENE2_LOCAL_API_BASE_URL=http://localhost:8080 \
+  | NENE2_LOCAL_API_BASE_URL=http://localhost:8600 \
     NENE2_LOCAL_JWT_SECRET=your-secret \
     php tools/local-mcp-server.php
 ```

--- a/docs/operator/email-inbound.md
+++ b/docs/operator/email-inbound.md
@@ -67,7 +67,7 @@ it securely (not in `.env` if shared).
 
 ```env
 NENE_VAULT_EMAIL_MAILDIR=/var/mail/vault
-NENE_VAULT_EMAIL_API_BASE_URL=http://localhost:8080
+NENE_VAULT_EMAIL_API_BASE_URL=http://localhost:8600
 NENE_VAULT_EMAIL_API_TOKEN=your-bearer-token-here
 NENE_VAULT_EMAIL_CATEGORY=invoice_received
 ```

--- a/docs/operator/installation.md
+++ b/docs/operator/installation.md
@@ -49,8 +49,8 @@ Services:
 
 | Service | Default URL | Notes |
 |---|---|---|
-| API (Apache + PHP 8.4) | http://localhost:8080 | |
-| Admin UI (Vite) | http://localhost:5173 | Dev server; proxies `/admin`, `/health` to the API |
+| API (Apache + PHP 8.4) | http://localhost:8600 | Fixed "86 lane" — see README |
+| Admin UI (Vite) | http://localhost:5186 | Dev server; proxies `/admin`, `/health` to the API |
 
 On first start, `init.sh` bootstraps the SQLite schema and seeds the default
 organization and admin user.
@@ -148,7 +148,7 @@ The PHP process must be able to write to `var/` (SQLite DB) and
 
 ## First login
 
-Open http://localhost:5173 and log in with `ADMIN_EMAIL` / `ADMIN_PASSWORD` from
+Open http://localhost:5186 and log in with `ADMIN_EMAIL` / `ADMIN_PASSWORD` from
 `.env`. Change the password immediately after first login.
 
 ---

--- a/tools/email-inbound.php
+++ b/tools/email-inbound.php
@@ -8,7 +8,7 @@
  *
  * Environment variables (set in .env or export before running):
  *   NENE_VAULT_EMAIL_MAILDIR        Directory containing .eml files (required)
- *   NENE_VAULT_EMAIL_API_BASE_URL   API base URL (default: http://localhost:8080)
+ *   NENE_VAULT_EMAIL_API_BASE_URL   API base URL (default: http://localhost:8600)
  *   NENE_VAULT_EMAIL_API_TOKEN      Bearer token for API auth (required)
  *   NENE_VAULT_EMAIL_CATEGORY       Document category (default: invoice_received)
  *   NENE_VAULT_EMAIL_DRY_RUN        Set to 'true' to parse only without uploading
@@ -33,7 +33,7 @@ use NeneVault\Email\MaildirPoller;
 use NeneVault\Email\MimeParser;
 
 $maildir = (string) (getenv('NENE_VAULT_EMAIL_MAILDIR') ?: '');
-$apiBase = rtrim((string) (getenv('NENE_VAULT_EMAIL_API_BASE_URL') ?: 'http://localhost:8080'), '/');
+$apiBase = rtrim((string) (getenv('NENE_VAULT_EMAIL_API_BASE_URL') ?: 'http://localhost:8600'), '/');
 $token = (string) (getenv('NENE_VAULT_EMAIL_API_TOKEN') ?: '');
 $category = (string) (getenv('NENE_VAULT_EMAIL_CATEGORY') ?: 'invoice_received');
 $dryRun = getenv('NENE_VAULT_EMAIL_DRY_RUN') === 'true';

--- a/tools/local-mcp-server.php
+++ b/tools/local-mcp-server.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * OpenAPI contract: docs/openapi/openapi.yaml
  *
  * Environment variables:
- *   NENE2_LOCAL_API_BASE_URL   API base URL (default: http://localhost:8080)
+ *   NENE2_LOCAL_API_BASE_URL   API base URL (default: http://localhost:8600)
  *   NENE2_LOCAL_JWT_SECRET     JWT secret — required for authenticated tools
  *
  * Usage (Claude Desktop claude_desktop_config.json):
@@ -20,7 +20,7 @@ declare(strict_types=1);
  *       "command": "php",
  *       "args": ["/path/to/nene-vault/tools/local-mcp-server.php"],
  *       "env": {
- *         "NENE2_LOCAL_API_BASE_URL": "http://localhost:8080",
+ *         "NENE2_LOCAL_API_BASE_URL": "http://localhost:8600",
  *         "NENE2_LOCAL_JWT_SECRET": "your-vault-jwt-secret"
  *       }
  *     }
@@ -37,7 +37,7 @@ use Nene2\Mcp\NativeLocalMcpHttpClient;
 require dirname(__DIR__) . '/vendor/autoload.php';
 
 $root = dirname(__DIR__);
-$apiBaseUrl = (string) (getenv('NENE2_LOCAL_API_BASE_URL') ?: 'http://localhost:8080');
+$apiBaseUrl = (string) (getenv('NENE2_LOCAL_API_BASE_URL') ?: 'http://localhost:8600');
 
 $bearerToken = null;
 $jwtSecret = getenv('NENE2_LOCAL_JWT_SECRET');


### PR DESCRIPTION
## Summary

NeNe Vault runs alongside sibling products on the same dev machine. Pins host-published Docker ports to the unused **"86 lane"** so they never collide. The previous default frontend port `5173` collided with NeNe Clear.

## Fixed allocation

| Service | Host port | Env var |
|---|---|---|
| API (Apache/PHP) | **8600** | `NENE_VAULT_PORT` |
| Frontend (Vite) | **5186** | `NENE_VAULT_FRONTEND_PORT` |
| MySQL | **3386** | `NENE_VAULT_MYSQL_PORT` |

Reserved by siblings (never reuse): NENE2 `82**`/`3316`, Clear `83**`/`5173`, Profile `84**`/`3409`, Invoice `85**`/`5185`, Records `180**`.

Container-internal ports (8080/5173/3306) are unchanged — only the host side moves.

## Documented as a binding rule

- `README.md` → new "Local port allocation" table (with sibling reservations)
- `.cursor/rules/00-project-always.mdc` → port rule
- `CLAUDE.md` → local ports section
- `.env.example` → fixed defaults + sibling-avoidance note

## Also updated (host-facing API URL → 8600)

`.mcp.json`, `tools/local-mcp-server.php`, `tools/email-inbound.php` defaults; `docs/operator/{installation,email-inbound}.md`, `docs/mcp/README.md`.

## Test plan

- [x] `docker compose config --quiet` — valid
- [x] `composer check` — all gates green
- [x] Local `.env` (gitignored) updated to the fixed allocation

Closes #83
🤖 Generated with [Claude Code](https://claude.com/claude-code)