### PR TITLE
docs: 成熟度を示す Phase 4 complete バッジを追加する (#99)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](./LICENSE)
 [![PHP 8.4](https://img.shields.io/badge/PHP-8.4-777BB4?logo=php)](https://www.php.net/)
 [![Public](https://img.shields.io/badge/status-public-blue)]()
+[![Status: Phase 4 complete](https://img.shields.io/badge/status-Phase%204%20complete-brightgreen)]()
 
 **Received-document archive — self-hosted for Japan SMB.**
 


### PR DESCRIPTION
## 目的
README から開発成熟度が読み取れない（可視性 Public バッジのみ）。実態（roadmap 全 Phase 完了・会計士承認済）を示すステータスバッジを追加する。

## 変更点
Status: Phase 4 complete バッジを追加（Public バッジはそのまま）。

## 検証
README 表示のみ。コード・テスト・API への影響なし。

## セルフレビュー
docs-policy

Closes #99