### PR TITLE
feat(frontend): integrity-verified inline preview on document detail

### DIFF
--- a/docs/explanation/scope-contract.md
+++ b/docs/explanation/scope-contract.md
@@ -67,6 +67,7 @@ immutable, and traceable** — Vault does not pretend to be the ledger.
 | D8 | Multi-tenant isolation, RBAC, audit events for upload/void/metadata change | ADR 0006 |
 | D9 | Admin UI + REST API + MCP (read-heavy; write with auth) | NENE2 inheritance |
 | D10 | Tier A installer + release ZIP beside other NeNe back-office apps | ADR 0003 |
+| D11 | Display **integrity-verified inline preview** of stored bytes (image/PDF) in the Admin UI; SHA-256 is re-checked client-side and bytes are hidden on mismatch | 可視性の確保 · 税務調査の現場提示 |
 
 ---
 

--- a/frontend/src/entities/document/file.ts
+++ b/frontend/src/entities/document/file.ts
@@ -1,0 +1,100 @@
+import { useEffect, useState } from 'react';
+import { apiClient } from '@/shared/api/client';
+
+/**
+ * Integrity-checked fetch of a document version's stored bytes for in-browser preview.
+ *
+ * The download endpoint (keyed by the version's ULID, not its ordinal number) is the
+ * single authenticated path to the file bytes — the storage path is never exposed
+ * (Hard rule). We re-compute SHA-256 in the browser and compare it to the recorded
+ * hash so the operator (and, in a tax audit, the examiner) can see the displayed
+ * bytes are the unmodified original.
+ */
+export type DocumentFileStatus = 'loading' | 'verified' | 'mismatch' | 'error';
+
+export interface DocumentFile {
+  url: string | undefined;
+  blob: Blob | undefined;
+  mimeType: string;
+  status: DocumentFileStatus;
+}
+
+export interface DocumentFileRequest {
+  documentId: string;
+  versionId: string;
+  sha256: string;
+  mimeType: string;
+}
+
+function downloadPath(documentId: string, versionId: string): string {
+  return `/admin/vault/documents/${documentId}/versions/${versionId}/download`;
+}
+
+/** Authenticated fetch of the raw file bytes (bearer token via the api client). */
+export function fetchDocumentBlob(documentId: string, versionId: string): Promise<Blob> {
+  return apiClient.getBlob(downloadPath(documentId, versionId));
+}
+
+async function sha256Hex(buffer: ArrayBuffer): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', buffer);
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+export function useDocumentFile(req: DocumentFileRequest | undefined): DocumentFile {
+  const documentId = req?.documentId;
+  const versionId = req?.versionId;
+  const expectedHash = req?.sha256;
+  const mimeType = req?.mimeType ?? '';
+
+  const [state, setState] = useState<DocumentFile>({
+    url: undefined,
+    blob: undefined,
+    mimeType,
+    status: 'loading',
+  });
+
+  useEffect(() => {
+    if (documentId === undefined || versionId === undefined || expectedHash === undefined) {
+      return undefined;
+    }
+
+    const controller = new AbortController();
+    let objectUrl: string | undefined;
+    setState({ url: undefined, blob: undefined, mimeType, status: 'loading' });
+
+    void (async () => {
+      try {
+        const blob = await apiClient.getBlob(
+          downloadPath(documentId, versionId),
+          controller.signal,
+        );
+        const hash = await sha256Hex(await blob.arrayBuffer());
+        if (controller.signal.aborted) {
+          return;
+        }
+        objectUrl = URL.createObjectURL(blob);
+        setState({
+          url: objectUrl,
+          blob,
+          mimeType,
+          status: hash === expectedHash ? 'verified' : 'mismatch',
+        });
+      } catch {
+        if (!controller.signal.aborted) {
+          setState({ url: undefined, blob: undefined, mimeType, status: 'error' });
+        }
+      }
+    })();
+
+    return () => {
+      controller.abort();
+      if (objectUrl !== undefined) {
+        URL.revokeObjectURL(objectUrl);
+      }
+    };
+  }, [documentId, versionId, expectedHash, mimeType]);
+
+  return state;
+}

--- a/frontend/src/entities/document/index.ts
+++ b/frontend/src/entities/document/index.ts
@@ -16,3 +16,5 @@ export {
 export type { UploadDocumentInput, UpdateMetadataInput, VoidDocumentInput } from './mutations';
 export { useOcrSuggest } from './ocr';
 export type { OcrPrefill } from './ocr';
+export { useDocumentFile, fetchDocumentBlob } from './file';
+export type { DocumentFile, DocumentFileStatus, DocumentFileRequest } from './file';

--- a/frontend/src/features/document-detail/index.ts
+++ b/frontend/src/features/document-detail/index.ts
@@ -2,4 +2,5 @@ export { VoidModal } from './ui/VoidModal';
 export { RestoreModal } from './ui/RestoreModal';
 export { MetadataEditModal } from './ui/MetadataEditModal';
 export { DocumentHistoryTable } from './ui/DocumentHistoryTable';
+export { DocumentPreview } from './ui/DocumentPreview';
 export type { OcrPrefill } from './hooks/use-metadata-edit';

--- a/frontend/src/features/document-detail/ui/DocumentPreview.test.tsx
+++ b/frontend/src/features/document-detail/ui/DocumentPreview.test.tsx
@@ -1,0 +1,65 @@
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { renderWithProviders } from '@tests/render/render-with-providers';
+import type { DocumentFile } from '@/entities/document';
+import { DocumentPreview } from './DocumentPreview';
+
+function file(overrides: Partial<DocumentFile>): DocumentFile {
+  return {
+    url: 'blob:mock',
+    blob: undefined,
+    mimeType: 'image/jpeg',
+    status: 'verified',
+    ...overrides,
+  };
+}
+
+describe('DocumentPreview', () => {
+  it('renders an image with the integrity badge when verified', () => {
+    const { container } = renderWithProviders(
+      <DocumentPreview file={file({ status: 'verified', mimeType: 'image/jpeg' })} />,
+    );
+    expect(screen.getByRole('img')).toHaveAttribute('src', 'blob:mock');
+    expect(container.querySelector('.badge-success')?.textContent).toContain('✓');
+  });
+
+  it('renders an iframe for PDFs', () => {
+    const { container } = renderWithProviders(
+      <DocumentPreview file={file({ status: 'verified', mimeType: 'application/pdf' })} />,
+    );
+    expect(container.querySelector('iframe.preview-frame')).toHaveAttribute('src', 'blob:mock');
+  });
+
+  it('hides the bytes and shows a danger callout on integrity mismatch', () => {
+    const { container } = renderWithProviders(
+      <DocumentPreview file={file({ status: 'mismatch' })} />,
+    );
+    expect(container.querySelector('.callout-danger')).toBeInTheDocument();
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+    expect(container.querySelector('iframe')).not.toBeInTheDocument();
+  });
+
+  it('shows a placeholder while loading', () => {
+    const { container } = renderWithProviders(
+      <DocumentPreview file={file({ status: 'loading', url: undefined })} />,
+    );
+    expect(container.querySelector('.preview-empty')).toBeInTheDocument();
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+  });
+
+  it('shows a danger callout on fetch error', () => {
+    const { container } = renderWithProviders(
+      <DocumentPreview file={file({ status: 'error', url: undefined })} />,
+    );
+    expect(container.querySelector('.callout-danger')).toBeInTheDocument();
+  });
+
+  it('shows an unsupported placeholder for non-previewable verified types', () => {
+    const { container } = renderWithProviders(
+      <DocumentPreview file={file({ status: 'verified', mimeType: 'application/zip' })} />,
+    );
+    expect(container.querySelector('.preview-empty')).toBeInTheDocument();
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+    expect(container.querySelector('iframe')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/document-detail/ui/DocumentPreview.tsx
+++ b/frontend/src/features/document-detail/ui/DocumentPreview.tsx
@@ -1,0 +1,47 @@
+import { useTranslation } from '@/shared/i18n/use-translation';
+import { Callout } from '@/shared/ui';
+import type { DocumentFile } from '@/entities/document';
+
+const PREVIEWABLE_IMAGE_TYPES = ['image/jpeg', 'image/png'];
+
+interface DocumentPreviewProps {
+  file: DocumentFile;
+}
+
+export function DocumentPreview({ file }: DocumentPreviewProps) {
+  const { t } = useTranslation();
+
+  if (file.status === 'loading') {
+    return <div className="preview-frame preview-empty">{t('document.preview.loading')}</div>;
+  }
+
+  if (file.status === 'error' || file.url === undefined) {
+    return <Callout tone="danger">{t('document.preview.error')}</Callout>;
+  }
+
+  // Integrity check failed — do NOT render the bytes; the file may be tampered.
+  if (file.status === 'mismatch') {
+    return <Callout tone="danger">{t('document.preview.integrity_mismatch')}</Callout>;
+  }
+
+  return (
+    <>
+      <div className="row gap-sm mb-stack-md">
+        <span className="badge badge-success no-dot">
+          ✓ {t('document.preview.integrity_verified')}
+        </span>
+      </div>
+      {PREVIEWABLE_IMAGE_TYPES.includes(file.mimeType) ? (
+        <img className="preview-frame" src={file.url} alt={t('document.preview.image_alt')} />
+      ) : file.mimeType === 'application/pdf' ? (
+        <iframe
+          className="preview-frame preview-pdf"
+          src={file.url}
+          title={t('document.preview.pdf_title')}
+        />
+      ) : (
+        <div className="preview-frame preview-empty">{t('document.preview.unsupported')}</div>
+      )}
+    </>
+  );
+}

--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -1,6 +1,11 @@
 import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { useDocumentById, useOcrSuggest } from '@/entities/document';
+import {
+  useDocumentById,
+  useDocumentFile,
+  fetchDocumentBlob,
+  useOcrSuggest,
+} from '@/entities/document';
 import { useDocumentHistory } from '@/entities/audit';
 import { authStore } from '@/entities/auth';
 import {
@@ -8,12 +13,12 @@ import {
   RestoreModal,
   MetadataEditModal,
   DocumentHistoryTable,
+  DocumentPreview,
 } from '@/features/document-detail';
 import type { OcrPrefill } from '@/features/document-detail';
 import { useTranslation } from '@/shared/i18n/use-translation';
 import { formatJpy, formatDate, formatDateTime } from '@/shared/lib/format';
 import { AppShell, Button, Callout, EmptyState } from '@/shared/ui';
-import { env } from '@/shared/config/env';
 
 type Modal = 'void' | 'restore' | 'metadata-edit' | null;
 
@@ -30,6 +35,23 @@ export function DocumentDetailPage() {
   const { data: doc, isLoading, isError } = useDocumentById(docId);
   const { data: history } = useDocumentHistory(docId);
 
+  // The download/preview endpoint is keyed by the version's ULID, which only the
+  // history response carries — the document detail exposes just the ordinal number.
+  const currentVersion =
+    doc !== undefined
+      ? history?.versions.find((v) => v.version_number === doc.version_number)
+      : undefined;
+  const file = useDocumentFile(
+    doc !== undefined && currentVersion !== undefined
+      ? {
+          documentId: doc.id,
+          versionId: currentVersion.id,
+          sha256: currentVersion.file_sha256,
+          mimeType: currentVersion.mime_type,
+        }
+      : undefined,
+  );
+
   function handleLogout() {
     authStore.clearSession();
     navigate('/login', { replace: true });
@@ -44,16 +66,19 @@ export function DocumentDetailPage() {
     setModal('metadata-edit');
   }
 
-  function handleDownload() {
-    if (doc === undefined) return;
-    const base = env.apiBaseUrl.replace(/\/$/, '');
-    const url = `${base}/admin/vault/documents/${doc.id}/versions/${String(doc.version_number)}/download`;
+  async function handleDownload() {
+    if (doc === undefined || currentVersion === undefined) return;
+    // Reuse the already-fetched, integrity-verified bytes when available; otherwise
+    // fetch through the authenticated client (a plain <a href> would drop the bearer token).
+    const blob = file.blob ?? (await fetchDocumentBlob(doc.id, currentVersion.id));
+    const objectUrl = URL.createObjectURL(blob);
     const a = document.createElement('a');
-    a.href = url;
+    a.href = objectUrl;
     a.download = doc.original_filename ?? `document-${doc.id}`;
     document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);
+    URL.revokeObjectURL(objectUrl);
   }
 
   return (
@@ -102,7 +127,13 @@ export function DocumentDetailPage() {
             </div>
 
             <div className="row gap-sm wrap">
-              <Button variant="secondary" onClick={handleDownload}>
+              <Button
+                variant="secondary"
+                onClick={() => {
+                  void handleDownload();
+                }}
+                disabled={currentVersion === undefined}
+              >
                 {t('document.detail.download_button')}
               </Button>
               <Button
@@ -194,6 +225,9 @@ export function DocumentDetailPage() {
             <div className="row gap-sm mb-stack-md">
               <span className="tick" />
               <h2 className="subtitle">{t('document.detail.file_section')}</h2>
+            </div>
+            <div className="preview-block">
+              <DocumentPreview file={file} />
             </div>
             <dl className="dl">
               <div>

--- a/frontend/src/shared/api/client.ts
+++ b/frontend/src/shared/api/client.ts
@@ -60,6 +60,31 @@ async function request<T>(path: string, options: RequestOptions = {}): Promise<T
   return (await response.json()) as T;
 }
 
+async function requestBlob(path: string, signal?: AbortSignal): Promise<Blob> {
+  const base = env.apiBaseUrl.replace(/\/$/, '');
+  const url = `${base}${path}`;
+  const headers: Record<string, string> = {};
+
+  const token = authStore.getToken();
+  if (token !== null) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+
+  const init: RequestInit = { method: 'GET', headers, credentials: 'include' };
+  if (signal !== undefined) {
+    init.signal = signal;
+  }
+
+  const response = await fetch(url, init);
+
+  if (!response.ok) {
+    handleAuthError(response, path);
+    throw await parseProblemDetails(response);
+  }
+
+  return await response.blob();
+}
+
 async function uploadFormData<T>(path: string, formData: FormData): Promise<T> {
   const base = env.apiBaseUrl.replace(/\/$/, '');
   const url = `${base}${path}`;
@@ -100,5 +125,8 @@ export const apiClient = {
   },
   upload<T>(path: string, formData: FormData): Promise<T> {
     return uploadFormData<T>(path, formData);
+  },
+  getBlob(path: string, signal?: AbortSignal): Promise<Blob> {
+    return requestBlob(path, signal);
   },
 };

--- a/frontend/src/shared/ui/theme/themes/default.css
+++ b/frontend/src/shared/ui/theme/themes/default.css
@@ -569,6 +569,31 @@
     border-bottom: 1px solid var(--color-line);
   }
 
+  /* ---- document preview ---- */
+  .preview-block {
+    margin-bottom: 18px;
+  }
+  .preview-frame {
+    display: block;
+    width: 100%;
+    max-height: 560px;
+    object-fit: contain;
+    background: var(--color-surface-muted, #f4f1ea);
+    border: 1px solid var(--color-line);
+    border-radius: var(--radius-sm);
+  }
+  .preview-pdf {
+    height: 560px;
+  }
+  .preview-empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 160px;
+    color: var(--color-text-muted, #6b6456);
+    font-size: var(--text-sm);
+  }
+
   /* ---- buttons ---- */
   .btn {
     font: inherit;

--- a/locales/en.json
+++ b/locales/en.json
@@ -295,6 +295,15 @@
       "date_uncertain_badge": "Date uncertain",
       "metadata_unconfirmed_badge": "Metadata unconfirmed"
     },
+    "preview": {
+      "loading": "Loading preview…",
+      "error": "Could not retrieve the file.",
+      "integrity_verified": "Integrity verified (SHA-256 match)",
+      "integrity_mismatch": "Integrity error: does not match the stored hash. Preview hidden.",
+      "image_alt": "Received document preview",
+      "pdf_title": "PDF preview",
+      "unsupported": "This format cannot be previewed. Please download to view."
+    },
     "metadata": {
       "transaction_date": "Transaction Date",
       "amount_cents": "Amount (JPY)",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -303,6 +303,15 @@
       "date_uncertain_badge": "日付未確定",
       "metadata_unconfirmed_badge": "メタデータ未確認"
     },
+    "preview": {
+      "loading": "プレビューを読み込み中…",
+      "error": "ファイルを取得できませんでした。",
+      "integrity_verified": "整合性検証済み（SHA-256 一致）",
+      "integrity_mismatch": "整合性エラー：保存されたハッシュと一致しません。プレビューを表示しません。",
+      "image_alt": "受領書類のプレビュー",
+      "pdf_title": "PDF プレビュー",
+      "unsupported": "この形式はプレビューに対応していません。ダウンロードしてご確認ください。"
+    },
     "metadata": {
       "transaction_date": "取引年月日",
       "amount_cents": "取引金額",


### PR DESCRIPTION
## What

Adds an **integrity-verified inline preview** of stored bytes on the document detail page. Images render via `<img>`, PDFs via `<iframe>`. The bytes are fetched through the authenticated api client, **SHA-256 is re-computed in the browser**, and a green `✓ Integrity verified` badge is shown on match. On mismatch the bytes are **not rendered** — a danger callout is shown instead.

Motivation: with tax-audit usage in scope, the operator (and the examiner, on-site) needs to confirm "this is the right, unmodified document" on screen without download → open → switch apps for every item. Scope contract **D11** records this viewing UX.

## Also fixes a pre-existing download bug

The download endpoint is keyed by the **version's ULID**, but the detail page passed the ordinal `version_number` (→ 404), and the plain `<a href>` dropped the bearer token entirely. Both download and preview now resolve the real version id from the history response and go through the authenticated `fetch` + blob path.

## Changes

- `shared/api/client`: add `getBlob` (bearer-authenticated binary fetch)
- `entities/document/file`: `useDocumentFile` hook + `fetchDocumentBlob` helper
- `features/document-detail`: `DocumentPreview` component (+ 6 tests)
- `pages/DocumentDetailPage`: wire preview, fix download to use version ULID
- `locales`: `document.preview.*` (ja/en, key parity verified)
- `docs/explanation/scope-contract.md`: D11

## Verification

- `npm run check` green (type-check, lint, prettier, **200 tests**, knip, storybook build)
- Live API: download with the correct version ULID returns `200 image/jpeg`, **SHA-256 matches exactly**, `401` without token
- Browser (Playwright): image preview renders with the verified badge (`✓ Integrity verified (SHA-256 match)`); PDF iframe receives a `blob:` `application/pdf` source (blank only under headless Chromium, which lacks a PDF viewer — renders in real browsers)

## Compliance notes

- No new API/contract surface; reuses the existing version download endpoint
- Storage path never exposed; bytes served only via the authenticated, SHA-256-verified path (Hard rules respected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)