### PR TITLE
feat(export): CSV 出力を Nene2\Export\CsvWriter へ移行し formula injection を閉塞する (#110)

### DIFF
--- a/src/Export/ExportDocumentsUseCase.php
+++ b/src/Export/ExportDocumentsUseCase.php
@@ -8,6 +8,7 @@ use Nene2\Audit\AuditEvent;
 use Nene2\Audit\AuditRecorderFactoryInterface;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Database\DatabaseTransactionManagerInterface;
+use Nene2\Export\CsvWriter;
 use NeneVault\Audit\AuditAction;
 use NeneVault\Document\DocumentSearchCriteria;
 use NeneVault\Document\VaultDocument;
@@ -102,21 +103,14 @@ final readonly class ExportDocumentsUseCase implements ExportDocumentsUseCaseInt
         $handle = fopen('php://temp', 'r+');
         assert($handle !== false);
 
-        fputcsv($handle, self::MANIFEST_HEADER, escape: '');
-
-        foreach ($rows as [$document, $version]) {
-            fputcsv($handle, [
-                $document->id,
-                (string) $version->versionNumber,
-                $document->transactionDate ?? '',
-                $document->amountCents !== null ? (string) $document->amountCents : '',
-                $document->counterpartyName,
-                $document->category,
-                $version->fileSha256,
-                $document->uploadedAt ?? '',
-                $document->voidedAt ?? '',
-            ], escape: '');
-        }
+        // Nene2\Export\CsvWriter applies safe defaults framework-wide (ADR 0015):
+        // formula-injection neutralisation of string cells, RFC 4180 quoting, and
+        // a UTF-8 BOM. counterparty_name / category are user-controlled text, so
+        // this closes the previous formula-injection exposure. amount_cents and the
+        // version number are passed as native ints so genuine numeric values (incl.
+        // negative amounts) stay numeric and are never mistaken for a formula.
+        $writer = new CsvWriter($handle, self::MANIFEST_HEADER);
+        $writer->writeAll($this->manifestRows($rows));
 
         rewind($handle);
         $csv = stream_get_contents($handle);
@@ -125,6 +119,28 @@ final readonly class ExportDocumentsUseCase implements ExportDocumentsUseCaseInt
         assert($csv !== false);
 
         return $csv;
+    }
+
+    /**
+     * @param list<array{0: VaultDocument, 1: DocumentVersion}> $rows
+     *
+     * @return iterable<list<string|int|null>>
+     */
+    private function manifestRows(array $rows): iterable
+    {
+        foreach ($rows as [$document, $version]) {
+            yield [
+                $document->id,
+                $version->versionNumber,
+                $document->transactionDate ?? '',
+                $document->amountCents,
+                $document->counterpartyName,
+                $document->category,
+                $version->fileSha256,
+                $document->uploadedAt ?? '',
+                $document->voidedAt ?? '',
+            ];
+        }
     }
 
     /**

--- a/tests/Export/ExportApiTest.php
+++ b/tests/Export/ExportApiTest.php
@@ -123,6 +123,55 @@ final class ExportApiTest extends TestCase
         @unlink($tmpZip);
     }
 
+    public function test_export_csv_neutralizes_formula_injection_and_has_bom(): void
+    {
+        $handler = $this->handler();
+
+        // Attacker-controlled counterparty text that would be a live formula when
+        // the CSV is opened in Excel / LibreOffice / Google Sheets.
+        $payload = '=cmd|/c calc!A1-' . bin2hex(random_bytes(4));
+
+        $this->upload($handler, $payload, '2026-11-01', '15000');
+
+        $response = $handler->handle($this->jsonRequest('POST', '/admin/vault/export', [
+            'transaction_date_from' => '2026-11-01',
+            'transaction_date_to' => '2026-11-30',
+            'counterparty_name' => $payload,
+        ]));
+
+        $this->assertSame(200, $response->getStatusCode(), (string) $response->getBody());
+
+        $csv = (string) $response->getBody();
+
+        // Framework default: UTF-8 BOM (Excel-JP safe).
+        $this->assertStringStartsWith("\xEF\xBB\xBF", $csv);
+
+        // The raw formula must never appear as a live cell; it is neutralised with
+        // a leading single quote so the spreadsheet renders it as text.
+        $this->assertStringNotContainsString(",{$payload},", $csv);
+        $this->assertStringContainsString("'" . $payload, $csv);
+
+        // Round-trip: parsing the neutralised CSV must recover the quoted value
+        // exactly, and amount_cents must stay a plain numeric cell (not neutralised).
+        $body = substr($csv, 3); // strip BOM
+        $lines = array_values(array_filter(explode("\n", trim($body))));
+        $header = str_getcsv($lines[0], ',', '"', '');
+        $counterpartyCol = array_search('counterparty_name', $header, true);
+        $amountCol = array_search('amount_cents', $header, true);
+        $this->assertNotFalse($counterpartyCol);
+
+        $matched = null;
+        foreach (array_slice($lines, 1) as $line) {
+            $cells = str_getcsv($line, ',', '"', '');
+            if (($cells[$counterpartyCol] ?? null) === "'" . $payload) {
+                $matched = $cells;
+                break;
+            }
+        }
+        $this->assertNotNull($matched, 'neutralised counterparty row must round-trip');
+        $this->assertSame('15000', $matched[$amountCol], 'numeric amount must stay un-neutralised');
+    }
+
     public function test_export_requires_auth(): void
     {
         $response = $this->handler()->handle($this->jsonRequest('POST', '/admin/vault/export', [], auth: false));

--- a/tests/Export/ExportBoundaryTest.php
+++ b/tests/Export/ExportBoundaryTest.php
@@ -39,7 +39,9 @@ final class ExportBoundaryTest extends ApiTestCase
         );
 
         $this->assertSame(200, $response->getStatusCode(), (string) $response->getBody());
+        // CsvWriter emits a UTF-8 BOM by framework default; strip it before parsing.
         $csv  = (string) $response->getBody();
+        $csv  = str_starts_with($csv, "\xEF\xBB\xBF") ? substr($csv, 3) : $csv;
         $cols = str_getcsv(explode("\n", trim($csv))[0], separator: ',', enclosure: '"', escape: '');
         $this->assertContains('document_id', $cols);
         $this->assertContains('file_sha256', $cols);


### PR DESCRIPTION
## 目的

Vault の manifest CSV 出力を NENE2 v1.8.0（ADR 0015）の `Nene2\Export\CsvWriter` へ移行し、`counterparty_name` / `category` など**利用者制御テキストの formula injection 無防備出力**を閉塞する。設計は `_work/reports/2026-07-06/upstream-design/03-csv-helper.md`。

Closes #110

## 変更点

- `ExportDocumentsUseCase::buildCsv` の手組み `fputcsv` を `CsvWriter` へ置換。行生成は generator `manifestRows()` に分離（CsvWriter の streaming I/F に合わせる）。
- ヘッダ（`MANIFEST_HEADER`）・列順・出力先（standalone CSV と ZIP の `manifest.csv` 兼用）は不変。
- `amount_cents` / version 番号を `(string)` キャストせず native int で渡す。型ベース中和により数値は素通し＝負の金額も壊れない。

## 出力変化（framework 既定・意図したセキュリティ是正）

1. **UTF-8 BOM が先頭に付与**される（CsvWriter 既定 ON・Excel-JP 文字化け防止）。移行前の vault は BOM なしだった。
2. **formula injection 中和**: `counterparty_name` / `category` が `= + - @` / TAB / CR で始まる場合に `'` を前置。これが本 PR の主目的（脆弱性是正）。
3. RFC 4180 quoting（escape 空）は移行前と同じ挙動。

## 検証

- `composer test` → **294 tests / 836 assertions OK**（vault は #18 で hermetic 化済・clean env で実行）。
  - 追加: `ExportApiTest::test_export_csv_neutralizes_formula_injection_and_has_bom`（injection 中和・BOM 先頭・round-trip parse・数値素通し）。
  - 更新: `ExportBoundaryTest::test_export_returns_csv_with_correct_columns` を BOM 除去してヘッダ parse するよう修正。
- `composer analyse`（PHPStan）・`composer cs` クリーン。`php -l` パス。

## NENE2 依存

vault は `hideyukimori/nene2: @dev`（path-repo → `../NENE2`）で解決。`../NENE2` は v1.8.0（`Nene2\Export\CsvWriter` 収録）のため追加の composer 変更は不要。Packagist 経由の消費者は `^1.8` + `composer update` が要る。

## 残リスク

BOM 付与により、BOM を前提にしない下流パーサ（自前 import 等）があると先頭列名の読み取りに影響しうる。設計レポート §5 の通り BOM の全社統一は別 issue。vault の CSV は Excel/監査エクスポート用途で BOM 付与が安全側。

Self-review: backend-api

🤖 Generated with [Claude Code](https://claude.com/claude-code)
