### PR TITLE
fix(i18n): native date picker follows language — sync <html lang> on mount (#91)

### DIFF
--- a/frontend/src/shared/i18n/i18n-context.test.tsx
+++ b/frontend/src/shared/i18n/i18n-context.test.tsx
@@ -1,0 +1,71 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { useContext } from 'react';
+import { I18nProvider } from './i18n-context';
+import { I18nContext } from './context';
+
+const STORAGE_KEY = 'nene-vault.locale';
+
+function LocaleProbe() {
+  const ctx = useContext(I18nContext);
+  if (ctx === null) throw new Error('no context');
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        ctx.setLocale(ctx.locale === 'ja' ? 'en' : 'ja');
+      }}
+    >
+      {ctx.locale}
+    </button>
+  );
+}
+
+describe('I18nProvider <html lang> sync', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.lang = 'ja';
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('syncs <html lang> to the resolved initial locale on mount (en)', () => {
+    localStorage.setItem(STORAGE_KEY, 'en');
+    render(
+      <I18nProvider>
+        <LocaleProbe />
+      </I18nProvider>,
+    );
+    expect(document.documentElement.lang).toBe('en');
+    expect(screen.getByRole('button')).toHaveTextContent('en');
+  });
+
+  it('syncs <html lang> to ja when the initial locale is ja', () => {
+    localStorage.setItem(STORAGE_KEY, 'ja');
+    render(
+      <I18nProvider>
+        <LocaleProbe />
+      </I18nProvider>,
+    );
+    expect(document.documentElement.lang).toBe('ja');
+  });
+
+  it('updates <html lang> when the locale changes', () => {
+    localStorage.setItem(STORAGE_KEY, 'ja');
+    render(
+      <I18nProvider>
+        <LocaleProbe />
+      </I18nProvider>,
+    );
+    expect(document.documentElement.lang).toBe('ja');
+
+    act(() => {
+      screen.getByRole('button').click();
+    });
+
+    expect(document.documentElement.lang).toBe('en');
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('en');
+  });
+});

--- a/frontend/src/shared/i18n/i18n-context.tsx
+++ b/frontend/src/shared/i18n/i18n-context.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
 import { persistLocale, resolveInitialLocale, type SupportedLocale } from './locales';
 import { translate, type TranslateParams } from './translate';
 import { I18nContext } from './context';
@@ -6,9 +6,15 @@ import { I18nContext } from './context';
 export function I18nProvider({ children }: { children: ReactNode }) {
   const [locale, setLocaleState] = useState<SupportedLocale>(resolveInitialLocale);
 
+  // Keep <html lang> in sync with the active locale so native browser widgets
+  // (e.g. the type="date" picker placeholder 年/月/日 vs mm/dd/yyyy) follow the
+  // selected language — including on first mount, not only on toggle.
+  useEffect(() => {
+    document.documentElement.lang = locale;
+  }, [locale]);
+
   const setLocale = useCallback((next: SupportedLocale) => {
     persistLocale(next);
-    document.documentElement.lang = next;
     setLocaleState(next);
   }, []);
 


### PR DESCRIPTION
## Summary

In English mode the native date picker still showed the Japanese format placeholder (年/月/日). Native browser controls read the nearest `lang` attribute; `I18nProvider` only set `document.documentElement.lang` on **toggle**, never on initial mount, and `index.html` is hardcoded `lang="ja"`. So an English-mode user saw Japanese date fields until they manually re-toggled the language.

## Fix

- `I18nProvider`: sync `document.documentElement.lang` via `useEffect` keyed on `locale` → applies on initial mount **and** on change.
- Removed the now-redundant assignment in `setLocale`.
- `i18n-context.test.tsx`: 3 tests (lang sync on mount en / mount ja / on toggle).

## Test plan
- [x] `npm run check --prefix frontend` — 178 tests (25 files), type-check, lint, build green

Closes #91
🤖 Generated with [Claude Code](https://claude.com/claude-code)