### PR TITLE
fix(i18n): make metadata-edit + search form labels bilingual in English mode (#87)

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -268,7 +268,7 @@
       "date_to_label": "取引年月日 (To)",
       "amount_min_label": "取引金額 (Min)",
       "amount_max_label": "取引金額 (Max)",
-      "counterparty_label": "取引先名",
+      "counterparty_label": "取引先名 (Counterparty)",
       "category_label": "Category",
       "include_voided_label": "Include voided",
       "search_button": "Search",
@@ -290,9 +290,9 @@
       "metadata_unconfirmed_badge": "Metadata unconfirmed"
     },
     "metadata": {
-      "transaction_date": "取引年月日",
-      "amount_cents": "取引金額",
-      "counterparty_name": "取引先名",
+      "transaction_date": "取引年月日 (Transaction Date)",
+      "amount_cents": "取引金額 (Amount, JPY)",
+      "counterparty_name": "取引先名 (Counterparty)",
       "category": "Category",
       "tags": "Tags",
       "source": "Source",


### PR DESCRIPTION
## Summary

Some form labels weren't bilingual in English mode. The upload/export forms (and date/amount in search) show `取引年月日 (Transaction Date)` etc., but:

- **Metadata edit form** showed pure Japanese (取引年月日 / 取引金額 / 取引先名)
- **Search form** counterparty label was pure Japanese while date/amount in the *same form* were bilingual

## Fix

`en.json` only — align all form input labels to the existing bilingual convention (Japanese statutory term + English gloss):

| Key | Before | After |
|---|---|---|
| `document.metadata.transaction_date` | 取引年月日 | 取引年月日 (Transaction Date) |
| `document.metadata.amount_cents` | 取引金額 | 取引金額 (Amount, JPY) |
| `document.metadata.counterparty_name` | 取引先名 | 取引先名 (Counterparty) |
| `document.search.counterparty_label` | 取引先名 | 取引先名 (Counterparty) |

`ja.json` unchanged (pure Japanese is correct there). ADR 0005's statutory Japanese term is preserved in both locales. Compact display surfaces (list table headers, manifest column names) intentionally stay pure Japanese.

## Test plan
- [x] `composer locales` — 354/354 keys consistent
- [x] `npm run check --prefix frontend` — 175 tests green
- [x] Audited every form-label namespace in en.json — no remaining JP-only labels

Closes #87
🤖 Generated with [Claude Code](https://claude.com/claude-code)