### PR TITLE
Load .env at the config boundaries (Tier A org-not-resolved fix)

### DIFF
--- a/public_html/index.php
+++ b/public_html/index.php
@@ -5,11 +5,16 @@ declare(strict_types=1);
 use Nene2\Http\ResponseEmitter;
 use NeneVault\Http\AuthorizationHeaderFallback;
 use NeneVault\Http\RuntimeContainerFactory;
+use NeneVault\Support\EnvFileLoader;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Nyholm\Psr7Server\ServerRequestCreator;
 use Psr\Http\Server\RequestHandlerInterface;
 
 require dirname(__DIR__) . '/vendor/autoload.php';
+
+// Tier A: .env values must reach raw getenv() readers (ORG_SLUG tenant
+// resolution etc.) — shared hosting provides no process env (#124).
+EnvFileLoader::load(dirname(__DIR__));
 
 $container = (new RuntimeContainerFactory(dirname(__DIR__)))->create();
 $psr17Factory = $container->get(Psr17Factory::class);

--- a/src/Support/EnvFileLoader.php
+++ b/src/Support/EnvFileLoader.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Support;
+
+/**
+ * Loads `.env` into the process environment at a config boundary (#124).
+ *
+ * Docker injects real environment variables, but Tier A shared hosting only
+ * has the `.env` file — and while `Nene2\Config\ConfigLoader` parses it into
+ * `AppConfig`, raw `getenv()` readers (tenant resolution's `ORG_SLUG`, CLI
+ * tools) never see those values. This loader bridges the gap: values already
+ * present in the real environment always win, so Docker behavior is
+ * unchanged.
+ */
+final readonly class EnvFileLoader
+{
+    public static function load(string $projectRoot): void
+    {
+        $path = $projectRoot . '/.env';
+
+        if (!is_file($path)) {
+            return;
+        }
+
+        foreach (file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) ?: [] as $line) {
+            $line = trim($line);
+
+            if ($line === '' || str_starts_with($line, '#')) {
+                continue;
+            }
+
+            $parts = explode('=', $line, 2);
+
+            if (count($parts) !== 2) {
+                continue;
+            }
+
+            $key = trim($parts[0]);
+            $value = trim($parts[1]);
+
+            // EnvironmentWriter quotes values when needed; strip one layer.
+            if (strlen($value) >= 2 && $value[0] === '"' && str_ends_with($value, '"')) {
+                $value = stripcslashes(substr($value, 1, -1));
+            }
+
+            if ($key === '' || getenv($key) !== false) {
+                continue; // real environment wins
+            }
+
+            putenv($key . '=' . $value);
+            $_ENV[$key] = $value;
+        }
+    }
+}

--- a/tests/Support/EnvFileLoaderTest.php
+++ b/tests/Support/EnvFileLoaderTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Tests\Support;
+
+use NeneVault\Support\EnvFileLoader;
+use PHPUnit\Framework\TestCase;
+
+final class EnvFileLoaderTest extends TestCase
+{
+    private string $dir;
+
+    protected function setUp(): void
+    {
+        $this->dir = sys_get_temp_dir() . '/' . uniqid('envloader-', true);
+        mkdir($this->dir, 0775, true);
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->dir . '/.env');
+        @rmdir($this->dir);
+        putenv('ENVLOADER_PLAIN');
+        putenv('ENVLOADER_QUOTED');
+        putenv('ENVLOADER_PRESET');
+    }
+
+    public function test_loads_plain_and_quoted_values_and_skips_comments(): void
+    {
+        file_put_contents($this->dir . '/.env', "# comment\nENVLOADER_PLAIN=hello\nENVLOADER_QUOTED=\"with # hash\"\n");
+
+        EnvFileLoader::load($this->dir);
+
+        self::assertSame('hello', getenv('ENVLOADER_PLAIN'));
+        self::assertSame('with # hash', getenv('ENVLOADER_QUOTED'));
+    }
+
+    public function test_real_environment_wins(): void
+    {
+        putenv('ENVLOADER_PRESET=from-real-env');
+        file_put_contents($this->dir . '/.env', "ENVLOADER_PRESET=from-file\n");
+
+        EnvFileLoader::load($this->dir);
+
+        self::assertSame('from-real-env', getenv('ENVLOADER_PRESET'));
+    }
+
+    public function test_missing_file_is_a_no_op(): void
+    {
+        EnvFileLoader::load($this->dir);
+        self::assertFalse(getenv('ENVLOADER_PLAIN'));
+    }
+}

--- a/tools/seed-demo.php
+++ b/tools/seed-demo.php
@@ -36,6 +36,7 @@ use NeneVault\Document\RestoreDocumentUseCaseInterface;
 use NeneVault\Document\UploadDocumentUseCaseInterface;
 use NeneVault\Document\VoidDocumentUseCaseInterface;
 use NeneVault\Http\RuntimeContainerFactory;
+use NeneVault\Support\EnvFileLoader;
 use NeneVault\Organization\CreateOrganizationInput;
 use NeneVault\Organization\CreateOrganizationUseCaseInterface;
 use NeneVault\Organization\OrganizationRepositoryInterface;
@@ -49,6 +50,7 @@ if (PHP_SAPI !== 'cli') {
 }
 
 $root = dirname(__DIR__);
+EnvFileLoader::load($root);
 
 $fail = static function (string $message): never {
     fwrite(STDERR, $message . PHP_EOL);


### PR DESCRIPTION
On vault.ayane.co.jp every authenticated call returned `org-not-resolved`: single-tenant resolution reads `ORG_SLUG` via raw `getenv()`, which is empty on shared hosting where the config lives in `.env` (ConfigLoader parses it into `AppConfig` but never `putenv`s). Same root cause left CLI tools blind to `.env`.

`EnvFileLoader::load()` at `public_html/index.php` and `tools/seed-demo.php`: parse once, real environment wins (Docker unchanged), `EnvironmentWriter`-quoted values unescaped. 3 unit tests; `composer check` green.

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)