### PR TITLE
fix(i18n): statutory field labels render in English in English mode (revise ADR 0005) (#89)

### DIFF
--- a/docs/adr/0005-ui-language-scope-ja-en.md
+++ b/docs/adr/0005-ui-language-scope-ja-en.md
@@ -47,8 +47,12 @@ NeNe Vault admin UI and operator-facing materials support
   third locale will be rejected at review with a pointer to this ADR.
 - **Language selector:** toggle ja / en in admin UI; default resolves from
   browser `Accept-Language` header with `ja` as fallback.
-- **Statutory field labels** (e.g. 取引年月日, 取引金額, 取引先) appear in
-  Japanese in both locales where legally traceable terminology is required.
+- **Statutory field labels** (取引年月日, 取引金額, 取引先名) render in the active
+  locale: Japanese in `ja` mode, plain English in `en` mode
+  (Transaction Date, Amount, Counterparty). See "Revision 2026-05-31" below.
+  The legally-traceable Japanese terminology is preserved in the `ja` catalog,
+  in the export manifest's canonical mapping, and in compliance documentation —
+  the UI label is a display concern and follows the selected locale.
 
 This restriction applies to the upstream repository only. The MIT licence permits
 operators or forks to add additional locales; the upstream project will not
@@ -71,6 +75,23 @@ maintain them.
   statutory labels.
 - Future jurisdiction expansion (e.g. a Taiwan edition) would require a fork
   or a separate product, not an i18n flag in this repository.
+
+## Revision 2026-05-31 — statutory labels follow the active locale
+
+The original decision required statutory field labels to appear in Japanese in
+**both** locales. In practice this left English-mode forms (search, upload,
+metadata edit) showing Japanese-led labels, which read as "untranslated" to
+English operators.
+
+**Revised rule:** statutory field labels render in the active locale —
+Japanese in `ja` mode, plain English in `en` mode. The legally-traceable
+Japanese terminology is not lost: it remains the canonical form in the `ja`
+catalog, in `docs/terms.md`, in the compliance documentation, and in the export
+manifest's column semantics. The on-screen label is a display concern and must
+follow the operator's selected language, consistent with the rest of the UI.
+
+This does not weaken compliance: the statutory mapping lives in the data layer
+and documentation, not in the UI label text.
 
 ## Related
 

--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -91,7 +91,7 @@ Any change that touches **document storage, file serving, search, metadata editi
 - **No hard-coded operator-facing text** in frontend components. Every UI string lives in `locales/ja.json` and `locales/en.json`, looked up by key.
 - Both locale files **MUST** have an identical key structure — enforced by `composer locales`. A missing key blocks merge.
 - Only `ja` and `en` locales exist (ADR 0005). Do not add a third.
-- Statutory field labels (取引年月日, 取引金額, 取引先名) stay Japanese in both locales.
+- Statutory field labels (取引年月日, 取引金額, 取引先名) follow the active locale: Japanese in `ja`, plain English in `en` (Transaction Date / Amount / Counterparty). The Japanese terminology is preserved in the `ja` catalog, `docs/terms.md`, and export manifest semantics (ADR 0005, revised 2026-05-31).
 - API Problem Details responses stay English (ADR 0008); the `problem.*` locale keys translate them for display only.
 - See [`locale-guide.md`](./locale-guide.md).
 

--- a/docs/development/frontend-standards.md
+++ b/docs/development/frontend-standards.md
@@ -363,7 +363,10 @@ Rules: **no hardcoded user-facing strings** — use `t('document.list.title')`. 
 follow `docs/development/locale-guide.md` (namespaces: `common`, `auth`,
 `navigation`, `document`, …). `ja` is default; detection order
 `localStorage['nene-vault.locale']` → `navigator.language` → `ja`. Statutory labels
-(取引年月日, 取引金額, 取引先名) stay Japanese in both locales. Missing key renders
+(取引年月日, 取引金額, 取引先名) follow the active locale — Japanese in `ja`, plain
+English in `en` (Transaction Date / Amount / Counterparty); the Japanese term is
+preserved in the `ja` catalog, `docs/terms.md`, and export manifest semantics
+(ADR 0005, revised 2026-05-31). Missing key renders
 the key (visible, not blank). `{{name}}` interpolation. Adding a string updates
 **both** `locales/*.json` (enforced by `composer locales`).
 

--- a/docs/development/locale-guide.md
+++ b/docs/development/locale-guide.md
@@ -50,10 +50,12 @@ composer locales        # runs tools/validate-locales.php
 
 ## Rules
 
-1. **Statutory field labels stay Japanese in both locales.** 取引年月日, 取引金額,
-   取引先名 appear in Japanese even in `en.json` — they are legally traceable
-   terms (ADR 0005, ADR 0008). The English file may add a parenthetical gloss,
-   e.g. `"取引年月日 (Transaction Date)"`.
+1. **Statutory field labels follow the active locale** (ADR 0005, revised
+   2026-05-31). 取引年月日 / 取引金額 / 取引先名 stay Japanese in `ja.json`, and
+   render as plain English in `en.json` — "Transaction Date", "Amount (JPY)",
+   "Counterparty". The legally-traceable Japanese terminology is preserved in the
+   `ja` catalog, `docs/terms.md`, and the export manifest semantics; the UI label
+   is a display concern that follows the selected language.
 
 2. **API stays English.** Problem Details responses from the API are English
    (ADR 0008). The `problem.*` keys translate those for display only — they do

--- a/docs/review/frontend.md
+++ b/docs/review/frontend.md
@@ -49,7 +49,7 @@ Violations of placement / dependency / data-flow / security / styling / testing
 
 - [ ] No hardcoded operator-facing strings — all via `t(key)`.
 - [ ] New keys added to **both** `locales/ja.json` and `locales/en.json` (`composer locales` green).
-- [ ] Statutory labels (取引年月日, 取引金額, 取引先名) stay Japanese in both locales.
+- [ ] Statutory labels (取引年月日, 取引金額, 取引先名) follow the active locale — Japanese in `ja`, plain English in `en` (ADR 0005, revised 2026-05-31).
 - [ ] No third locale introduced.
 
 ## API & security

--- a/locales/en.json
+++ b/locales/en.json
@@ -5,7 +5,6 @@
     "direction": "ltr",
     "note": "Secondary locale. Statutory field labels remain in Japanese in both locales (ADR 0005)."
   },
-
   "common": {
     "buttons": {
       "save": "Save",
@@ -65,7 +64,6 @@
     "no": "No",
     "none": "None"
   },
-
   "auth": {
     "login": {
       "title": "NeNe Vault Login",
@@ -88,7 +86,6 @@
       "account_inactive": "This account is inactive. Please contact your administrator."
     }
   },
-
   "navigation": {
     "home": "Home",
     "documents": "Received Documents",
@@ -100,7 +97,6 @@
     "logout": "Log Out",
     "language": "Language"
   },
-
   "organization": {
     "list": {
       "title": "Organizations",
@@ -151,7 +147,6 @@
       "not_found": "The specified organization was not found."
     }
   },
-
   "user": {
     "list": {
       "title": "Users",
@@ -202,15 +197,14 @@
       "cannot_delete_self": "You cannot delete your own account."
     }
   },
-
   "vault_settings": {
     "title": "Vault Settings",
     "save_button": "Save Settings",
     "fields": {
       "retention_years_label": "Retention Period (years)",
       "retention_years_hint": "Number of years to retain documents (counted from the transaction date). 10 years or more is recommended to satisfy the Electronic Books Preservation Act.",
-      "retention_warning": "The retention period is below 10 years. It may not satisfy the statutory retention period (7 years from the filing deadline). Please confirm with your 税理士.",
-      "retention_min_hint": "Minimum: 7 years (税理士 confirmation required)",
+      "retention_warning": "The retention period is below 10 years. It may not satisfy the statutory retention period (7 years from the filing deadline). Please confirm with your tax advisor (税理士).",
+      "retention_min_hint": "Minimum: 7 years (tax advisor confirmation required)",
       "storage_path_label": "Storage Path (override)",
       "storage_path_placeholder": "/var/vault/storage",
       "storage_path_hint": "Leave blank to use the default path",
@@ -224,15 +218,14 @@
       "saved": "Vault settings saved."
     }
   },
-
   "document": {
     "list": {
       "title": "Received Documents",
       "upload_button": "Upload Document",
       "table": {
-        "transaction_date": "取引年月日",
-        "amount": "取引金額",
-        "counterparty_name": "取引先名",
+        "transaction_date": "Transaction Date",
+        "amount": "Amount (JPY)",
+        "counterparty_name": "Counterparty",
         "category": "Category",
         "status": "Status",
         "uploaded_at": "Uploaded",
@@ -247,28 +240,28 @@
       "file_label": "Select File",
       "file_hint": "PDF, JPEG, PNG (max {{max_size_mb}} MB)",
       "file_drag": "Drop file here",
-      "transaction_date_label": "取引年月日 (Transaction Date)",
+      "transaction_date_label": "Transaction Date",
       "transaction_date_placeholder": "e.g. 2026-03-31",
       "transaction_date_hint": "The transaction date stated on the document",
-      "amount_label": "取引金額 (Amount, JPY)",
+      "amount_label": "Amount (JPY)",
       "amount_placeholder": "e.g. 110000",
       "amount_hint": "Leave blank if not stated",
-      "counterparty_label": "取引先名 (Counterparty)",
+      "counterparty_label": "Counterparty",
       "counterparty_placeholder": "e.g. Sample Inc.",
       "category_label": "Category",
       "tags_label": "Tags",
       "tags_placeholder": "Enter tags separated by commas",
       "submit": "Upload",
-      "scan_warning": "Scanned documents are subject to different \"scanner preservation\" (スキャナ保存) requirements. Please confirm with your 税理士.",
+      "scan_warning": "Scanned documents are subject to different scanner preservation (スキャナ保存) requirements. Please confirm with your tax advisor (税理士).",
       "duplicate_warning": "An identical file has already been uploaded. Upload as a duplicate?"
     },
     "search": {
       "title": "Search Documents",
-      "date_from_label": "取引年月日 (From)",
-      "date_to_label": "取引年月日 (To)",
-      "amount_min_label": "取引金額 (Min)",
-      "amount_max_label": "取引金額 (Max)",
-      "counterparty_label": "取引先名 (Counterparty)",
+      "date_from_label": "Transaction Date (From)",
+      "date_to_label": "Transaction Date (To)",
+      "amount_min_label": "Amount (Min)",
+      "amount_max_label": "Amount (Max)",
+      "counterparty_label": "Counterparty",
       "category_label": "Category",
       "include_voided_label": "Include voided",
       "search_button": "Search",
@@ -290,9 +283,9 @@
       "metadata_unconfirmed_badge": "Metadata unconfirmed"
     },
     "metadata": {
-      "transaction_date": "取引年月日 (Transaction Date)",
-      "amount_cents": "取引金額 (Amount, JPY)",
-      "counterparty_name": "取引先名 (Counterparty)",
+      "transaction_date": "Transaction Date",
+      "amount_cents": "Amount (JPY)",
+      "counterparty_name": "Counterparty",
       "category": "Category",
       "tags": "Tags",
       "source": "Source",
@@ -367,7 +360,6 @@
       "restored": "Document restored."
     }
   },
-
   "audit_event": {
     "list": {
       "title": "Audit Log",
@@ -415,14 +407,13 @@
       "document_link": "Linked Record"
     }
   },
-
   "export": {
     "title": "Export Documents",
     "description": "Download documents for a date range as a ZIP file and a manifest CSV.",
     "form": {
-      "date_from_label": "取引年月日 (From)",
-      "date_to_label": "取引年月日 (To)",
-      "counterparty_label": "取引先名 (Filter)",
+      "date_from_label": "Transaction Date (From)",
+      "date_to_label": "Transaction Date (To)",
+      "counterparty_label": "Counterparty (Filter)",
       "include_voided_label": "Include voided",
       "format_label": "Output format",
       "format_zip": "ZIP (document files + manifest)",
@@ -433,9 +424,9 @@
       "title": "Export File Contents",
       "document_id": "Document ID",
       "version": "Version",
-      "transaction_date": "取引年月日",
+      "transaction_date": "Transaction Date",
       "amount_cents": "Amount (integer JPY)",
-      "counterparty_name": "取引先名",
+      "counterparty_name": "Counterparty",
       "category": "Category",
       "file_sha256": "SHA-256",
       "uploaded_at": "Uploaded",
@@ -447,7 +438,6 @@
       "downloaded": "Downloaded."
     }
   },
-
   "validation": {
     "required": "This field is required.",
     "invalid_format": "The format is invalid.",
@@ -461,7 +451,6 @@
     "file_too_large": "The file size exceeds the limit.",
     "duplicate_file": "An identical file is already registered."
   },
-
   "problem": {
     "unauthorized": "Authentication is required. Please log in.",
     "forbidden": "You do not have permission to perform this action.",
@@ -486,15 +475,14 @@
     "user_email_conflict": "This email address is already in use.",
     "ocr_failed": "OCR could not be run. Check the server configuration."
   },
-
   "compliance": {
     "scanner_warning": {
       "title": "Note on Scanner Preservation",
-      "body": "This file appears to be a scanned document. Scanner preservation (スキャナ保存) may be subject to different legal requirements than electronic transaction data. Please confirm with your 税理士."
+      "body": "This file appears to be a scanned document. Scanner preservation (スキャナ保存) may be subject to different legal requirements than electronic transaction data. Please confirm with your tax advisor (税理士)."
     },
     "retention_short_warning": {
       "title": "Please Review Your Retention Setting",
-      "body": "The retention period is below 10 years. It may fall short of the statutory retention period (7 years from the day after the filing deadline). Please confirm with your 税理士 before saving."
+      "body": "The retention period is below 10 years. It may fall short of the statutory retention period (7 years from the day after the filing deadline). Please confirm with your tax advisor (税理士) before saving."
     },
     "date_uncertain_warning": {
       "title": "Transaction Date Not Set",


### PR DESCRIPTION
## Summary

The "Received Documents" forms (search / upload / metadata edit) still showed Japanese-led labels in English mode. Per product-owner decision, statutory field labels now render in **plain English** in English mode.

| Field | JA mode | EN mode (before) | EN mode (after) |
|---|---|---|---|
| transaction_date | 取引年月日 | 取引年月日 (Transaction Date) | **Transaction Date** |
| amount | 取引金額 | 取引金額 (Amount, JPY) | **Amount (JPY)** |
| counterparty | 取引先名 | 取引先名 (Counterparty) | **Counterparty** |

Applied across search, upload, metadata edit, list-table headers, and export form + manifest. `ja.json` unchanged. Warning prose's terms of art converted to English-with-gloss (`tax advisor (税理士)`, `scanner preservation (スキャナ保存)`).

## Governance (revises ADR 0005)

ADR 0005 previously required statutory labels to stay Japanese in both locales. Revised: labels follow the active locale. The legally-traceable Japanese term is preserved in the `ja` catalog, `docs/terms.md`, compliance docs, and the export manifest semantics — the UI label is a display concern, so **compliance is unaffected**. Updated:
- `docs/adr/0005-ui-language-scope-ja-en.md` (rule + "Revision 2026-05-31")
- `coding-standards.md`, `frontend-standards.md`, `locale-guide.md`, `docs/review/frontend.md`

## Test plan
- [x] `composer locales` — 354/354 consistent
- [x] `composer openapi` — valid
- [x] `npm run check --prefix frontend` — 175 tests green
- [x] Re-audited en.json — no Japanese remains in field labels (only 税理士/スキャナ保存 glosses in prose)

Closes #89
🤖 Generated with [Claude Code](https://claude.com/claude-code)