### PR TITLE
test: phpunit の env を force=true で hermetic 化 (#18)

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,18 +13,29 @@
             <directory>src</directory>
         </include>
     </source>
+    <!--
+        force="true" makes this suite hermetic: PHPUnit overwrites any value already
+        present in the shell environment instead of deferring to it. Without force,
+        an operator's exported shell var (e.g. ORG_SLUG or NENE2_LOCAL_JWT_SECRET in
+        ~/.bashrc) silently overrides these defaults and produces phantom failures —
+        most visibly a tenant-slug mismatch that yields 403 org-access-denied across
+        the boundary tests. See issue #18. Every value below is a fixed test-only
+        value; keep every runtime-behaviour env forced so the run cannot be polluted
+        from outside.
+    -->
     <php>
-        <env name="APP_ENV" value="test"/>
-        <env name="APP_DEBUG" value="false"/>
-        <env name="NENE2_LOCAL_JWT_SECRET" value="nene-vault-test-secret"/>
-        <env name="PROBLEM_DETAILS_BASE_URL" value="https://nene-vault.dev/problems/"/>
-        <env name="TENANT_RESOLUTION" value="single"/>
-        <env name="ORG_SLUG" value="test-org"/>
-        <env name="DB_ENV" value="test"/>
-        <env name="DB_ADAPTER" value="sqlite"/>
-        <env name="DB_NAME" value="var/nene_vault_test.sqlite"/>
-        <env name="NENE_VAULT_STORAGE_PATH" value="/tmp/nene-vault-test"/>
-        <env name="NENE_VAULT_MAX_FILE_SIZE_MB" value="20"/>
+        <env name="APP_ENV" value="test" force="true"/>
+        <env name="APP_DEBUG" value="false" force="true"/>
+        <!-- Fixed test-only signing secret; forced so a shell-exported secret can't diverge sign/verify. -->
+        <env name="NENE2_LOCAL_JWT_SECRET" value="nene-vault-test-secret" force="true"/>
+        <env name="PROBLEM_DETAILS_BASE_URL" value="https://nene-vault.dev/problems/" force="true"/>
+        <env name="TENANT_RESOLUTION" value="single" force="true"/>
+        <env name="ORG_SLUG" value="test-org" force="true"/>
+        <env name="DB_ENV" value="test" force="true"/>
+        <env name="DB_ADAPTER" value="sqlite" force="true"/>
+        <env name="DB_NAME" value="var/nene_vault_test.sqlite" force="true"/>
+        <env name="NENE_VAULT_STORAGE_PATH" value="/tmp/nene-vault-test" force="true"/>
+        <env name="NENE_VAULT_MAX_FILE_SIZE_MB" value="20" force="true"/>
         <!--
           Opt in to the framework's development JWT secret so any test that boots the
           runtime container (RuntimeServiceProvider -> GuardedJwtSecretResolver) can
@@ -34,6 +45,6 @@
           sets NENE2_LOCAL_JWT_SECRET above, so the configured secret is used and this
           opt-in path is not currently exercised — kept for defense in depth.)
         -->
-        <env name="NENE2_ALLOW_DEV_SECRET" value="1"/>
+        <env name="NENE2_ALLOW_DEV_SECRET" value="1" force="true"/>
     </php>
 </phpunit>


### PR DESCRIPTION
## 概要

Closes #18

issue #18 は当初「`composer test` が 156/291 失敗（org-access-denied）＝既存テスト負債」として起票されたが、**誤診**だった。真因は **shell env 汚染**。

`phpunit.xml.dist` の `<env>` は `force` 属性が無いと **既存の shell 環境変数を上書きしない**（PHPUnit の仕様）。`~/.bashrc` 等でテスト関連の env が export されていると、xml のテスト用既定値が握りつぶされる。

- 主犯は **`ORG_SLUG`**: shell 側の値が `test-org` を上書き → テナント slug 不一致 → **403 org-access-denied** を境界テスト全域で量産（当初の ~156 失敗の正体）。
- `NENE2_LOCAL_JWT_SECRET` の汚染は署名・検証が同じ env を参照して**対称**なので、単独では壊れない（これも実測で確認）。

## 修正

runtime 挙動を決める全ての `<env>` に **`force="true"`** を付与し、shell に何が export されていてもテストは常に xml の固定値を使う **hermetic** な状態にした。テストロジックは不変。

## 検証（force の効きを実証）

| env | 修正前 | 修正後 |
|---|---|---|
| clean (`env -i`) | 282/282 green | 282/282 green |
| `ORG_SLUG=evil` | **149 failures + 15 errors** | **282/282 green** |
| `NENE2_LOCAL_JWT_SECRET=polluted ORG_SLUG=evil APP_ENV=production` | (汚染) | **282/282 green** |

`composer check` 全体（test + PHPStan + CS + locales + openapi + mcp）green。

## スコープ

phpunit env の hermetic 化のみ。fleet-wide の `force="true"` 化は別途。
指示書: `_work/handoff-vault-phpunit-hermetic-2026-07-05-work-order.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)