### PR TITLE
docs(compliance): Review 3 pre-prod gate package + sync todo with completed roadmap (#95)

### DIFF
--- a/docs/compliance-review/2026-review-3-preprod-package.md
+++ b/docs/compliance-review/2026-review-3-preprod-package.md
@@ -1,0 +1,164 @@
+# Review 3 Package — Pre-Production Final Verification (NeNe Vault, 2026)
+
+**For:** the licensed 税理士 / 公認会計士 who recorded Review 2
+(辻村 拓也 / 辻村総合会計事務所, 2026-05-31) — or an equivalent licensed
+professional — to complete the **pre-production go-live gate**.
+
+**Why this package exists:** Review 2 **approved** development and test-environment
+implementation, but attached a condition (`signoff-record.md` → Review 2 §Conditions):
+
+> 本番環境への移行（プロダクションリリース）承認の前提として、テスト環境での
+> 計算結果および出力帳票サンプルの最終検証を別途実施すること。→ 本番リリース前に
+> Review 3 を追加すること。
+
+This package supplies that test-environment evidence so Review 3 can be recorded.
+Review 1/2 already confirmed the **posture**; Review 3 verifies the **actual
+outputs** a tax inspection would see.
+
+> **Not legal advice.** Engineering's interpretation of 電子帳簿保存法 for received
+> 電子取引データ. We ask you to confirm the produced samples are defensible for
+> a 税務調査 handoff and record the decision in `signoff-record.md` (Review 3 block).
+
+**Binding source of truth:** [`received-document-compliance.md`](../explanation/received-document-compliance.md).
+**Posture mapping (already reviewed):** [`2026-tax-advisor-review-package.md`](./2026-tax-advisor-review-package.md).
+
+---
+
+## 1. What changed since Review 2
+
+Nothing in the compliance posture. Review 2 reviewed the design; since then the
+ecosystem features shipped (MCP read/write tools, S3 storage adapter, email
+inbound, OCR assist — all Phase 4) **without altering** integrity, search,
+retention, audit, or export behavior. OCR remains suggest-only with human
+confirmation (compliance §8). This Review 3 is therefore an **output verification**,
+not a re-review of design.
+
+State of the build at package date: `composer check` and
+`npm run check --prefix frontend` both green (287 backend tests, full frontend
+suite, PHPStan 0 errors, locale + OpenAPI + MCP catalogs valid).
+
+---
+
+## 2. Condition 1 — Test-environment output samples to verify
+
+Generate these from a seeded test environment and attach them (or regenerate
+live) when recording Review 3. Commands assume `docker compose up` (API :8600).
+
+### 2.1 Manifest CSV (`POST /admin/vault/export`, `format=csv`)
+
+Column order is fixed in code (`ExportDocumentsUseCase::MANIFEST_HEADER`):
+
+```
+document_id,version,transaction_date,amount_cents,counterparty_name,category,file_sha256,uploaded_at,voided_at
+```
+
+| Column | Meaning | Verify against |
+| --- | --- | --- |
+| `document_id` | Stable document identifier | `vault_documents.id` |
+| `version` | Version number of the served file | `document_versions.version_number` |
+| `transaction_date` | 取引年月日 (ISO date) | metadata |
+| `amount_cents` | 取引金額 in integer JPY (no decimals; JPY has none) | metadata |
+| `counterparty_name` | 取引先名 | metadata |
+| `category` | Document category | metadata |
+| `file_sha256` | Integrity hash of the served version | `document_versions.file_sha256` |
+| `uploaded_at` | Provenance timestamp | `document_versions` |
+| `voided_at` | Non-empty ⇒ logically deleted (void), not erased | `vault_documents.voided_at` |
+
+**To confirm:** that these columns are sufficient for a 税務調査 handoff
+(this was Review 2 Q5; Review 3 confirms it against a real exported file, not the
+spec). No storage path or secret appears in any column (hard rule).
+
+### 2.2 Export ZIP (`format=zip`)
+
+Structure produced by `ExportDocumentsUseCase::buildZip`:
+
+```
+manifest.csv
+files/{document_id}/v{version_number}/{stored_filename}
+```
+
+The same `manifest.csv` as §2.1, plus each document's original-format bytes.
+**To confirm:** opening the ZIP, the manifest rows map 1:1 to the files under
+`files/`, and each file opens in its original format (見読可能性 / legibility).
+
+### 2.3 Retention dates (ADR 0004 — the "計算結果" in Condition 1)
+
+The only date Vault *computes* is `retention_expires_at`. Verify the anchor and
+default against ADR 0004 with at least these cases:
+
+| Case | transaction_date | Expected `retention_expires_at` | Note |
+| --- | --- | --- | --- |
+| Calendar-year, mid-Jan | 2024-01-15 | 2034-01-15 | 10y from transaction date — covers the 7y-from-filing-deadline minimum |
+| Late-December | 2024-12-28 | 2034-12-28 | safe-side margin smaller but still ≥ statutory |
+| Unknown date | (none) | 10y from `uploaded_at`, flagged `date_uncertain` | compliance §5.3 |
+
+**To confirm:** the 10-year-from-transaction-date default (Review 2 Q2, "妥当"
+in test environment) holds in the produced data, and `date_uncertain` is flagged
+where the transaction date is unknown.
+
+### 2.4 Integrity round-trip (SHA-256)
+
+Download a version via `GET …/versions/{versionId}/download` and confirm the
+served bytes hash to the `file_sha256` shown in the manifest. The download path
+verifies the hash **before** serving (`DownloadDocumentVersionUseCase`); a
+mismatch must fail closed.
+
+### 2.5 Correction-history evidence (void + metadata change)
+
+For one sample document, produce: an edit of 取引金額/取引先, then a void, then a
+restore. Export the audit trail (`listVaultAuditEvents` / audit UI) and confirm
+each mutation carries before/after and actor/timestamp, and that the document is
+never hard-deleted within retention (訂正削除の履歴, 規則 第4条第1項第2号).
+
+---
+
+## 3. Condition 2 — Master-setting flexibility for law changes
+
+Review 2 condition 2: keep logic changeable via master settings so 電帳法 / 国税庁
+告示 changes can be absorbed without code surgery, and add a re-review block on
+any such change.
+
+**To confirm:** the retention anchor/period (ADR 0004) and the gate process
+(`signoff-record.md` "Process notes": any 電帳法 amendment is treated as a **P0**
+re-review) are documented and operable. Note for the reviewer: the retention
+default is currently a code-level constant per ADR 0004 — if you require it to be
+an operator-editable master setting before go-live, record that as a Review 3
+condition and we will open an Issue + ADR.
+
+---
+
+## 4. How to record the decision
+
+Append a **Review 3** block to
+[`signoff-record.md`](./signoff-record.md) using the template there:
+
+- Decision: **Approved** ⇒ go-live gate closes; operators may run in production.
+- **Approved with conditions** ⇒ list each as a checkbox + open an Issue; any
+  deviation from the compliance doc needs an ADR with this sign-off (compliance §0.2).
+- **Changes required** ⇒ production stays blocked.
+
+Then update the "Review status" table in `signoff-record.md` and check off the
+**税理士 Review 3** item in [`../todo/current.md`](../todo/current.md).
+
+---
+
+## 5. Open questions for Review 3
+
+- Are the manifest columns (§2.1) and ZIP layout (§2.2) what you would hand an
+  inspector unchanged, or do you want additional columns (e.g. document source,
+  `date_uncertain` flag) surfaced in the CSV?
+- Should `retention_expires_at` become an operator-editable master setting before
+  go-live (§3), or is the ADR 0004 constant acceptable for the first release?
+- Any 電帳法 guidance updates since 2026-05-31 that change the posture?
+
+---
+
+## 6. Verify claims yourself
+
+- Export behavior: `src/Export/ExportDocumentsUseCase.php`; tests
+  `tests/Export/ExportApiTest.php`, `tests/Export/ExportBoundaryTest.php`
+- Retention: [ADR 0004](../adr/0004-retention-period-calculation.md)
+- Integrity/download, void/restore, audit: `tests/Document/`
+- API contract: [`docs/openapi/openapi.yaml`](../openapi/openapi.yaml)
+
+Last updated: 2026-06-01

--- a/docs/compliance-review/README.md
+++ b/docs/compliance-review/README.md
@@ -20,7 +20,8 @@ posture, and the record of their sign-off.
 
 | File | Purpose |
 | --- | --- |
-| `2026-tax-advisor-review-package.md` | The review package: statutory basis → implementation evidence, posture to confirm, known limits, open questions |
+| `2026-tax-advisor-review-package.md` | Review 1/2 package: statutory basis → implementation evidence, posture to confirm, known limits, open questions |
+| `2026-review-3-preprod-package.md` | Review 3 package: pre-production output verification (manifest CSV / ZIP / retention samples) per Review 2's go-live condition |
 | `signoff-record.md` | Sign-off record the professional completes (name, credential, date, findings) |
 
 ## How to use

--- a/docs/compliance-review/signoff-record.md
+++ b/docs/compliance-review/signoff-record.md
@@ -13,10 +13,11 @@ audit trail of the gate itself.
 
 | Field | Value |
 | --- | --- |
-| **Gate status** | 🟢 Approved — licensed professional sign-off recorded (Review 2) |
-| **Package reviewed** | `2026-tax-advisor-review-package.md` |
+| **Gate status** | 🟢 Approved for dev/test (Review 2) · 🔲 **Pre-production Review 3 open** |
+| **Package reviewed** | `2026-tax-advisor-review-package.md` (R1/R2) · `2026-review-3-preprod-package.md` (R3) |
 | **Phase 2 UI development** | ✅ Unblocked by maintainer decision (Review 1) |
-| **Phase 2 UI production ship** | ✅ Unblocked by licensed professional sign-off (Review 2, 2026-05-31) |
+| **Dev / test implementation** | ✅ Unblocked by licensed professional sign-off (Review 2, 2026-05-31) |
+| **Production go-live** | 🔲 Blocked until **Review 3** (pre-prod output verification) is recorded — Review 2 condition |
 
 ---
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,7 @@
 # Current TODO
 
-**Phase 1 — Document API complete; compliance review gate open.**
+**All roadmap phases (0–4) complete; compliance gate approved. Remaining work is the
+pre-production go-live gate (税理士 Review 3) and Tier A live testing.**
 
 ## Done
 
@@ -40,11 +41,26 @@
 - [x] 事務処理規程 template — `docs/operator/jimu-shokirei-template.md` (PR #66)
 - [x] Web installer + release ZIP (Tier A shared hosting) — `install.php` + `tools/build-release.sh` (PR #68)
 
-## Phase 4 — In progress
+## Phase 4 — Done
 
 - [x] MCP read tools — `searchVaultDocuments`, `getVaultDocumentById`, `getVaultDocumentHistory`, `listVaultAuditEvents` (PR #70)
+- [x] MCP write tools + OCR/export integration guide (PR #80)
 - [x] S3-compatible storage adapter — `S3DocumentStorage` + Sig V4, select via `NENE_VAULT_STORAGE_ADAPTER=s3` (PR #72)
 - [x] Optional email inbound (mailbox → auto-upload via IMAP/MIME parser) — `src/Email/` + `tools/email-inbound.php` (PR #74)
 - [x] OCR assist — suggest metadata from PDF/image, human confirm (PR #76)
 
-Last updated: 2026-05-31
+## Go-live gate — Open 🔲
+
+These are the only items between the current (complete, all-green) codebase and
+production use by operators. Both come from Review 2's recorded conditions
+(`docs/compliance-review/signoff-record.md`).
+
+- [ ] **税理士 Review 3** — pre-production final verification of test-environment
+      output samples (manifest CSV, export ZIP, retention dates) before any operator
+      goes live. Engineering package: `docs/compliance-review/2026-review-3-preprod-package.md`.
+- [ ] **Tier A live testing** — verify `install.php` + release ZIP on real shared
+      hosting alongside sibling products (roadmap Phase 0/3 "pending Tier A testing").
+- [ ] **Standing P0 watch** — on any 電帳法 amendment / 国税庁 guidance, open a P0
+      Issue and add a new review block to `signoff-record.md` (Review 2 condition 2).
+
+Last updated: 2026-06-01


### PR DESCRIPTION
Closes #95.

## Summary

All roadmap phases (0–4) are complete and both check suites are green. The only
remaining work before production is the licensed-professional **Review 3** go-live
gate. This PR prepares that gate and fixes stale tracking docs. **Docs only — no
code or behavior change.**

## Changes

- **Add `docs/compliance-review/2026-review-3-preprod-package.md`** — pre-production
  output-verification package fulfilling Review 2's recorded condition (verify
  test-environment calculation results + report samples before release). Maps to
  concrete checks: manifest CSV columns (`ExportDocumentsUseCase::MANIFEST_HEADER`),
  export ZIP layout, retention ADR 0004 cases, SHA-256 round-trip, correction-history
  evidence, and the master-setting flexibility condition.
- **Wire the package in** — gate README file table + `signoff-record.md` status
  table; production go-live marked blocked until Review 3 is recorded.
- **Sync `docs/todo/current.md`** with the roadmap — Phase 4 marked Done (was stale
  "In progress" with all items checked), "gate open" header corrected, and a
  "Go-live gate" section added (Review 3, Tier A live testing, P0 law-change watch).

## Verification

Docs-only; `composer check` and `npm run check --prefix frontend` were green before
the change and are unaffected (no source touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)