### PR TITLE
fix(auth): 本番でJWT secret未設定時にフェイルクローズする

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 APP_ENV=local
 APP_DEBUG=false
 APP_NAME=NeNe Vault
-NENE2_LOCAL_JWT_SECRET=nene-vault-dev-secret-change-in-production
+NENE2_LOCAL_JWT_SECRET=
 PROBLEM_DETAILS_BASE_URL=https://nene-vault.dev/problems/
 
 # --- Vault-specific ---

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -9,6 +9,7 @@ use Nene2\Auth\LocalBearerTokenVerifier;
 use Nene2\Auth\TokenIssuerInterface;
 use Nene2\Auth\TokenVerifierInterface;
 use Nene2\Config\AppConfig;
+use Nene2\Config\AppEnvironment;
 use Nene2\Config\ConfigLoader;
 use Nene2\Database\DatabaseConnectionFactoryInterface;
 use Nene2\Database\DatabaseQueryExecutorInterface;
@@ -45,6 +46,8 @@ use Psr\Log\LoggerInterface;
 final readonly class RuntimeServiceProvider implements ServiceProviderInterface
 {
     public const PROJECT_ROOT = 'nene-vault.project_root';
+
+    private const DEFAULT_DEV_SECRET = 'nene-vault-dev-secret';
 
     public function register(ContainerBuilder $builder): void
     {
@@ -186,7 +189,7 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Application config service is invalid.');
                     }
 
-                    return new LocalBearerTokenVerifier($config->localJwtSecret ?? 'nene-vault-dev-secret');
+                    return new LocalBearerTokenVerifier(self::resolveJwtSecret($config));
                 },
             )
             ->set(
@@ -344,5 +347,27 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                 },
             )
             ->set(ResponseEmitter::class, static fn (): ResponseEmitter => new ResponseEmitter());
+    }
+
+    /**
+     * Resolve the local JWT signing key, failing closed in production. When the key
+     * (`NENE2_LOCAL_JWT_SECRET`) is unset or blank, production refuses to boot rather
+     * than falling back to the public dev constant — which would let anyone forge a
+     * token. Dev/test keep the convenience fallback.
+     */
+    private static function resolveJwtSecret(AppConfig $config): string
+    {
+        if ($config->localJwtSecret !== null && $config->localJwtSecret !== '') {
+            return $config->localJwtSecret;
+        }
+
+        if ($config->environment === AppEnvironment::Production) {
+            throw new LogicException(
+                'NENE2_LOCAL_JWT_SECRET must be set in production. '
+                . 'Generate one with: php -r "echo bin2hex(random_bytes(32));"',
+            );
+        }
+
+        return self::DEFAULT_DEV_SECRET;
     }
 }

--- a/tests/Http/JwtSecretResolutionTest.php
+++ b/tests/Http/JwtSecretResolutionTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Tests\Http;
+
+use LogicException;
+use Nene2\Config\AppConfig;
+use Nene2\Config\AppEnvironment;
+use Nene2\Config\DatabaseConfig;
+use NeneVault\Http\RuntimeServiceProvider;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * The local JWT signing key must fail closed in production when
+ * NENE2_LOCAL_JWT_SECRET is unset or blank, rather than falling back to the
+ * public dev constant (which would let anyone forge a superadmin token).
+ */
+final class JwtSecretResolutionTest extends TestCase
+{
+    public function testProductionWithoutSecretRefusesToBoot(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('NENE2_LOCAL_JWT_SECRET');
+
+        self::resolve(self::config(AppEnvironment::Production, null));
+    }
+
+    public function testProductionWithBlankSecretRefusesToBoot(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('NENE2_LOCAL_JWT_SECRET');
+
+        self::resolve(self::config(AppEnvironment::Production, ''));
+    }
+
+    public function testProductionWithSecretUsesIt(): void
+    {
+        self::assertSame(
+            'a-real-production-secret',
+            self::resolve(self::config(AppEnvironment::Production, 'a-real-production-secret')),
+        );
+    }
+
+    public function testLocalWithoutSecretFallsBackToDevConstant(): void
+    {
+        // Off-production convenience: the dev fallback is allowed only outside production.
+        self::assertNotSame('', self::resolve(self::config(AppEnvironment::Local, null)));
+    }
+
+    private static function resolve(AppConfig $config): string
+    {
+        $method = new ReflectionMethod(RuntimeServiceProvider::class, 'resolveJwtSecret');
+
+        /** @var string $secret */
+        $secret = $method->invoke(null, $config);
+
+        return $secret;
+    }
+
+    private static function config(AppEnvironment $environment, ?string $secret): AppConfig
+    {
+        return new AppConfig(
+            $environment,
+            false,
+            'NeNe Vault',
+            new DatabaseConfig(null, 'test', 'sqlite', '', 1, ':memory:', '', '', ''),
+            null,
+            $secret,
+        );
+    }
+}


### PR DESCRIPTION
## 目的

Closes #101

`RuntimeServiceProvider` の `LocalBearerTokenVerifier` 生成部が `NENE2_LOCAL_JWT_SECRET` 未設定/空文字時に公開済みの dev 固定鍵 `nene-vault-dev-secret` へフォールバックしていた。本番でこの env を設定し忘れてデプロイすると、既知の dev 鍵で署名した superadmin トークンが受理される（偽造受理）。

pilot=nene-records PR #725 と同一パターン（invoice/records/field/clear に既存の参照実装あり・本 PR で移植）。横断監査根拠: `_work/reports/2026-07-05/nene-backend-audit.md` §2。

## 変更点

- `src/Http/RuntimeServiceProvider.php`: `resolveJwtSecret(AppConfig $config): string` を追加。
  - secret が null/空文字でなければそれを使用。
  - `AppEnvironment::Production` かつ secret 未設定/空文字なら起動拒否（`LogicException`、鍵生成コマンド案内つき）。
  - それ以外（dev/test）は従来どおり `DEFAULT_DEV_SECRET`（`nene-vault-dev-secret`）にフォールバック。
  - `LocalBearerTokenVerifier` 生成部のフォールバック式をこのメソッド呼び出しに置換。
- `.env.example`: 同梱していた既知 dev 鍵 `nene-vault-dev-secret-change-in-production` を `NENE2_LOCAL_JWT_SECRET=`（空値）に変更し、コピー事故での本番流出を防止。
- `tests/Http/JwtSecretResolutionTest.php`（新規）: `ReflectionMethod` で `resolveJwtSecret` を直接叩く4ケース（本番×null拒否／本番×空拒否／本番×設定採用／dev×既定鍵）。

## スコープ

この JWT フェイルクローズ変更と `.env.example` の既知鍵除去のみ。invoice/field/clear/records（参照実装・fan-out 対象外）には不接触。

## 検証結果

- `composer check` green: PHPUnit 291 tests / 830 assertions OK・PHPStan level 8 no errors・CS Fixer OK・locales 379 keys consistent・OpenAPI valid・MCP catalog valid。
- **fail-closed 実証**: `$_SERVER['APP_ENV']=production` かつ `NENE2_LOCAL_JWT_SECRET` 未設定でコンテナから `LocalBearerTokenVerifier` を解決 → 起動拒否を確認。
  ```
  boot rejected: Nene2\DependencyInjection\ServiceResolutionException: Service "Nene2\Auth\LocalBearerTokenVerifier" could not be resolved.
  previous: LogicException: NENE2_LOCAL_JWT_SECRET must be set in production. Generate one with: php -r "echo bin2hex(random_bytes(32));"
  ```
  （DI が例外を `ServiceResolutionException` で包むため `getPrevious()` で `LogicException` を確認。`$config->environment->value === 'production'` を先に検証してから拒否を確認、no-op でないことを担保。）
- **dev 非回帰**: `APP_ENV=local` かつ secret 未設定でコンテナから同サービスを解決 → 正常起動（`Nene2\Auth\LocalBearerTokenVerifier` を取得）を確認。

## デプロイ前提（重要）

本 PR をデプロイする前に、本番環境の `NENE2_LOCAL_JWT_SECRET` に実鍵（`php -r "echo bin2hex(random_bytes(32));"`）を設定すること。未設定のままデプロイすると起動拒否でダウンする。

Self-review: backend-api