### PR TITLE
Demo seat: viewer role, never admin (public-URL safety)

### DIFF
--- a/docs/demo.md
+++ b/docs/demo.md
@@ -38,11 +38,13 @@ metadata, which is what the 電帳法 search showcase exercises.
 ## 2.5 Auto-login (`/demo/standard`, #127)
 
 With `DEMO_MODE=1` in `.env`, opening `https://…/demo/standard` seats the
-visitor straight into the demo org as `demo-admin` (a one-shot page stores a
-normal 24 h session in the SPA and lands on the dashboard) — the same
-"hand out one URL" experience as the invoice/clear demos, without the
-disposable-org module. Fail-close: 404 while `DEMO_MODE` is unset or the
-demo admin is not seeded.
+visitor straight into the demo org as **`demo-viewer` (read-only, #130)** —
+one URL, land signed in. Read covers the showcase (search, SHA-256 verified
+download, audit trail, export); the upload demo uses the hand-out **admin**
+credentials on the login form. The seat never mints an admin token: all
+visitors share the one fixed org, so a public admin session would be a
+public upload endpoint. Fail-close: 404 while `DEMO_MODE` is unset or the
+demo viewer is not seeded.
 
 ## 3. Showcase walkthrough (the 見せ場)
 

--- a/src/Demo/SeatFixedDemoHandler.php
+++ b/src/Demo/SeatFixedDemoHandler.php
@@ -14,8 +14,9 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**
- * Auto-login for the fixed demo organization (#127): `GET /demo/standard`
- * mints a normal 24 h access token for the seeded demo admin and serves a
+ * Auto-login for the fixed demo organization (#127, viewer-scoped per #130):
+ * `GET /demo/standard` mints a normal 24 h access token for the seeded demo
+ * VIEWER and serves a
  * one-shot seat page whose nonce'd inline script stores the SPA's
  * `AuthSession` JSON in `localStorage` and replaces into the app — the
  * invoice/clear "open one URL, land signed in" experience, without the
@@ -25,8 +26,10 @@ use Psr\Http\Message\ServerRequestInterface;
  * resolves to the served org, so a token whose `org_id` is that org passes
  * the capability org-scope check.
  *
- * Fail-close: 404 while `DEMO_MODE` is off, and 404 when the demo admin
- * account is absent (not a demo deployment). The page carries its own
+ * Fail-close: 404 while `DEMO_MODE` is off, and 404 when the demo viewer
+ * account is absent (not a demo deployment). The shared-org admin token this
+ * page must NEVER mint again would make the URL a public upload endpoint
+ * (#130) — the disposable-org adoption is the real fix. The page carries its own
  * per-response CSP — the app-wide policy would block the inline script (the
  * trap invoice hit; the security-headers middleware only fills absent
  * headers). Only server-generated values are embedded; nothing from the
@@ -34,7 +37,7 @@ use Psr\Http\Message\ServerRequestInterface;
  */
 final readonly class SeatFixedDemoHandler
 {
-    public const string DEMO_ADMIN_EMAIL = 'demo-admin@nene-vault.dev';
+    public const string DEMO_VIEWER_EMAIL = 'demo-viewer@nene-vault.dev';
 
     private const int TOKEN_TTL_SECONDS = 86400; // mirror LoginUseCase
 
@@ -53,28 +56,32 @@ final readonly class SeatFixedDemoHandler
             return $this->notFound();
         }
 
-        $admin = $this->users->findByEmail(self::DEMO_ADMIN_EMAIL);
+        // Seat as VIEWER (#130): every visitor shares the one fixed org, so a
+        // public admin token would be a public upload endpoint. Read covers
+        // the showcase (search / SHA-256 / audit / export); the upload demo
+        // uses the hand-out admin credentials on the login form.
+        $viewer = $this->users->findByEmail(self::DEMO_VIEWER_EMAIL);
 
-        if ($admin === null || $admin->organizationId === null || Role::tryFrom($admin->role) !== Role::Admin) {
+        if ($viewer === null || $viewer->organizationId === null || Role::tryFrom($viewer->role) !== Role::Viewer) {
             return $this->notFound();
         }
 
         $now = $this->clock->now()->getTimestamp();
         $token = $this->tokenIssuer->issue([
-            'sub' => $admin->email,
-            'user_id' => $admin->id,
-            'role' => $admin->role,
-            'org_id' => $admin->organizationId,
+            'sub' => $viewer->email,
+            'user_id' => $viewer->id,
+            'role' => $viewer->role,
+            'org_id' => $viewer->organizationId,
             'iat' => $now,
             'exp' => $now + self::TOKEN_TTL_SECONDS,
         ]);
 
         $session = json_encode([
             'token' => $token,
-            'userId' => $admin->id,
-            'email' => $admin->email,
-            'role' => $admin->role,
-            'orgId' => $admin->organizationId,
+            'userId' => $viewer->id,
+            'email' => $viewer->email,
+            'role' => $viewer->role,
+            'orgId' => $viewer->organizationId,
         ], JSON_THROW_ON_ERROR | JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP);
 
         $nonce = base64_encode(random_bytes(18));

--- a/tests/Demo/SeatFixedDemoHandlerTest.php
+++ b/tests/Demo/SeatFixedDemoHandlerTest.php
@@ -107,20 +107,20 @@ final class SeatFixedDemoHandlerTest extends TestCase
         return (new Psr17Factory())->createServerRequest('GET', '/demo/standard');
     }
 
-    private function demoAdmin(): User
+    private function demoViewer(): User
     {
         return new User(
             id: 7,
-            email: 'demo-admin@nene-vault.dev',
+            email: 'demo-viewer@nene-vault.dev',
             passwordHash: 'x',
-            role: 'admin',
+            role: 'viewer',
             organizationId: 2,
         );
     }
 
     public function test_fail_close_when_demo_mode_is_off(): void
     {
-        $response = $this->handler(false, $this->demoAdmin())->handle($this->request());
+        $response = $this->handler(false, $this->demoViewer())->handle($this->request());
 
         self::assertSame(404, $response->getStatusCode());
     }
@@ -130,18 +130,20 @@ final class SeatFixedDemoHandlerTest extends TestCase
         self::assertSame(404, $this->handler(true, null)->handle($this->request())->getStatusCode());
     }
 
-    public function test_fail_close_for_a_non_admin_or_orgless_account(): void
+    public function test_fail_close_for_a_non_viewer_or_orgless_account(): void
     {
-        $viewer = new User(id: 8, email: 'demo-admin@nene-vault.dev', passwordHash: 'x', role: 'viewer', organizationId: 2);
-        self::assertSame(404, $this->handler(true, $viewer)->handle($this->request())->getStatusCode());
+        // An admin behind the viewer email must never be seated (#130): a
+        // shared-org admin token would be a public upload endpoint.
+        $admin = new User(id: 8, email: 'demo-viewer@nene-vault.dev', passwordHash: 'x', role: 'admin', organizationId: 2);
+        self::assertSame(404, $this->handler(true, $admin)->handle($this->request())->getStatusCode());
 
-        $orgless = new User(id: 9, email: 'demo-admin@nene-vault.dev', passwordHash: 'x', role: 'admin', organizationId: null);
+        $orgless = new User(id: 9, email: 'demo-viewer@nene-vault.dev', passwordHash: 'x', role: 'viewer', organizationId: null);
         self::assertSame(404, $this->handler(true, $orgless)->handle($this->request())->getStatusCode());
     }
 
     public function test_seat_page_stores_the_auth_session_and_lands_in_the_spa(): void
     {
-        $response = $this->handler(true, $this->demoAdmin())->handle($this->request());
+        $response = $this->handler(true, $this->demoViewer())->handle($this->request());
 
         self::assertSame(200, $response->getStatusCode());
         $html = (string) $response->getBody();
@@ -156,20 +158,20 @@ final class SeatFixedDemoHandlerTest extends TestCase
         $session = json_decode($m[1] ?? '', true);
         self::assertIsArray($session);
         self::assertSame(7, $session['userId']);
-        self::assertSame('demo-admin@nene-vault.dev', $session['email']);
-        self::assertSame('admin', $session['role']);
+        self::assertSame('demo-viewer@nene-vault.dev', $session['email']);
+        self::assertSame('viewer', $session['role']);
         self::assertSame(2, $session['orgId']);
 
         $claims = (new LocalBearerTokenVerifier('seat-test-secret'))->verify((string) $session['token']);
         self::assertSame(7, $claims['user_id']);
         self::assertSame(2, $claims['org_id']);
-        self::assertSame('admin', $claims['role']);
+        self::assertSame('viewer', $claims['role']);
         self::assertEqualsWithDelta(86400, (int) $claims['exp'] - (int) $claims['iat'], 5);
     }
 
     public function test_page_specific_csp_matches_the_script_nonce(): void
     {
-        $response = $this->handler(true, $this->demoAdmin())->handle($this->request());
+        $response = $this->handler(true, $this->demoViewer())->handle($this->request());
 
         $csp = $response->getHeaderLine('Content-Security-Policy');
         self::assertStringContainsString("default-src 'none'", $csp);


### PR DESCRIPTION
Implements #130's interim option (coordinator's acceptance-review finding): the fixed-org seat page now mints the **demo viewer's** session instead of admin — a shared-org public admin token is a public upload endpoint. Read covers the walkable showcase (search / SHA-256-verified download / audit trail / export); the upload demo uses the hand-out admin credentials on the login form. The handler additionally fail-closes if an admin account ever sits behind the viewer email.

The disposable-org adoption (board B) remains the real fix; this makes the URL distributable meanwhile.

Verification: 5 unit tests updated (incl. the new admin-behind-viewer-email 404 guard); `composer check` green.

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)