### PR TITLE
Route /demo through the front controller

### DIFF
--- a/public_html/.htaccess
+++ b/public_html/.htaccess
@@ -11,8 +11,8 @@ RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 RewriteCond %{REQUEST_FILENAME} -f
 RewriteRule ^ - [L]
 
-# API and health routes → PHP front controller
-RewriteRule ^(admin|health) index.php [QSA,L]
+# API, health and demo-seat routes → PHP front controller (#127)
+RewriteRule ^(admin|health|demo) index.php [QSA,L]
 
 # All other routes → SPA index.html (if present) or PHP front controller
 RewriteCond %{DOCUMENT_ROOT}/index.html -f


### PR DESCRIPTION
Follow-up to #127: `.htaccess` routed only `^(admin|health)` to PHP, so `/demo/standard` was swallowed by the SPA fallback on Apache. Found on the live deployment; one-line rewrite update. Refs #127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)