### PR TITLE
Demo groundwork: generated received-document PDFs, org reaper, Tier A serving fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,3 +79,10 @@ NENE_VAULT_MYSQL_PORT=3386
 
 # --- Frontend proxy host (set to 'app' when using Docker Compose) ---
 # NENE_VAULT_APP_HOST=app
+
+# --- Demo seeding (#118, docs/demo.md) ------------------------------------------
+# Fixed hand-out credentials used by tools/seed-demo.php (reset = rerun).
+# Keep them here so scheduled resets don't rotate the passwords. 12+ chars;
+# quote values containing # (dotenv treats an unquoted # as a comment).
+NENE_VAULT_DEMO_ADMIN_PASSWORD=
+NENE_VAULT_DEMO_VIEWER_PASSWORD=

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -1,0 +1,80 @@
+# Demo Environment Runbook
+
+One page for running, showing, and resetting the NeNe Vault prospect demo
+(#118). The demo is a **fixed, pre-seeded organization** with hand-out
+credentials — no self-signup, no auth-code changes. Reset = rerun the seeder.
+
+## 1. Prepare
+
+`.env` essentials (see `.env.example`):
+
+```dotenv
+NENE2_LOCAL_JWT_SECRET=<64 hex chars>       # required — fail-close without it
+TENANT_RESOLUTION=single
+ORG_SLUG=demo                               # the app serves the demo org directly
+NENE_VAULT_STORAGE_PATH=storage/vault
+NENE_VAULT_DEMO_ADMIN_PASSWORD="…12+ chars…"
+NENE_VAULT_DEMO_VIEWER_PASSWORD="…12+ chars…"
+```
+
+Schema: `php docker/bootstrap-schema.php` (sqlite) or phinx/installer (MySQL).
+
+## 2. Seed / reset
+
+```bash
+php tools/seed-demo.php --force
+```
+
+**Destructive for the demo org only**: reaps every DB row **and stored file**
+of the org with slug `demo`, then reseeds ~20 generated received-invoice PDFs
+(9 fictional Japanese vendors across the construction / building-maintenance /
+creative industries, 適格請求書 T+13-digit registration numbers) dated over
+the past 12 months relative to the run day, with void→restore history so the
+audit trail has movement. All uploads go through the real use cases — SHA-256,
+version rows and audit events are authentic. PDF bodies are romanized
+(base-14 fonts carry no CJK); the Japanese vendor names live in the searchable
+metadata, which is what the 電帳法 search showcase exercises.
+
+## 3. Showcase walkthrough (the 見せ場)
+
+1. **Search** — filter by counterparty (e.g. 大和建設株式会社), by period
+   (電帳法の期間検索), by amount range.
+2. **Detail + SHA-256** — open a document, download the version, note the
+   verified hash.
+3. **History / audit** — the void→restore documents show a full trail; the
+   audit page shows a year of activity.
+4. **Upload** — drop in any PDF; duplicate detection and retention calculation
+   run live.
+5. **Export** — CSV manifest of the filtered set.
+6. **Reset** — rerun `php tools/seed-demo.php --force`; clean again.
+
+## 4. Known limitations
+
+- Disposable per-visitor orgs (`/demo/{template}`, invoice-style) are **not
+  possible on a single-domain deployment**: Vault resolves the tenant from the
+  host (TENANT_RESOLUTION), so every request lands on the fixed `ORG_SLUG`
+  org. Wildcard subdomains or a tenancy design decision are prerequisites —
+  the seeder/reaper here are already org_id-parameterized for that future
+  round.
+- OCR / email-inbound stay disabled in the demo (external dependencies).
+- Sessions last 24 h (normal token TTL).
+
+## 5. Shared-hosting (HETEML) deployment sketch
+
+Target `vault.ayane.co.jp` (same shape as invoice/clear; DB `_nene_vault`).
+
+1. `bash tools/build-release.sh` on the dev machine (vendor `--no-dev`, SPA
+   built into `public_html/`, installer included; the zip keeps `.htaccess`).
+2. rsync so only `public_html/` is inside the docroot (vendor one level up).
+3. Run `install.php` once (requirements → DB → app settings → admin), then
+   **delete it** — it self-unlinks on success.
+4. `.env`: MySQL `_nene_vault` credentials, `APP_DEBUG=false`, real
+   `NENE2_LOCAL_JWT_SECRET`, `TENANT_RESOLUTION=single`, `ORG_SLUG=demo`,
+   demo passwords as above.
+5. Seed over SSH: `php8.4 tools/seed-demo.php --force`; register a nightly
+   reset cron with the same command.
+
+The `Authorization` header is stripped by HETEML's front proxy — the SPA
+mirrors the token into `X-Authorization` and the front controller adopts it
+when the standard header is absent (#118), the same fix proven on invoice and
+clear.

--- a/docs/terms.md
+++ b/docs/terms.md
@@ -467,6 +467,8 @@ Base URL: `https://nene-vault.dev/problems/`
 | `NENE_VAULT_PORT` | Optional | HTTP port (default 8080) | `PORT`, `VAULT_PORT`, `APP_PORT` |
 | `NENE_VAULT_APP_ENV` | Optional | `local` / `test` / `production` | `APP_ENV`, `ENV`, `ENVIRONMENT` |
 | `NENE_VAULT_MAX_FILE_SIZE_MB` | Optional | Max upload size in MB (default 20) | `MAX_FILE_SIZE`, `UPLOAD_LIMIT` |
+| `NENE_VAULT_DEMO_ADMIN_PASSWORD` | Optional | Fixed hand-out demo admin password for `tools/seed-demo.php` (#118) | `DEMO_PASSWORD`, `DEMO_ADMIN_PASS` |
+| `NENE_VAULT_DEMO_VIEWER_PASSWORD` | Optional | Fixed hand-out demo viewer password for `tools/seed-demo.php` (#118) | `DEMO_VIEWER_PASS` |
 | `DB_HOST` | Required | Database host | `DATABASE_HOST`, `MYSQL_HOST` |
 | `DB_PORT` | Optional | Database port | `DATABASE_PORT`, `MYSQL_PORT` |
 | `DB_NAME` | Required | Database name | `DATABASE_NAME`, `MYSQL_DATABASE` |

--- a/frontend/src/shared/api/client.ts
+++ b/frontend/src/shared/api/client.ts
@@ -32,6 +32,9 @@ async function request<T>(path: string, options: RequestOptions = {}): Promise<T
   const token = authStore.getToken();
   if (token !== null) {
     headers['Authorization'] = `Bearer ${token}`;
+    // Shared-hosting front proxies (HETEML) strip the standard Authorization
+    // header; the backend adopts this mirror when it is absent (#118).
+    headers['X-Authorization'] = `Bearer ${token}`;
   }
 
   const init: RequestInit = {
@@ -68,6 +71,9 @@ async function uploadFormData<T>(path: string, formData: FormData): Promise<T> {
   const token = authStore.getToken();
   if (token !== null) {
     headers['Authorization'] = `Bearer ${token}`;
+    // Shared-hosting front proxies (HETEML) strip the standard Authorization
+    // header; the backend adopts this mirror when it is absent (#118).
+    headers['X-Authorization'] = `Bearer ${token}`;
   }
 
   const response = await fetch(url, {

--- a/public_html/.htaccess
+++ b/public_html/.htaccess
@@ -1,6 +1,12 @@
 Options -MultiViews -Indexes
 RewriteEngine On
 
+# Some CGI/FastCGI hosts have Apache itself drop the Authorization header;
+# re-deliver it as an env var so PHP still sees it. Front proxies that strip
+# it before Apache (HETEML) are covered by the SPA's X-Authorization mirror +
+# AuthorizationHeaderFallback (#118).
+RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+
 # Serve existing static files (JS, CSS, images, fonts) directly
 RewriteCond %{REQUEST_FILENAME} -f
 RewriteRule ^ - [L]

--- a/public_html/index.php
+++ b/public_html/index.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Nene2\Http\ResponseEmitter;
+use NeneVault\Http\AuthorizationHeaderFallback;
 use NeneVault\Http\RuntimeContainerFactory;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Nyholm\Psr7Server\ServerRequestCreator;
@@ -21,6 +22,10 @@ $serverRequestCreator = new ServerRequestCreator(
 );
 
 $request = $serverRequestCreator->fromGlobals();
+
+// Shared-hosting front proxies (HETEML) strip the Authorization header; adopt
+// the SPA's X-Authorization mirror when the standard header is absent (#118).
+$request = AuthorizationHeaderFallback::apply($request);
 $application = $container->get(RequestHandlerInterface::class);
 assert($application instanceof RequestHandlerInterface);
 $response = $application->handle($request);

--- a/src/Demo/DemoDataSeeder.php
+++ b/src/Demo/DemoDataSeeder.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Demo;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\ClockInterface;
+use NeneVault\Document\RestoreDocumentUseCaseInterface;
+use NeneVault\Document\UploadDocumentInput;
+use NeneVault\Document\UploadDocumentUseCaseInterface;
+use NeneVault\Document\VoidDocumentUseCaseInterface;
+
+/**
+ * Seeds one organization with a T-relative received-document demo dataset
+ * (#118): ~20 generated invoice PDFs from fictional Japanese vendors (the
+ * three invoice-demo industries — construction / building maintenance /
+ * creative — so sales can tell one story across products), spread over the
+ * past 12 months, with some void→restore history so the audit trail and
+ * document history have movement.
+ *
+ * **org_id-parameterized by design** (owner decision 07-09): next round's
+ * `Nene2\Demo` disposable-org adoption calls this same class from a
+ * `DemoDataSeederInterface` shim, so the fixed-org tool and the future
+ * `/demo/{template}` flow share one seeder.
+ *
+ * Documents go through the real {@see UploadDocumentUseCaseInterface} —
+ * SHA-256, version rows, retention calculation and audit events are all
+ * authentic — then upload/audit timestamps are spread back over the year
+ * (the one thing a use case cannot do). PDF bodies are romanized (base-14
+ * fonts carry no CJK); the Japanese vendor names live in the searchable
+ * metadata.
+ */
+final readonly class DemoDataSeeder
+{
+    /**
+     * Vendors: Japanese name (metadata), romaji (PDF body), T-number,
+     * industry line items.
+     *
+     * @var list<array{string, string, string, list<string>}>
+     */
+    private const array VENDORS = [
+        ['大和建設株式会社', 'Yamato Kensetsu K.K.', 'T1234567890123', ['Scaffolding work', 'Foundation work', 'Site expenses']],
+        ['株式会社山田工務店', 'Yamada Koumuten Co., Ltd.', 'T2345678901234', ['Carpentry work', 'Interior finishing']],
+        ['あおぞらビルメンテナンス株式会社', 'Aozora Building Maintenance', 'T3456789012345', ['Monthly cleaning service', 'Equipment inspection']],
+        ['ミナト設備管理株式会社', 'Minato Facility Management', 'T4567890123456', ['HVAC maintenance', 'Elevator inspection']],
+        ['クリエイトワークス株式会社', 'Create Works Inc.', 'T5678901234567', ['Design direction', 'Web production']],
+        ['株式会社スタジオ青海', 'Studio Oumi Co., Ltd.', 'T6789012345678', ['Video production', 'Monthly retainer']],
+        ['さくらオフィスサプライ株式会社', 'Sakura Office Supply', 'T7890123456789', ['Office supplies', 'Toner cartridges']],
+        ['東商事株式会社', 'Azuma Shoji K.K.', 'T8901234567890', ['Materials wholesale', 'Delivery charge']],
+        ['藤沢電機株式会社', 'Fujisawa Denki K.K.', 'T9012345678901', ['Electrical work', 'Fixture replacement']],
+    ];
+
+    public function __construct(
+        private UploadDocumentUseCaseInterface $upload,
+        private VoidDocumentUseCaseInterface $void,
+        private RestoreDocumentUseCaseInterface $restore,
+        private DatabaseQueryExecutorInterface $query,
+        private ClockInterface $clock,
+    ) {
+    }
+
+    /**
+     * @return array{documents: int, voided: int, restored: int}
+     */
+    public function seed(int $orgId, ?int $actorUserId): array
+    {
+        $today = $this->clock->now()->setTime(0, 0);
+        mt_srand(20260712 + $orgId); // deterministic content; only T moves
+
+        $documentIds = [];
+        $docCount = 20;
+
+        for ($i = 0; $i < $docCount; $i++) {
+            $vendor = self::VENDORS[$i % count(self::VENDORS)];
+            // Spread over the past 12 months; a few in the current month so the
+            // dashboard looks alive. 電帳法's period search is the showcase.
+            $daysAgo = $i < 3 ? mt_rand(3, 20) : mt_rand(21, 360);
+            $txDate = $today->modify(sprintf('-%d days', $daysAgo));
+
+            $lineDefs = $vendor[3];
+            $lines = [];
+            $total = 0;
+            $lineCount = mt_rand(1, min(2, count($lineDefs)));
+            for ($l = 0; $l < $lineCount; $l++) {
+                $yen = mt_rand(33, 1650) * 1000;
+                $lines[] = [$lineDefs[($i + $l) % count($lineDefs)], $yen];
+                $total += $yen;
+            }
+
+            $invoiceNumber = sprintf('INV-%s-%03d', $txDate->format('Ym'), $i + 1);
+            $pdf = DemoInvoicePdf::build(
+                vendorRomaji: $vendor[1],
+                registrationNumber: $vendor[2],
+                invoiceNumber: $invoiceNumber,
+                issueDate: $txDate->format('Y-m-d'),
+                lines: $lines,
+                totalYen: $total,
+            );
+
+            $tmp = tempnam(sys_get_temp_dir(), 'vault-demo-');
+            if ($tmp === false) {
+                throw new \RuntimeException('Could not create a temp file for the demo PDF.');
+            }
+            file_put_contents($tmp, $pdf);
+
+            try {
+                $category = match (true) {
+                    $i % 7 === 5 => 'receipt',
+                    $i % 7 === 6 => 'delivery_note',
+                    default => 'invoice_received',
+                };
+                $output = $this->upload->execute(new UploadDocumentInput(
+                    organizationId: $orgId,
+                    tmpPath: $tmp,
+                    originalFilename: $invoiceNumber . '.pdf',
+                    mimeType: 'application/pdf',
+                    fileSizeBytes: strlen($pdf),
+                    counterpartyName: $vendor[0],
+                    category: $category,
+                    transactionDate: $txDate->format('Y-m-d'),
+                    amountCents: $total * 100,
+                    tags: $i % 3 === 0 ? ['月次'] : [],
+                    source: 'web_upload',
+                    confirmDuplicate: true,
+                    actorUserId: $actorUserId,
+                ));
+                $document = $output->document;
+            } finally {
+                @unlink($tmp);
+            }
+
+            $documentIds[] = $document->id;
+
+            // Backdate what the use case rightly stamped with "now": the demo
+            // must look like a year of steady operation, not one bulk upload.
+            $uploadedAt = $txDate->modify(sprintf('+%d days', mt_rand(1, 3)))->format('Y-m-d')
+                . sprintf(' %02d:%02d:%02d', mt_rand(9, 17), mt_rand(0, 59), mt_rand(0, 59));
+            $this->query->execute('UPDATE vault_documents SET uploaded_at = ? WHERE id = ?', [$uploadedAt, $document->id]);
+            $this->query->execute('UPDATE document_versions SET uploaded_at = ? WHERE vault_document_id = ?', [$uploadedAt, $document->id]);
+            $this->query->execute(
+                "UPDATE audit_events SET created_at = ? WHERE organization_id = ? AND entity_type = 'vault_document' AND entity_id = ?",
+                [$uploadedAt, $orgId, $document->id],
+            );
+        }
+
+        // History movement: two docs voided then restored, one left voided —
+        // the void/restore trail and the voided-state filter both show life.
+        $voided = 0;
+        $restored = 0;
+        foreach ([4 => true, 9 => true, 14 => false] as $index => $restoreIt) {
+            $documentId = $documentIds[$index];
+            $this->void->execute($documentId, $orgId, '誤アップロード', '別書類と取り違えたため無効化', $actorUserId);
+            $voided++;
+            if ($restoreIt) {
+                $this->restore->execute($documentId, $orgId, $actorUserId);
+                $restored++;
+            }
+        }
+
+        return ['documents' => $docCount, 'voided' => $voided, 'restored' => $restored];
+    }
+}

--- a/src/Demo/DemoInvoicePdf.php
+++ b/src/Demo/DemoInvoicePdf.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Demo;
+
+/**
+ * Generates a minimal, self-contained one-page invoice PDF for demo seeding
+ * (#118) — no PDF library, just the PDF 1.4 syntax with base-14 fonts and a
+ * programmatically corrected xref table, so the bytes are a *valid* PDF that
+ * browsers and viewers render.
+ *
+ * Base-14 fonts carry no CJK glyphs, so the PDF body uses romanized vendor
+ * names and English labels; the Japanese vendor names live in the searchable
+ * document metadata (`counterparty_name`), which is what the 電帳法 search
+ * showcase exercises. The 適格請求書 registration number (T + 13 digits) is
+ * printed prominently.
+ */
+final readonly class DemoInvoicePdf
+{
+    /**
+     * @param list<array{string, int}> $lines item label (ASCII) and amount in yen
+     */
+    public static function build(
+        string $vendorRomaji,
+        string $registrationNumber,
+        string $invoiceNumber,
+        string $issueDate,
+        array $lines,
+        int $totalYen,
+    ): string {
+        $esc = static fn (string $s): string => str_replace(['\\', '(', ')'], ['\\\\', '\\(', '\\)'], $s);
+
+        $content = "BT\n/F1 22 Tf\n50 780 Td\n(INVOICE) Tj\nET\n";
+        $content .= "BT\n/F2 11 Tf\n50 750 Td\n({$esc($vendorRomaji)}) Tj\nET\n";
+        $content .= "BT\n/F2 10 Tf\n50 733 Td\n(Registration No. {$esc($registrationNumber)}) Tj\nET\n";
+        $content .= "BT\n/F2 10 Tf\n400 780 Td\n(No. {$esc($invoiceNumber)}) Tj\nET\n";
+        $content .= "BT\n/F2 10 Tf\n400 765 Td\n(Date: {$esc($issueDate)}) Tj\nET\n";
+        $content .= "50 715 m 545 715 l S\n";
+
+        $y = 685;
+        foreach ($lines as [$label, $yen]) {
+            $amount = number_format($yen);
+            $content .= "BT\n/F2 11 Tf\n60 {$y} Td\n({$esc($label)}) Tj\nET\n";
+            $content .= "BT\n/F2 11 Tf\n440 {$y} Td\n(JPY {$amount}) Tj\nET\n";
+            $y -= 22;
+        }
+
+        $y -= 8;
+        $content .= "50 {$y} m 545 {$y} l S\n";
+        $y -= 24;
+        $total = number_format($totalYen);
+        $content .= "BT\n/F1 13 Tf\n360 {$y} Td\n(TOTAL  JPY {$total}) Tj\nET\n";
+        $content .= "BT\n/F2 8 Tf\n50 60 Td\n(Sample document generated for the NeNe Vault demo. Not a real invoice.) Tj\nET\n";
+
+        $objects = [
+            '<< /Type /Catalog /Pages 2 0 R >>',
+            '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+            '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Resources << /Font << /F1 4 0 R /F2 5 0 R >> >> /Contents 6 0 R >>',
+            '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold >>',
+            '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>',
+            '<< /Length ' . strlen($content) . " >>\nstream\n" . $content . 'endstream',
+        ];
+
+        $pdf = "%PDF-1.4\n";
+        $offsets = [];
+        foreach ($objects as $i => $body) {
+            $offsets[] = strlen($pdf);
+            $pdf .= ($i + 1) . " 0 obj\n" . $body . "\nendobj\n";
+        }
+
+        $xrefAt = strlen($pdf);
+        $pdf .= "xref\n0 " . (count($objects) + 1) . "\n";
+        $pdf .= "0000000000 65535 f \n";
+        foreach ($offsets as $offset) {
+            $pdf .= sprintf('%010d 00000 n ', $offset) . "\n";
+        }
+        $pdf .= "trailer\n<< /Size " . (count($objects) + 1) . " /Root 1 0 R >>\nstartxref\n" . $xrefAt . "\n%%EOF\n";
+
+        return $pdf;
+    }
+}

--- a/src/Demo/DemoOrgReaper.php
+++ b/src/Demo/DemoOrgReaper.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Demo;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+/**
+ * Destroys one demo organization and everything it owns (#118): the DB rows
+ * (children → parents — the migrations declare no FK cascade) **and the org's
+ * document storage tree** (`{storageRoot}/vault/{orgId}/`), which is
+ * Vault-specific residue the sibling reapers don't have.
+ *
+ * A demo org's audit trail is part of its demo data and dies with it — this
+ * NEVER runs against real tenants: callers select targets explicitly (the
+ * reset tool by the fixed demo slug; a future sweeper by the `demo-` prefix).
+ * Idempotent: reaping an org that is already gone is success. Consumer-ready
+ * for the `Nene2\Demo` `DisposableOrgReaperInterface` next round.
+ */
+final readonly class DemoOrgReaper
+{
+    /** Tables carrying `organization_id`, children first. */
+    private const array CHILD_TABLES = [
+        'document_versions',
+        'vault_documents',
+        'audit_events',
+        'vault_settings',
+        'users',
+    ];
+
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+        private string $storageRoot,
+    ) {
+    }
+
+    public function reap(int $orgId): void
+    {
+        foreach (self::CHILD_TABLES as $table) {
+            $this->query->execute("DELETE FROM {$table} WHERE organization_id = ?", [$orgId]);
+        }
+
+        $this->query->execute('DELETE FROM organizations WHERE id = ?', [$orgId]);
+
+        self::removeTree($this->storageRoot . '/vault/' . $orgId);
+    }
+
+    /** Best-effort recursive delete of the org's document tree. */
+    private static function removeTree(string $dir): void
+    {
+        $children = @scandir($dir);
+
+        if ($children === false) {
+            return;
+        }
+
+        foreach ($children as $child) {
+            if ($child === '.' || $child === '..') {
+                continue;
+            }
+
+            $path = $dir . '/' . $child;
+            is_dir($path) ? self::removeTree($path) : @unlink($path);
+        }
+
+        @rmdir($dir);
+    }
+}

--- a/src/Http/AuthorizationHeaderFallback.php
+++ b/src/Http/AuthorizationHeaderFallback.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Http;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Recovers the Bearer token on shared hosting whose front proxy strips the
+ * standard `Authorization` header before it reaches PHP (Tier A concern,
+ * observed on HETEML — custom headers pass through, `Authorization` does
+ * not; proven on the invoice and clear deployments, #118). The admin SPA
+ * mirrors the token into `X-Authorization`; that value is adopted only when
+ * `Authorization` is absent, so environments that deliver the standard
+ * header are unaffected.
+ */
+final readonly class AuthorizationHeaderFallback
+{
+    public const string FALLBACK_HEADER = 'X-Authorization';
+
+    public static function apply(ServerRequestInterface $request): ServerRequestInterface
+    {
+        if ($request->getHeaderLine('Authorization') !== '') {
+            return $request;
+        }
+
+        $fallback = $request->getHeaderLine(self::FALLBACK_HEADER);
+
+        if ($fallback === '') {
+            return $request;
+        }
+
+        return $request->withHeader('Authorization', $fallback);
+    }
+}

--- a/tests/Demo/DemoInvoicePdfTest.php
+++ b/tests/Demo/DemoInvoicePdfTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Tests\Demo;
+
+use NeneVault\Demo\DemoInvoicePdf;
+use PHPUnit\Framework\TestCase;
+
+final class DemoInvoicePdfTest extends TestCase
+{
+    private function build(): string
+    {
+        return DemoInvoicePdf::build(
+            vendorRomaji: 'Yamato Kensetsu K.K.',
+            registrationNumber: 'T1234567890123',
+            invoiceNumber: 'INV-202607-001',
+            issueDate: '2026-07-01',
+            lines: [['Scaffolding work', 550000], ['Site (extra) costs', 66000]],
+            totalYen: 616000,
+        );
+    }
+
+    public function test_produces_a_structurally_valid_pdf(): void
+    {
+        $pdf = $this->build();
+
+        self::assertStringStartsWith('%PDF-1.4', $pdf);
+        self::assertStringEndsWith("%%EOF\n", $pdf);
+
+        // The startxref offset must point at the xref table — the property
+        // real viewers need; a drifting offset means the writer broke.
+        self::assertSame(1, preg_match('/startxref\n(\d+)\n%%EOF\n$/', $pdf, $m));
+        $xrefAt = (int) ($m[1] ?? -1);
+        self::assertSame('xref', substr($pdf, $xrefAt, 4));
+
+        // Every object offset in the xref table points at its object header.
+        preg_match_all('/^(\d{10}) 00000 n /m', $pdf, $offsets);
+        foreach (array_slice($offsets[1], 0, 6) as $i => $offset) {
+            self::assertSame(($i + 1) . ' 0 obj', substr($pdf, (int) $offset, strlen(($i + 1) . ' 0 obj')));
+        }
+    }
+
+    public function test_contains_the_invoice_facts_and_escapes_specials(): void
+    {
+        $pdf = $this->build();
+
+        self::assertStringContainsString('(INVOICE)', $pdf);
+        self::assertStringContainsString('T1234567890123', $pdf);
+        self::assertStringContainsString('INV-202607-001', $pdf);
+        self::assertStringContainsString('TOTAL  JPY 616,000', $pdf);
+        // Parentheses in labels must be escaped inside PDF string literals.
+        self::assertStringContainsString('Site \\(extra\\) costs', $pdf);
+    }
+}

--- a/tests/Demo/DemoSeedLifecycleTest.php
+++ b/tests/Demo/DemoSeedLifecycleTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Tests\Demo;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\UtcClock;
+use NeneVault\Demo\DemoDataSeeder;
+use NeneVault\Demo\DemoOrgReaper;
+use NeneVault\Document\RestoreDocumentUseCaseInterface;
+use NeneVault\Document\UploadDocumentUseCaseInterface;
+use NeneVault\Document\VoidDocumentUseCaseInterface;
+use NeneVault\Organization\CreateOrganizationInput;
+use NeneVault\Organization\CreateOrganizationUseCaseInterface;
+use NeneVault\Tests\Support\ApiTestCase;
+use NeneVault\User\CreateUserUseCaseInterface;
+
+/**
+ * End-to-end lifecycle over the shared test container (#118): seed a demo org
+ * through the real use cases, verify the dataset and the on-disk files, then
+ * reap and verify nothing of the org remains (rows or files).
+ */
+final class DemoSeedLifecycleTest extends ApiTestCase
+{
+    private function storageRoot(): string
+    {
+        $root = (string) (getenv('NENE_VAULT_STORAGE_PATH') ?: 'storage/vault');
+
+        return str_starts_with($root, '/') ? $root : dirname(__DIR__, 2) . '/' . $root;
+    }
+
+    private function query(): DatabaseQueryExecutorInterface
+    {
+        $query = self::bootContainer()->get(DatabaseQueryExecutorInterface::class);
+        assert($query instanceof DatabaseQueryExecutorInterface);
+
+        return $query;
+    }
+
+    private function countFor(string $table, int $orgId): int
+    {
+        $row = $this->query()->fetchOne("SELECT COUNT(*) AS n FROM {$table} WHERE organization_id = ?", [$orgId]);
+
+        return is_array($row) ? (int) $row['n'] : -1;
+    }
+
+    public function test_seed_then_reap_lifecycle(): void
+    {
+        self::bootContainer();
+
+        $container = self::bootContainer();
+        $createOrg = $container->get(CreateOrganizationUseCaseInterface::class);
+        assert($createOrg instanceof CreateOrganizationUseCaseInterface);
+        $createUser = $container->get(CreateUserUseCaseInterface::class);
+        assert($createUser instanceof CreateUserUseCaseInterface);
+        $upload = $container->get(UploadDocumentUseCaseInterface::class);
+        assert($upload instanceof UploadDocumentUseCaseInterface);
+        $void = $container->get(VoidDocumentUseCaseInterface::class);
+        assert($void instanceof VoidDocumentUseCaseInterface);
+        $restore = $container->get(RestoreDocumentUseCaseInterface::class);
+        assert($restore instanceof RestoreDocumentUseCaseInterface);
+
+        $slug = 'demo-lifecycle-' . bin2hex(random_bytes(4));
+        $org = $createOrg->execute(new CreateOrganizationInput(name: 'デモ商事株式会社', slug: $slug));
+        $admin = $createUser->execute('demo-admin@' . $slug . '.example', 'lifecycle-password-1', 'admin', $org->id, null);
+
+        $summary = (new DemoDataSeeder(
+            $upload,
+            $void,
+            $restore,
+            $this->query(),
+            new UtcClock(),
+        ))->seed($org->id, $admin->id);
+
+        self::assertSame(20, $summary['documents']);
+        self::assertSame(20, $this->countFor('vault_documents', $org->id));
+        self::assertSame(20, $this->countFor('document_versions', $org->id));
+
+        // One document stays voided; the two restored ones are active again.
+        $row = $this->query()->fetchOne(
+            "SELECT COUNT(*) AS n FROM vault_documents WHERE organization_id = ? AND status = 'voided'",
+            [$org->id],
+        );
+        self::assertSame(1, is_array($row) ? (int) $row['n'] : -1);
+
+        // Files exist on disk under the org's tree, and SHA-256 round-trips.
+        $orgDir = $this->storageRoot() . '/vault/' . $org->id;
+        self::assertDirectoryExists($orgDir);
+        $version = $this->query()->fetchOne(
+            'SELECT file_path, file_sha256 FROM document_versions WHERE organization_id = ? LIMIT 1',
+            [$org->id],
+        );
+        self::assertIsArray($version);
+        $absolute = $this->storageRoot() . '/' . (string) $version['file_path'];
+        self::assertFileExists($absolute);
+        self::assertSame((string) $version['file_sha256'], hash_file('sha256', $absolute));
+
+        // Dates are spread — not a single bulk-upload day.
+        $range = $this->query()->fetchOne(
+            'SELECT MIN(transaction_date) AS lo, MAX(transaction_date) AS hi FROM vault_documents WHERE organization_id = ?',
+            [$org->id],
+        );
+        self::assertIsArray($range);
+        self::assertNotSame($range['lo'], $range['hi']);
+
+        // Reap: every row and every file of the org is gone.
+        (new DemoOrgReaper($this->query(), $this->storageRoot()))->reap($org->id);
+
+        foreach (['vault_documents', 'document_versions', 'audit_events', 'vault_settings', 'users'] as $table) {
+            self::assertSame(0, $this->countFor($table, $org->id), "{$table} not fully reaped");
+        }
+        $row = $this->query()->fetchOne('SELECT COUNT(*) AS n FROM organizations WHERE id = ?', [$org->id]);
+        self::assertSame(0, is_array($row) ? (int) $row['n'] : -1);
+        self::assertDirectoryDoesNotExist($orgDir);
+
+        // Idempotent: reaping again is a no-op success.
+        (new DemoOrgReaper($this->query(), $this->storageRoot()))->reap($org->id);
+    }
+}

--- a/tests/Http/AuthorizationHeaderFallbackTest.php
+++ b/tests/Http/AuthorizationHeaderFallbackTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Tests\Http;
+
+use NeneVault\Http\AuthorizationHeaderFallback;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class AuthorizationHeaderFallbackTest extends TestCase
+{
+    private function request(): ServerRequestInterface
+    {
+        return (new Psr17Factory())->createServerRequest('GET', '/admin/documents');
+    }
+
+    public function test_standard_header_wins_over_the_mirror(): void
+    {
+        $request = $this->request()
+            ->withHeader('Authorization', 'Bearer standard')
+            ->withHeader('X-Authorization', 'Bearer mirror');
+
+        self::assertSame('Bearer standard', AuthorizationHeaderFallback::apply($request)->getHeaderLine('Authorization'));
+    }
+
+    public function test_mirror_is_adopted_when_standard_header_is_absent(): void
+    {
+        $request = $this->request()->withHeader('X-Authorization', 'Bearer mirror');
+
+        self::assertSame('Bearer mirror', AuthorizationHeaderFallback::apply($request)->getHeaderLine('Authorization'));
+    }
+
+    public function test_no_headers_leaves_the_request_unchanged(): void
+    {
+        self::assertFalse(AuthorizationHeaderFallback::apply($this->request())->hasHeader('Authorization'));
+    }
+}

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -80,7 +80,10 @@ touch "$STAGING/storage/vault/.gitkeep"
 # ── Create ZIP ────────────────────────────────────────────────────────────────
 echo "--> Creating ZIP archive..."
 cd "$DIST"
-zip -r "nene-vault-$VERSION.zip" "nene-vault-$VERSION/" -x "*/\.*" -q
+# Exclude dot-directories but KEEP required dotfiles: the blanket "*/\.*"
+# pattern silently dropped public_html/.htaccess and .env.example from the
+# Tier A zip (#118) — without .htaccess Apache serves no routes at all.
+zip -r "nene-vault-$VERSION.zip" "nene-vault-$VERSION/" -x "*/.git/*" -x "*/.gitkeep" -q
 
 echo ""
 echo "==> Release ZIP: $ZIP_FILE"

--- a/tools/seed-demo.php
+++ b/tools/seed-demo.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Demo-org seeder (#118): drop and re-seed the fixed demo organization with a
+ * T-relative received-document dataset in one command — generated invoice
+ * PDFs from fictional Japanese vendors, spread over the past 12 months, with
+ * void→restore history. Rerun = reset (DB rows AND the org's storage tree).
+ *
+ * The heavy lifting lives in org_id-parameterized classes
+ * ({@see \NeneVault\Demo\DemoDataSeeder}, {@see \NeneVault\Demo\DemoOrgReaper})
+ * so next round's `Nene2\Demo` disposable-org adoption reuses them unchanged
+ * (owner decision 07-09).
+ *
+ * DESTRUCTIVE for the demo org only: every DB row and stored file belonging
+ * to the org with the given slug is deleted first. Do not point this at a
+ * database holding real records.
+ *
+ * Usage:
+ *   php tools/seed-demo.php --force \
+ *     --admin-password '…12+ chars…' --viewer-password '…12+ chars…'
+ *   NENE_VAULT_DEMO_ADMIN_PASSWORD=… NENE_VAULT_DEMO_VIEWER_PASSWORD=… \
+ *     php tools/seed-demo.php --force
+ *
+ * Reads .env like the app (ConfigLoader via RuntimeContainerFactory). With
+ * TENANT_RESOLUTION=single the app serves the org named by ORG_SLUG — set
+ * ORG_SLUG to the demo slug (default `demo`) on a demo deployment.
+ */
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\UtcClock;
+use NeneVault\Demo\DemoDataSeeder;
+use NeneVault\Demo\DemoOrgReaper;
+use NeneVault\Document\RestoreDocumentUseCaseInterface;
+use NeneVault\Document\UploadDocumentUseCaseInterface;
+use NeneVault\Document\VoidDocumentUseCaseInterface;
+use NeneVault\Http\RuntimeContainerFactory;
+use NeneVault\Organization\CreateOrganizationInput;
+use NeneVault\Organization\CreateOrganizationUseCaseInterface;
+use NeneVault\Organization\OrganizationRepositoryInterface;
+use NeneVault\User\CreateUserUseCaseInterface;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+if (PHP_SAPI !== 'cli') {
+    fwrite(STDERR, 'This script must be run from the command line.' . PHP_EOL);
+    exit(1);
+}
+
+$root = dirname(__DIR__);
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, $message . PHP_EOL);
+    exit(1);
+};
+
+// --- Parse arguments (--key value or --key=value) ------------------------------
+$rawArgv = $_SERVER['argv'] ?? [];
+$args = array_slice(is_array($rawArgv) ? array_values($rawArgv) : [], 1);
+$count = count($args);
+/** @var array<string, string> $opts */
+$opts = [];
+for ($i = 0; $i < $count; $i++) {
+    $arg = (string) $args[$i];
+    if ($arg === '-h' || $arg === '--help') {
+        fwrite(STDOUT, implode(PHP_EOL, [
+            'Drop and re-seed the fixed demo organization with T-relative demo documents.',
+            '',
+            'Usage:',
+            '  php tools/seed-demo.php --force --admin-password PASS --viewer-password PASS',
+            '',
+            'Options:',
+            '  --org-slug SLUG        Demo org slug (default: demo — match ORG_SLUG in .env)',
+            '  --org-name NAME        Demo org display name (default: デモ商事株式会社)',
+            '  --admin-email EMAIL    Hand-out admin login (default: demo-admin@nene-vault.dev)',
+            '  --viewer-email EMAIL   Hand-out viewer login (default: demo-viewer@nene-vault.dev)',
+            '  --admin-password PASS  Admin password (default: NENE_VAULT_DEMO_ADMIN_PASSWORD env)',
+            '  --viewer-password PASS Viewer password (default: NENE_VAULT_DEMO_VIEWER_PASSWORD env)',
+            '  --force                Skip the interactive confirmation (required for cron)',
+        ]) . PHP_EOL);
+        exit(0);
+    }
+    if (!str_starts_with($arg, '--')) {
+        $fail(sprintf('Unexpected argument: %s (see --help)', $arg));
+    }
+    $body = substr($arg, 2);
+    if (str_contains($body, '=')) {
+        [$key, $value] = explode('=', $body, 2);
+    } else {
+        $key = $body;
+        $next = $i + 1 < $count ? (string) $args[$i + 1] : '';
+        if ($next !== '' && !str_starts_with($next, '--')) {
+            $value = $next;
+            $i++;
+        } else {
+            $value = '';
+        }
+    }
+    $opts[$key] = $value;
+}
+
+$env = static fn (string $key, string $default = ''): string => (string) (getenv($key) ?: $default);
+$optOr = static function (string $key, string $default) use ($opts): string {
+    $value = trim($opts[$key] ?? '');
+
+    return $value !== '' ? $value : $default;
+};
+
+$orgSlug = $optOr('org-slug', 'demo');
+$orgName = $optOr('org-name', 'デモ商事株式会社');
+$adminEmail = $optOr('admin-email', 'demo-admin@nene-vault.dev');
+$viewerEmail = $optOr('viewer-email', 'demo-viewer@nene-vault.dev');
+$adminPassword = $opts['admin-password'] ?? $env('NENE_VAULT_DEMO_ADMIN_PASSWORD');
+$viewerPassword = $opts['viewer-password'] ?? $env('NENE_VAULT_DEMO_VIEWER_PASSWORD');
+
+if (strlen($adminPassword) < 12 || strlen($viewerPassword) < 12) {
+    $fail('Demo passwords are required and must be at least 12 characters. '
+        . 'Pass --admin-password/--viewer-password or set NENE_VAULT_DEMO_ADMIN_PASSWORD / '
+        . 'NENE_VAULT_DEMO_VIEWER_PASSWORD (keeps credentials stable across resets).');
+}
+
+// --- Confirm the destructive reset ---------------------------------------------
+if (!isset($opts['force'])) {
+    if (!stream_isatty(STDIN)) {
+        $fail('Refusing to reset without confirmation. Pass --force (e.g. from cron).');
+    }
+    fwrite(STDOUT, sprintf(
+        "This DELETES every record and stored file of organization '%s' and reseeds\n"
+        . 'fresh demo documents. Type the org slug to continue: ',
+        $orgSlug,
+    ));
+    $answer = trim((string) fgets(STDIN));
+    if ($answer !== $orgSlug) {
+        $fail('Aborted.');
+    }
+}
+
+// --- Container (same composition root as the app / install.php) ----------------
+$container = (new RuntimeContainerFactory($root))->create();
+
+/** @template T @param class-string<T> $id @return T */
+$get = static function (string $id) use ($container) {
+    $service = $container->get($id);
+    if (!$service instanceof $id) {
+        throw new LogicException($id . ' service is invalid.');
+    }
+
+    return $service;
+};
+
+$query = $get(DatabaseQueryExecutorInterface::class);
+$organizations = $get(OrganizationRepositoryInterface::class);
+
+// Storage root: mirror DocumentServiceProvider's resolution (config boundary).
+$storageRoot = $env('NENE_VAULT_STORAGE_PATH', 'storage/vault');
+if (!str_starts_with($storageRoot, '/')) {
+    $storageRoot = $root . '/' . $storageRoot;
+}
+
+// --- 1) Reap the previous demo org (DB rows + storage tree) --------------------
+$existing = $organizations->findBySlug($orgSlug);
+if ($existing !== null) {
+    (new DemoOrgReaper($query, $storageRoot))->reap($existing->id);
+    fwrite(STDOUT, sprintf('Reaped previous demo organization #%d.', $existing->id) . PHP_EOL);
+} else {
+    fwrite(STDOUT, 'No previous demo organization found.' . PHP_EOL);
+}
+
+// --- 2) Recreate org + hand-out users via the app's own use cases --------------
+$org = $get(CreateOrganizationUseCaseInterface::class)->execute(new CreateOrganizationInput(
+    name: $orgName,
+    slug: $orgSlug,
+));
+$createUser = $get(CreateUserUseCaseInterface::class);
+$admin = $createUser->execute($adminEmail, $adminPassword, 'admin', $org->id, null);
+$createUser->execute($viewerEmail, $viewerPassword, 'viewer', $org->id, null);
+
+// --- 3) Seed the T-relative document set ----------------------------------------
+$summary = (new DemoDataSeeder(
+    $get(UploadDocumentUseCaseInterface::class),
+    $get(VoidDocumentUseCaseInterface::class),
+    $get(RestoreDocumentUseCaseInterface::class),
+    $query,
+    new UtcClock(), // the container registers no clock; CLI is a config boundary
+))->seed($org->id, $admin->id);
+
+fwrite(STDOUT, PHP_EOL . sprintf(
+    'Seeded organization #%d (%s / %s): %d documents (%d voided, %d restored).',
+    $org->id,
+    $orgSlug,
+    $orgName,
+    $summary['documents'],
+    $summary['voided'],
+    $summary['restored'],
+) . PHP_EOL);
+fwrite(STDOUT, PHP_EOL . 'Hand-out credentials:' . PHP_EOL);
+fwrite(STDOUT, sprintf('  admin : %s', $adminEmail) . PHP_EOL);
+fwrite(STDOUT, sprintf('  viewer: %s', $viewerEmail) . PHP_EOL);
+fwrite(STDOUT, PHP_EOL . sprintf("Reminder: TENANT_RESOLUTION=single requires ORG_SLUG=%s in .env.", $orgSlug) . PHP_EOL);
+
+exit(0);


### PR DESCRIPTION
Executes the 2026-07-09 vault demo work order (fixed demo org + reset) with the seeder **org_id-parameterized** per the owner's decision, so the future `Nene2\Demo` disposable-org round reuses it unchanged. Full scope and the disposable-org architectural blocker (host-based tenant resolution) are documented in #118.

- **`tools/seed-demo.php`** — reap + reseed in one command: ~20 generated received-invoice PDFs (structurally valid PDF 1.4, xref-verified; 適格請求書 T+13桁; romanized bodies with Japanese vendor metadata), 12-month T-relative spread, void→restore history, fixed hand-out admin/viewer credentials.
- **`DemoOrgReaper`** — children→parents DB delete (no FK cascade exists) **plus the org's storage tree** (`{root}/vault/{orgId}/`), idempotent.
- **Tier A serving fixes**: `X-Authorization` mirror (SPA) + `AuthorizationHeaderFallback` (front controller) — HETEML's proxy strips `Authorization`, proven live on invoice (#597) and clear (#265); `.htaccess` `E=HTTP_AUTHORIZATION`; release zip no longer drops `.htaccess`/`.env.example` (the blanket `*/\.*` exclusion).
- `docs/demo.md`, `docs/terms.md` §20 registrations, `.env.example`.

**Verification**: `composer check` green (6 new tests: PDF xref/offset validity + escaping, seed→reap lifecycle over the real container with on-disk SHA-256 round-trip and file-tree cleanup, header fallback); `npm run check` green; scratch sqlite walk — 20 docs seeded (1 voided, 2 restored), poppler renders the PDFs, reset reaps rows+files and reseeds without duplicates.

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)