### PR TITLE
build: 準拠リンタ (composer conformance) を配線 (#112)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,13 +37,15 @@
         "openapi": "php tools/validate-openapi.php",
         "mcp": "php vendor/hideyukimori/nene2/tools/validate-mcp-tools.php",
         "mcp:server": "php tools/local-mcp-server.php",
+        "conformance": "php vendor/hideyukimori/nene2/tools/conformance.php --root=.",
         "check": [
             "@test",
             "@analyse",
             "@cs",
             "@locales",
             "@openapi",
-            "@mcp"
+            "@mcp",
+            "@conformance"
         ]
     },
     "config": {

--- a/conformance.baseline.json
+++ b/conformance.baseline.json
@@ -1,0 +1,72 @@
+{
+    "version": 1,
+    "allow": [],
+    "ignore": [
+        {
+            "rule": "D4",
+            "file": "src/Auth/LoginUseCase.php",
+            "message": "Raw current-time read time(). Inject Nene2\\Http\\ClockInterface (Nene2\\Http\\UtcClock in production) instead of reading the wall clock directly.",
+            "count": 2
+        },
+        {
+            "rule": "D4",
+            "file": "src/Auth/PdoUserRepository.php",
+            "message": "Raw current-time read date() with no explicit timestamp. Inject Nene2\\Http\\ClockInterface (Nene2\\Http\\UtcClock in production) instead of reading the wall clock directly.",
+            "count": 5
+        },
+        {
+            "rule": "D4",
+            "file": "src/Document/PdoVaultDocumentRepository.php",
+            "message": "Raw current-time read date() with no explicit timestamp. Inject Nene2\\Http\\ClockInterface (Nene2\\Http\\UtcClock in production) instead of reading the wall clock directly.",
+            "count": 2
+        },
+        {
+            "rule": "D4",
+            "file": "src/Document/UploadDocumentUseCase.php",
+            "message": "Raw current-time read date() with no explicit timestamp. Inject Nene2\\Http\\ClockInterface (Nene2\\Http\\UtcClock in production) instead of reading the wall clock directly.",
+            "count": 2
+        },
+        {
+            "rule": "D4",
+            "file": "src/Document/UploadDocumentUseCase.php",
+            "message": "Raw current-time read time(). Inject Nene2\\Http\\ClockInterface (Nene2\\Http\\UtcClock in production) instead of reading the wall clock directly.",
+            "count": 1
+        },
+        {
+            "rule": "D4",
+            "file": "src/DocumentVersion/PdoDocumentVersionRepository.php",
+            "message": "Raw current-time read date() with no explicit timestamp. Inject Nene2\\Http\\ClockInterface (Nene2\\Http\\UtcClock in production) instead of reading the wall clock directly.",
+            "count": 1
+        },
+        {
+            "rule": "D4",
+            "file": "src/DocumentVersion/S3DocumentStorage.php",
+            "message": "Raw current-time read gmdate() with no explicit timestamp. Inject Nene2\\Http\\ClockInterface (Nene2\\Http\\UtcClock in production) instead of reading the wall clock directly.",
+            "count": 1
+        },
+        {
+            "rule": "D4",
+            "file": "src/Export/ExportDocumentsHandler.php",
+            "message": "Raw current-time read date() with no explicit timestamp. Inject Nene2\\Http\\ClockInterface (Nene2\\Http\\UtcClock in production) instead of reading the wall clock directly.",
+            "count": 1
+        },
+        {
+            "rule": "D4",
+            "file": "src/Organization/PdoOrganizationRepository.php",
+            "message": "Raw current-time read date() with no explicit timestamp. Inject Nene2\\Http\\ClockInterface (Nene2\\Http\\UtcClock in production) instead of reading the wall clock directly.",
+            "count": 2
+        },
+        {
+            "rule": "D4",
+            "file": "src/Support/Ulid.php",
+            "message": "Raw current-time read microtime(). Inject Nene2\\Http\\ClockInterface (Nene2\\Http\\UtcClock in production) instead of reading the wall clock directly.",
+            "count": 1
+        },
+        {
+            "rule": "D4",
+            "file": "src/VaultSettings/PdoVaultSettingsRepository.php",
+            "message": "Raw current-time read date() with no explicit timestamp. Inject Nene2\\Http\\ClockInterface (Nene2\\Http\\UtcClock in production) instead of reading the wall clock directly.",
+            "count": 2
+        }
+    ]
+}


### PR DESCRIPTION
検品C / backend audit §6-P3 の準拠リンタ横展開。設計 `_work/reports/2026-07-06/upstream-design/04-conformance-linter.md` に沿い、NENE2 **v1.8.2** の `tools/conformance.php`（error 4ルール D1–D4）を invoice/clear pilot で確定したレシピで nene-vault に配線する。

Closes #112

## 変更

- `composer.json`: `conformance` スクリプト（`php vendor/hideyukimori/nene2/tools/conformance.php --root=.`）を追加し、`scripts.check` に `@conformance` を組み込み（**D3 = check 自己組込**を充足）
- `conformance.baseline.json`: 既存ドリフトを snapshot（新規混入のみ error になる逃がし弁）

NENE2 依存は path-repo `@dev`（`vendor/hideyukimori/nene2` は `../NENE2/` symlink・main は v1.8.2）ゆえ composer.json の依存制約・lock は変更不要。

## findings 内訳（初回スキャン: 21 件）

| ルール | 件数 | 扱い |
|---|---|---|
| D1 JWT 既定secretリテラル | 0 | v1.8.2 の guarded literal 免除で出ない |
| D2 依存ブランチ固定 | 0 | NENE2 は path-repo `@dev`（dev symlink・免除） |
| D3 check 自己組込欠落 | 1 | 配線で解消（baseline 不要） |
| D4 生 time API 直読み | 20（11ファイル） | 既存ドリフトとして baseline に snapshot |

真の偽陽性は無し。D4 は将来 `Nene2\Http\ClockInterface` 採用で順次解消（baseline の `ignore` エントリ）。

## 検証

- `composer conformance` → `Conformance OK — no error findings (20 suppressed by baseline/ignore)` exit 0
- `composer check` 緑（294 tests / phpstan 0 errors / cs / locales / openapi / mcp / conformance すべて OK）exit 0
- **ゲート実効**: 合成の新規 D4 違反1件を注入 → exit 1 を確認 → 除去して exit 0 復帰を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)