### PR TITLE
Release: dereference path-repo symlinks (zip shipped no framework)

### DIFF
--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -48,6 +48,17 @@ rsync -a --exclude='*.test.*' \
     "$ROOT/src/"       "$STAGING/src/"
 rsync -a \
     "$ROOT/vendor/"    "$STAGING/vendor/"
+
+# Path-repository packages (hideyukimori/nene2) are SYMLINKS in vendor/;
+# rsync -a keeps them as links and zip silently drops them — the shipped zip
+# then contains no framework at all (#122). Dereference into real files.
+find "$STAGING/vendor" -maxdepth 3 -type l | while read -r link; do
+    # Relative link targets only resolve from the ORIGINAL vendor tree.
+    src="$ROOT/vendor/${link#"$STAGING/vendor/"}"
+    real="$(readlink -f "$src")"
+    rm "$link"
+    rsync -a --exclude='.git/' --exclude='node_modules/' "$real/" "$link/"
+done
 rsync -a \
     "$ROOT/locales/"   "$STAGING/locales/"
 rsync -a \


### PR DESCRIPTION
Found deploying #120 to vault.ayane.co.jp: the Tier A zip contained an **empty `vendor/hideyukimori/`** — composer's path repository creates a symlink, `rsync -a` staging preserves it, `zip` drops it, and the deployed app 500s on the first autoload (`/health` included). Every release zip so far was affected; the nene-clear build already carries this dereference step.

Fix: replace vendor symlinks in staging with their real trees (resolved from the original vendor — the copied links are relative), excluding the framework's `.git`. Rebuilt zip verified: 251 `nene2/src/` entries.

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)