### PR TITLE
fix(i18n): close localization gaps — error slugs, locale-aware formatting, audit labels (#85)

### DIFF
--- a/frontend/src/features/document-detail/ui/DocumentHistoryTable.tsx
+++ b/frontend/src/features/document-detail/ui/DocumentHistoryTable.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from '@/shared/i18n/use-translation';
+import { formatDateTime } from '@/shared/lib/format';
 import { Text } from '@/shared/ui';
 import type { AuditEvent } from '@/entities/audit';
 
@@ -7,7 +8,7 @@ interface DocumentHistoryTableProps {
 }
 
 export function DocumentHistoryTable({ events }: DocumentHistoryTableProps) {
-  const { t } = useTranslation();
+  const { t, locale } = useTranslation();
 
   if (events.length === 0) {
     return <Text tone="muted">{t('document.history.no_history')}</Text>;
@@ -38,12 +39,14 @@ export function DocumentHistoryTable({ events }: DocumentHistoryTableProps) {
         <tbody>
           {events.map((event) => (
             <tr key={event.id} className="border-b border-border">
-              <td className="px-inline-md py-stack-sm font-medium">{event.action}</td>
+              <td className="px-inline-md py-stack-sm font-medium">
+                {t(`audit_event.action.${event.action}`)}
+              </td>
               <td className="px-inline-md py-stack-sm text-muted">
                 {event.actor_user_id !== null ? String(event.actor_user_id) : '—'}
               </td>
               <td className="px-inline-md py-stack-sm text-muted">
-                {event.created_at.slice(0, 16).replace('T', ' ')}
+                {formatDateTime(event.created_at, locale)}
               </td>
               <td className="px-inline-md py-stack-sm">
                 {event.before_json !== null ? (

--- a/frontend/src/features/document-search/ui/DocumentTable.tsx
+++ b/frontend/src/features/document-search/ui/DocumentTable.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from '@/shared/i18n/use-translation';
+import { formatJpy, formatDate } from '@/shared/lib/format';
 import { Text } from '@/shared/ui';
 import type { VaultDocument } from '@/entities/document';
 
@@ -7,18 +8,8 @@ interface DocumentTableProps {
   onSelectDocument: (id: string) => void;
 }
 
-function formatAmount(cents: number | null): string {
-  if (cents === null) return '—';
-  return new Intl.NumberFormat('ja-JP', { style: 'currency', currency: 'JPY' }).format(cents);
-}
-
-function formatDate(date: string | null): string {
-  if (date === null) return '—';
-  return date;
-}
-
 export function DocumentTable({ documents, onSelectDocument }: DocumentTableProps) {
-  const { t } = useTranslation();
+  const { t, locale } = useTranslation();
 
   if (documents.length === 0) {
     return (
@@ -71,7 +62,7 @@ export function DocumentTable({ documents, onSelectDocument }: DocumentTableProp
               </td>
               <td className="px-inline-md py-stack-sm font-medium">{doc.counterparty_name}</td>
               <td className="px-inline-md py-stack-sm text-right tabular-nums">
-                {formatAmount(doc.amount_cents)}
+                {formatJpy(doc.amount_cents, locale)}
               </td>
               <td className="px-inline-md py-stack-sm">{t(`document.category.${doc.category}`)}</td>
               <td className="px-inline-md py-stack-sm">

--- a/frontend/src/pages/AuditPage.tsx
+++ b/frontend/src/pages/AuditPage.tsx
@@ -4,13 +4,14 @@ import { useAuditEvents } from '@/entities/audit';
 import type { ListAuditEventsParams } from '@/entities/audit';
 import { authStore } from '@/entities/auth';
 import { useTranslation } from '@/shared/i18n/use-translation';
+import { formatDateTime } from '@/shared/lib/format';
 import { AppShell, Button, Input, Stack, Text } from '@/shared/ui';
 import { Pagination } from '@/features/document-search';
 
 const PAGE_SIZE = 20;
 
 export function AuditPage() {
-  const { t } = useTranslation();
+  const { t, locale } = useTranslation();
   const navigate = useNavigate();
 
   const [filterEntityType, setFilterEntityType] = useState('');
@@ -146,7 +147,9 @@ export function AuditPage() {
                   <tbody>
                     {events.map((event) => (
                       <tr key={event.id} className="border-b border-border hover:bg-surface-raised">
-                        <td className="px-inline-md py-stack-sm font-medium">{event.action}</td>
+                        <td className="px-inline-md py-stack-sm font-medium">
+                          {t(`audit_event.action.${event.action}`)}
+                        </td>
                         <td className="px-inline-md py-stack-sm text-muted">
                           {event.entity_type}/{event.entity_id}
                         </td>
@@ -154,7 +157,7 @@ export function AuditPage() {
                           {event.actor_user_id !== null ? String(event.actor_user_id) : '—'}
                         </td>
                         <td className="px-inline-md py-stack-sm text-muted">
-                          {event.created_at.slice(0, 16).replace('T', ' ')}
+                          {formatDateTime(event.created_at, locale)}
                         </td>
                         <td className="px-inline-md py-stack-sm">
                           {event.before_json !== null ? (

--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -11,19 +11,15 @@ import {
 } from '@/features/document-detail';
 import type { OcrPrefill } from '@/features/document-detail';
 import { useTranslation } from '@/shared/i18n/use-translation';
+import { formatJpy, formatDate, formatDateTime } from '@/shared/lib/format';
 import { AppShell, Button, Stack, Text } from '@/shared/ui';
 import { env } from '@/shared/config/env';
 
 type Modal = 'void' | 'restore' | 'metadata-edit' | null;
 
-function formatAmount(cents: number | null): string {
-  if (cents === null) return '—';
-  return new Intl.NumberFormat('ja-JP', { style: 'currency', currency: 'JPY' }).format(cents);
-}
-
 export function DocumentDetailPage() {
   const { id } = useParams<{ id: string }>();
-  const { t } = useTranslation();
+  const { t, locale } = useTranslation();
   const navigate = useNavigate();
   const [modal, setModal] = useState<Modal>(null);
   const [ocrPrefill, setOcrPrefill] = useState<OcrPrefill | undefined>(undefined);
@@ -162,13 +158,15 @@ export function DocumentDetailPage() {
                   <dt className="text-label-sm text-muted">
                     {t('document.metadata.transaction_date')}
                   </dt>
-                  <dd className="mt-stack-xs">{doc.transaction_date ?? '—'}</dd>
+                  <dd className="mt-stack-xs">{formatDate(doc.transaction_date)}</dd>
                 </div>
                 <div>
                   <dt className="text-label-sm text-muted">
                     {t('document.metadata.amount_cents')}
                   </dt>
-                  <dd className="mt-stack-xs tabular-nums">{formatAmount(doc.amount_cents)}</dd>
+                  <dd className="mt-stack-xs tabular-nums">
+                    {formatJpy(doc.amount_cents, locale)}
+                  </dd>
                 </div>
                 <div>
                   <dt className="text-label-sm text-muted">{t('document.metadata.category')}</dt>
@@ -180,13 +178,13 @@ export function DocumentDetailPage() {
                 </div>
                 <div>
                   <dt className="text-label-sm text-muted">{t('document.metadata.uploaded_at')}</dt>
-                  <dd className="mt-stack-xs">{doc.uploaded_at.slice(0, 16).replace('T', ' ')}</dd>
+                  <dd className="mt-stack-xs">{formatDateTime(doc.uploaded_at, locale)}</dd>
                 </div>
                 <div>
                   <dt className="text-label-sm text-muted">
                     {t('document.metadata.retention_expires_at')}
                   </dt>
-                  <dd className="mt-stack-xs">{doc.retention_expires_at}</dd>
+                  <dd className="mt-stack-xs">{formatDate(doc.retention_expires_at)}</dd>
                 </div>
                 {doc.tags.length > 0 && (
                   <div className="col-span-2">

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -6,6 +6,7 @@ import { authStore } from '@/entities/auth';
 import { useVaultSettings, useUpdateVaultSettings } from '@/entities/vault-settings';
 import { messageKeyForError } from '@/shared/i18n/map-problem-details';
 import { useTranslation } from '@/shared/i18n/use-translation';
+import { formatDateTime } from '@/shared/lib/format';
 import { AppShell, Button, Input, Stack, Text } from '@/shared/ui';
 import { useNavigate } from 'react-router-dom';
 
@@ -19,7 +20,7 @@ const settingsSchema = z.object({
 type SettingsFormValues = z.infer<typeof settingsSchema>;
 
 export function SettingsPage() {
-  const { t } = useTranslation();
+  const { t, locale } = useTranslation();
   const navigate = useNavigate();
   const { data: settings, isLoading } = useVaultSettings();
 
@@ -151,7 +152,7 @@ export function SettingsPage() {
                 {settings?.updated_at !== null && settings?.updated_at !== undefined && (
                   <Text tone="muted" className="text-label-xs">
                     {t('vault_settings.fields.updated_at_label')}:{' '}
-                    {settings.updated_at.slice(0, 16).replace('T', ' ')}
+                    {formatDateTime(settings.updated_at, locale)}
                   </Text>
                 )}
 

--- a/frontend/src/shared/i18n/map-problem-details.ts
+++ b/frontend/src/shared/i18n/map-problem-details.ts
@@ -14,6 +14,12 @@ const SLUG_TO_KEY: Record<string, string> = {
   'file-too-large': 'problem.file_too_large',
   'duplicate-file': 'problem.duplicate_file',
   'invalid-credentials': 'problem.invalid_credentials',
+  'invalid-document-state': 'problem.invalid_document_state',
+  'cannot-delete-self': 'problem.cannot_delete_self',
+  'invalid-user-role': 'problem.invalid_user_role',
+  'user-not-found': 'problem.user_not_found',
+  'user-email-conflict': 'problem.user_email_conflict',
+  'ocr-failed': 'problem.ocr_failed',
   'internal-server-error': 'problem.internal_server_error',
 };
 

--- a/frontend/src/shared/lib/format.test.ts
+++ b/frontend/src/shared/lib/format.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { formatJpy, formatDate, formatDateTime } from './format';
+
+describe('formatJpy', () => {
+  it('returns em dash for null', () => {
+    expect(formatJpy(null, 'ja')).toBe('—');
+    expect(formatJpy(null, 'en')).toBe('—');
+  });
+
+  it('formats yen for ja locale', () => {
+    const out = formatJpy(110000, 'ja');
+    expect(out).toContain('110,000');
+    expect(out).toMatch(/[¥￥]/);
+  });
+
+  it('formats yen for en locale', () => {
+    const out = formatJpy(110000, 'en');
+    expect(out).toContain('110,000');
+    // en-US renders JPY with the ¥ symbol
+    expect(out).toMatch(/¥|JPY/);
+  });
+
+  it('has no fractional digits (JPY has no minor unit)', () => {
+    expect(formatJpy(1000, 'en')).not.toContain('.00');
+  });
+});
+
+describe('formatDate', () => {
+  it('returns em dash for null', () => {
+    expect(formatDate(null)).toBe('—');
+  });
+
+  it('returns the ISO date verbatim', () => {
+    expect(formatDate('2026-03-31')).toBe('2026-03-31');
+  });
+});
+
+describe('formatDateTime', () => {
+  it('returns em dash for null/undefined/empty', () => {
+    expect(formatDateTime(null, 'ja')).toBe('—');
+    expect(formatDateTime(undefined, 'en')).toBe('—');
+    expect(formatDateTime('', 'ja')).toBe('—');
+  });
+
+  it('formats a valid ISO timestamp for ja', () => {
+    const out = formatDateTime('2026-03-31T09:05:00Z', 'ja');
+    expect(out).toContain('2026');
+    expect(out).toContain('03');
+  });
+
+  it('formats a valid ISO timestamp for en', () => {
+    const out = formatDateTime('2026-03-31T09:05:00Z', 'en');
+    expect(out).toContain('2026');
+  });
+
+  it('falls back to trimmed ISO for an unparseable value', () => {
+    expect(formatDateTime('not-a-date', 'ja')).toBe('not-a-date');
+  });
+});

--- a/frontend/src/shared/lib/format.ts
+++ b/frontend/src/shared/lib/format.ts
@@ -1,0 +1,56 @@
+import type { SupportedLocale } from '@/shared/i18n/locales';
+
+const EM_DASH = '—';
+
+const INTL_LOCALE: Record<SupportedLocale, string> = {
+  ja: 'ja-JP',
+  en: 'en-US',
+};
+
+/**
+ * Format an integer-yen amount as currency for the active locale.
+ * JPY has no minor unit, so `amount_cents` is whole yen (see naming-conventions).
+ * Returns an em dash for null (document carries no monetary value).
+ */
+export function formatJpy(cents: number | null, locale: SupportedLocale): string {
+  if (cents === null) {
+    return EM_DASH;
+  }
+
+  return new Intl.NumberFormat(INTL_LOCALE[locale], {
+    style: 'currency',
+    currency: 'JPY',
+  }).format(cents);
+}
+
+/**
+ * Format an ISO date string (YYYY-MM-DD) for display. The statutory date itself
+ * is locale-neutral (ISO), so this returns it verbatim, with an em dash for null.
+ */
+export function formatDate(date: string | null): string {
+  return date ?? EM_DASH;
+}
+
+/**
+ * Format an ISO 8601 timestamp as a locale-aware date-time for display.
+ * Falls back to a trimmed ISO string if the value cannot be parsed.
+ */
+export function formatDateTime(iso: string | null | undefined, locale: SupportedLocale): string {
+  if (iso === null || iso === undefined || iso === '') {
+    return EM_DASH;
+  }
+
+  const parsed = new Date(iso);
+  if (Number.isNaN(parsed.getTime())) {
+    // Defensive fallback: show the raw value trimmed to minutes.
+    return iso.slice(0, 16).replace('T', ' ');
+  }
+
+  return new Intl.DateTimeFormat(INTL_LOCALE[locale], {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(parsed);
+}

--- a/locales/en.json
+++ b/locales/en.json
@@ -478,7 +478,13 @@
     "org_not_found": "Organization not found.",
     "org_inactive": "This organization is currently inactive.",
     "internal_server_error": "A server error occurred. Please try again later.",
-    "invalid_credentials": "The email or password is incorrect."
+    "invalid_credentials": "The email or password is incorrect.",
+    "invalid_document_state": "This action cannot be performed in the document's current state.",
+    "cannot_delete_self": "You cannot delete your own account.",
+    "invalid_user_role": "The specified role is invalid.",
+    "user_not_found": "The specified user was not found.",
+    "user_email_conflict": "This email address is already in use.",
+    "ocr_failed": "OCR could not be run. Check the server configuration."
   },
 
   "compliance": {

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -478,7 +478,13 @@
     "org_not_found": "組織が見つかりません。",
     "org_inactive": "この組織は現在無効です。",
     "internal_server_error": "サーバーエラーが発生しました。しばらく後にもう一度お試しください。",
-    "invalid_credentials": "メールアドレスまたはパスワードが正しくありません。"
+    "invalid_credentials": "メールアドレスまたはパスワードが正しくありません。",
+    "invalid_document_state": "現在の状態ではこの操作を実行できません。",
+    "cannot_delete_self": "自分自身のアカウントは削除できません。",
+    "invalid_user_role": "指定された権限が正しくありません。",
+    "user_not_found": "指定されたユーザーが見つかりません。",
+    "user_email_conflict": "このメールアドレスは既に使用されています。",
+    "ocr_failed": "OCR の実行に失敗しました。サーバーの設定を確認してください。"
   },
 
   "compliance": {

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -24,6 +24,7 @@ use NeneVault\Document\VaultDocumentNotFoundExceptionHandler;
 use NeneVault\Export\ExportRouteRegistrar;
 use NeneVault\Export\ExportServiceProvider;
 use NeneVault\Http\HealthHandler;
+use NeneVault\Ocr\OcrExceptionHandler;
 use NeneVault\Ocr\OcrRouteRegistrar;
 use NeneVault\Ocr\OcrServiceProvider;
 use NeneVault\Organization\OrganizationNotFoundExceptionHandler;
@@ -165,6 +166,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $c->get(UserEmailConflictExceptionHandler::class),
                     $c->get(InvalidUserRoleExceptionHandler::class),
                     $c->get(CannotDeleteSelfExceptionHandler::class),
+                    $c->get(OcrExceptionHandler::class),
                 ];
             },
         );

--- a/src/Ocr/OcrExceptionHandler.php
+++ b/src/Ocr/OcrExceptionHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Ocr;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class OcrExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $e): bool
+    {
+        return $e instanceof OcrException;
+    }
+
+    public function handle(Throwable $e, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'ocr-failed', 'OCR Failed', 422, $e->getMessage());
+    }
+}

--- a/src/Ocr/OcrServiceProvider.php
+++ b/src/Ocr/OcrServiceProvider.php
@@ -7,6 +7,7 @@ namespace NeneVault\Ocr;
 use LogicException;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use NeneVault\Document\VaultDocumentRepositoryInterface;
 use NeneVault\DocumentVersion\DocumentStorageInterface;
@@ -90,6 +91,18 @@ final readonly class OcrServiceProvider implements ServiceProviderInterface
                     }
 
                     return new OcrRouteRegistrar($h);
+                },
+            )
+            ->set(
+                OcrExceptionHandler::class,
+                static function (ContainerInterface $c): OcrExceptionHandler {
+                    $pd = $c->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$pd instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('ProblemDetailsResponseFactory service is invalid.');
+                    }
+
+                    return new OcrExceptionHandler($pd);
                 },
             );
     }

--- a/src/Ocr/OcrSuggestHandler.php
+++ b/src/Ocr/OcrSuggestHandler.php
@@ -25,14 +25,9 @@ final readonly class OcrSuggestHandler
         $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
         $documentId = (string) ($params['id'] ?? '');
 
-        try {
-            $suggestion = $this->useCase->execute($documentId, $orgId);
-        } catch (OcrException $e) {
-            return $this->response->create(
-                ['error' => 'ocr_failed', 'message' => $e->getMessage()],
-                422,
-            );
-        }
+        // OcrException (→ 422) and VaultDocumentNotFoundException (→ 404) propagate
+        // to their registered domain exception handlers, which emit Problem Details.
+        $suggestion = $this->useCase->execute($documentId, $orgId);
 
         return $this->response->create([
             'document_id'      => $documentId,

--- a/tests/Ocr/OcrSuggestApiTest.php
+++ b/tests/Ocr/OcrSuggestApiTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Tests\Ocr;
+
+use NeneVault\Tests\Support\ApiTestCase;
+
+/**
+ * HTTP-level tests for GET /admin/vault/documents/{id}/ocr-suggest.
+ *
+ * OCR failures and not-found cases are surfaced as Problem Details via the
+ * registered domain exception handlers (no bespoke JSON error shape).
+ */
+final class OcrSuggestApiTest extends ApiTestCase
+{
+    private static string $adminToken = '';
+    private static int    $orgId      = 0;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::bootContainer();
+        self::$orgId      = self::ensureOrg('test-org');
+        self::$adminToken = self::issueToken('admin', self::$orgId, userId: 190);
+    }
+
+    public function test_unknown_document_returns_404_problem_details(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request('GET', '/admin/vault/documents/00000000000000000000000000/ocr-suggest', self::$adminToken),
+        );
+
+        $this->assertSame(404, $resp->getStatusCode());
+        $this->assertStringContainsString('application/problem+json', $resp->getHeaderLine('Content-Type'));
+        $body = json_decode((string) $resp->getBody(), true);
+        $this->assertStringContainsString('document-not-found', (string) $body['type']);
+    }
+
+    public function test_unauthenticated_returns_401(): void
+    {
+        $resp = $this->handler()->handle(
+            $this->request('GET', '/admin/vault/documents/00000000000000000000000000/ocr-suggest'),
+        );
+        $this->assertSame(401, $resp->getStatusCode());
+    }
+
+    public function test_ocr_failure_returns_422_problem_details_when_tesseract_unavailable(): void
+    {
+        // Upload a real document, then request OCR. In the test environment Tesseract
+        // is typically not installed, so the extractor throws OcrException → 422
+        // Problem Details. If Tesseract *is* present, the call succeeds (200); either
+        // way the response must be a documented shape, never a 500.
+        $id   = $this->uploadDoc($this->handler(), self::$adminToken, 'OcrProbe', '2026-01-01', '1000');
+        $resp = $this->handler()->handle(
+            $this->request('GET', "/admin/vault/documents/{$id}/ocr-suggest", self::$adminToken),
+        );
+
+        $status = $resp->getStatusCode();
+        $this->assertContains($status, [200, 422], 'OCR endpoint must return 200 or a 422 Problem Details, never 500');
+
+        if ($status === 422) {
+            $this->assertStringContainsString('application/problem+json', $resp->getHeaderLine('Content-Type'));
+            $body = json_decode((string) $resp->getBody(), true);
+            $this->assertStringContainsString('ocr-failed', (string) $body['type']);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Audited the running app for places where ja/en switching didn't fully apply, and routed all display text through the catalog + active locale.

## Gaps closed

**1. Unmapped error messages** — 6 backend Problem Details slugs weren't in the frontend map, so they fell back to a generic message (and leaked English):
`invalid-document-state`, `cannot-delete-self`, `invalid-user-role`, `user-not-found`, `user-email-conflict`, `ocr-failed`. Added mappings + `problem.*` keys (ja + en).

**2. Hardcoded `ja-JP` currency** — DocumentTable & DocumentDetailPage formatted JPY in Japanese regardless of locale. New `shared/lib/format.ts` (`formatJpy`) follows the active locale.

**3. Raw audit action codes** — AuditPage & DocumentHistoryTable showed `document.uploaded` etc. literally. Now use the existing `audit_event.action.*` labels.

**4. Hand-rolled date formatting** — `.slice(0,16).replace('T',' ')` in 4 components → shared `formatDateTime` / `formatDate` (locale-aware, null-safe).

**5. OCR error shape** — returned bespoke `{error,message}` JSON; now a proper Problem Details (`ocr-failed` 422) via a new `OcrExceptionHandler`, so it localizes like every other error.

## New
- `shared/lib/format.ts` + `format.test.ts` (locale-aware formatters)
- `src/Ocr/OcrExceptionHandler.php`
- `tests/Ocr/OcrSuggestApiTest.php`

## Test plan
- [x] `composer check` — 287 tests, PHPStan L8, CS, locales (354/354), OpenAPI, MCP ✅
- [x] `npm run check --prefix frontend` — 175 tests, type-check, lint, build ✅
- [x] Live: restarted backend; unknown-doc OCR/restore return correct Problem Details (no 500)

Closes #85
🤖 Generated with [Claude Code](https://claude.com/claude-code)