### PR TITLE
Installer: apply the ClaudeDesign visual design

### DIFF
--- a/public_html/install.php
+++ b/public_html/install.php
@@ -72,7 +72,7 @@ function refuse_install(string $message): never
 function ico(string $name): string
 {
     return match ($name) {
-        'mark' => '<svg viewBox="0 0 42 42" fill="none"><rect x="7" y="5" width="28" height="32" rx="3" stroke="currentColor" stroke-width="2.4"/><path d="M14 13h14M14 19h14M14 25h8" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"/><path d="M25 29.5l3 3 5.5-6" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/></svg>',
+        'mark' => '<svg viewBox="0 0 34 34" fill="none"><circle cx="17" cy="17" r="14.4" stroke="currentColor" stroke-width="1.9"/><circle cx="17" cy="17" r="11" stroke="currentColor" stroke-width="1.05"/><circle cx="17" cy="14.2" r="3.15" fill="currentColor"/><path d="M15.3 15.9 14 22.4h6l-1.3-6.5Z" fill="currentColor"/></svg>',
         'check' => '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M4 10.5l4 4 8-9"/></svg>',
         'x' => '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><path d="M5 5l10 10M15 5L5 15"/></svg>',
         'arrow' => '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M4 10h11M11 5l5 5-5 5"/></svg>',
@@ -392,7 +392,7 @@ function render_installer_page(array $state): string
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>NeNe Vault — セットアップウィザード</title>
-    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 42 42'%3E%3Crect width='42' height='42' rx='8' fill='%23233a5c'/%3E%3Crect x='10' y='8' width='22' height='26' rx='2.5' stroke='%23fff' fill='none' stroke-width='2.2'/%3E%3Cpath d='M15 15h12M15 20h12M15 25h7' stroke='%23c8a96a' stroke-width='2.2' stroke-linecap='round'/%3E%3C/svg%3E">
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 34 34'%3E%3Crect width='34' height='34' rx='7' fill='%232b2f3a'/%3E%3Ccircle cx='17' cy='17' r='11.4' fill='none' stroke='%23d96a4a' stroke-width='1.9'/%3E%3Ccircle cx='17' cy='17' r='8.7' fill='none' stroke='%23d96a4a' stroke-width='1'/%3E%3Ccircle cx='17' cy='14.4' r='2.6' fill='%23d96a4a'/%3E%3Cpath d='M15.5 15.9 14.4 21.4h5.2L18.5 15.9Z' fill='%23d96a4a'/%3E%3C/svg%3E">
     <style>{$css}</style>
     </head>
     <body data-view="{$viewAttr}" data-error="{$errFlag}">
@@ -436,192 +436,348 @@ function render_installer_page(array $state): string
     HTML;
 }
 
-/** Installer stylesheet — NeNe Vault identity: warm paper, deep ink, navy primary, brass accent. */
+/** Installer stylesheet (ClaudeDesign delivery 2026-07-10, #134). */
 function installer_css(): string
 {
     return <<<'CSS'
     :root{
-      --font-sans:"Noto Sans JP",system-ui,-apple-system,"Hiragino Kaku Gothic ProN","Yu Gothic",sans-serif;
+      /* ── fonts — system only (no web fonts permitted); serif echoes IBM Plex Serif ── */
+      --font-sans:system-ui,-apple-system,"Hiragino Kaku Gothic ProN","Yu Gothic UI","Yu Gothic","Noto Sans JP",sans-serif;
+      --font-serif:ui-serif,Georgia,"Hiragino Mincho ProN","Yu Mincho","Noto Serif JP",serif;
       --font-num:ui-monospace,"SFMono-Regular","Menlo","Consolas",monospace;
-      --bg:oklch(97.2% 0.007 83);--surface:oklch(99.4% 0.004 83);--surface-sunk:oklch(95.4% 0.008 83);
-      --border:oklch(90% 0.01 83);--border-strong:oklch(82% 0.014 83);
-      --fg:oklch(25% 0.015 260);--fg-muted:oklch(48% 0.014 260);--fg-subtle:oklch(60% 0.012 260);--fg-faint:oklch(70% 0.01 260);
-      --brand:oklch(38% 0.07 258);--brand-strong:oklch(31% 0.06 260);--brand-deep:oklch(24% 0.045 262);
-      --brand-soft:oklch(94% 0.015 255);--on-brand:oklch(98.5% 0.005 83);
-      --brass:oklch(72% 0.09 85);--brass-deep:oklch(58% 0.1 80);
-      --ok:oklch(47% 0.07 155);--ok-soft:oklch(94.5% 0.028 155);--danger:oklch(49% 0.115 28);--danger-soft:oklch(95% 0.03 28);
-      --warn:oklch(55% 0.075 75);--warn-soft:oklch(95.5% 0.03 83);
-      --radius:8px;--radius-sm:6px;
-      --ring:0 0 0 3px oklch(38% 0.07 258 / 0.18);
+
+      /* ── paper / surfaces — warm, never sterile white (Strongbox) ── */
+      --bg:oklch(97.2% 0.007 83);--surface:oklch(99.4% 0.004 83);--surface-2:oklch(98% 0.006 83);
+      --sunk:oklch(95.4% 0.008 83);--sunk-2:oklch(93.6% 0.009 80);
+
+      /* ── ink — warm deep slate ── */
+      --ink:oklch(29% 0.022 256);--ink-2:oklch(24% 0.02 256);--text:oklch(31% 0.02 256);
+      --text-muted:oklch(49% 0.018 256);--text-faint:oklch(60% 0.015 256);
+
+      /* ── borders — confident hairlines ── */
+      --line:oklch(89% 0.009 83);--line-2:oklch(84% 0.011 80);--line-strong:oklch(76% 0.013 78);
+
+      /* ── navy — primary trust color ── */
+      --navy:oklch(44% 0.085 254);--navy-deep:oklch(37% 0.085 256);--navy-hover:oklch(39% 0.085 255);
+      --navy-soft:oklch(94.5% 0.025 252);--navy-line:oklch(86% 0.04 252);
+
+      /* ── brass — the one accent: value, security, "the vault" ── */
+      --brass:oklch(60% 0.092 73);--brass-deep:oklch(50% 0.09 68);--brass-hi:oklch(72% 0.1 82);
+      --brass-soft:oklch(93% 0.05 80);--brass-line:oklch(82% 0.06 78);
+
+      /* ── seal / 朱 — reserved for the brand mark only ── */
+      --vermil:oklch(54% 0.142 33);--seal:var(--vermil);
+
+      /* ── status ── */
+      --success:oklch(53% 0.072 156);--success-soft:oklch(94% 0.03 156);
+      --danger:oklch(56% 0.097 33);--danger-soft:oklch(94.5% 0.035 33);--danger-hover:oklch(49% 0.1 33);
+      --warning:oklch(60% 0.075 74);--warning-soft:oklch(95% 0.045 80);
+
+      /* ── dark rail (brand panel) ── */
+      --rail:oklch(27% 0.018 258);--rail-2:oklch(31% 0.02 258);--rail-line:oklch(38% 0.018 258);
+      --rail-text:oklch(82% 0.012 258);--rail-faint:oklch(64% 0.014 258);
+
+      /* ── geometry ── */
+      --r:4px;--r-md:6px;--r-lg:8px;--r-full:999px;
+      --shadow-sm:0 1px 2px oklch(28% 0.02 256 / 7%);
+      --shadow:0 2px 6px oklch(28% 0.02 256 / 9%),0 1px 0 oklch(100% 0 0 / 40%) inset;
+      --shadow-lg:0 12px 36px oklch(25% 0.02 256 / 22%);
+      --ease:cubic-bezier(.22,.61,.36,1);--ease-out:cubic-bezier(.16,1,.3,1);
+
+      /* ── aliases: keep the installer's original token names working ── */
+      --brand:var(--navy);--brand-strong:var(--navy-deep);--brand-deep:var(--rail);
+      --brand-soft:var(--navy-soft);--on-brand:oklch(98% 0.01 83);
+      --border:var(--line);--border-strong:var(--line-2);
+      --fg:var(--text);--fg-muted:var(--text-muted);--fg-subtle:var(--text-faint);--fg-faint:oklch(68% 0.013 256);
+      --ok:var(--success);--ok-soft:var(--success-soft);
+      --warn:var(--warning);--warn-soft:var(--warning-soft);
+      --surface-sunk:var(--sunk);
+      --radius:var(--r-md);--radius-sm:var(--r);
+      --ring:0 0 0 3px var(--navy-soft);
     }
     *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
     html,body{height:100%}
-    body{font-family:var(--font-sans);background:var(--bg);color:var(--fg);line-height:1.6;-webkit-font-smoothing:antialiased}
-    code{font-family:var(--font-num);background:oklch(93.5% 0.01 83);padding:.05em .35em;border-radius:4px;font-size:.92em}
+    body{font-family:var(--font-sans);background:var(--bg);color:var(--fg);line-height:1.55;-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility}
+    code{font-family:var(--font-num);background:var(--sunk);padding:.05em .35em;border-radius:var(--r);font-size:.92em;font-feature-settings:"zero" 1}
+
+    /* ============================================================
+       STAGE
+       ============================================================ */
     .iz{min-height:100vh}
     .iz-stage{display:grid;grid-template-columns:minmax(380px,0.92fr) 1.08fr;min-height:100vh}
-    .iz-aside{position:relative;overflow:hidden;color:oklch(93% 0.01 255);display:flex;flex-direction:column;justify-content:space-between;padding:48px 46px 38px;
-      background:linear-gradient(157deg,var(--brand-strong) 0%,var(--brand-deep) 60%,oklch(20% 0.04 264) 100%)}
-    .iz-aside::before{content:"";position:absolute;inset:0;pointer-events:none;background-image:linear-gradient(oklch(100% 0 0/0.05) 1px,transparent 1px),linear-gradient(90deg,oklch(100% 0 0/0.05) 1px,transparent 1px);background-size:40px 40px;mask-image:linear-gradient(150deg,#000 8%,transparent 80%)}
+
+    /* ── brand panel: flat warm-slate rail + radial glow (matches app rail/login) ── */
+    .iz-aside{position:relative;overflow:hidden;color:var(--rail-text);display:flex;flex-direction:column;justify-content:space-between;padding:48px 46px 38px;
+      --seal:oklch(67% 0.15 36);
+      background:radial-gradient(125% 72% at 16% -12%,oklch(34% 0.026 258) 0%,transparent 58%),var(--rail)}
+    .iz-aside::before{content:"";position:absolute;inset:0;pointer-events:none;
+      background-image:linear-gradient(oklch(100% 0 0/0.045) 1px,transparent 1px),linear-gradient(90deg,oklch(100% 0 0/0.045) 1px,transparent 1px);
+      background-size:44px 44px;mask-image:linear-gradient(152deg,#000 6%,transparent 78%)}
     .iz-aside>*{position:relative;z-index:1}
     .iz-bs-top{display:flex;align-items:center;gap:13px}
-    .mono-mark{width:38px;height:36px;flex:none;color:var(--brass)}
+    .mono-mark{width:40px;height:40px;flex:none;color:var(--seal)}
     .mono-mark svg{width:100%;height:100%;display:block}
-    .abt-name{font-size:18px;font-weight:700;color:#fff}
-    .abt-sub{font-size:10.5px;color:oklch(76% 0.03 255);letter-spacing:.16em;text-transform:uppercase;margin-top:3px}
+    .abt-name{font-family:var(--font-serif);font-size:21px;font-weight:600;letter-spacing:.008em;color:oklch(97% 0.01 83);white-space:nowrap;line-height:1.1}
+    .abt-sub{font-size:9px;color:var(--brass);letter-spacing:.2em;text-transform:uppercase;margin-top:3px;font-weight:600}
     .iz-bs-mid{max-width:400px}
-    .iz-bs-mid h2{font-size:24px;font-weight:700;line-height:1.55;color:#fff;text-wrap:balance}
-    .iz-bs-mid .lead{font-size:13px;color:oklch(82% 0.02 255);margin-top:14px;line-height:1.9}
-    .vstep{list-style:none;margin:30px 0 0}
+    .iz-bs-mid h2{font-family:var(--font-serif);font-size:26px;font-weight:600;line-height:1.4;color:oklch(96% 0.01 83);letter-spacing:-.005em;text-wrap:balance}
+    .iz-bs-mid .lead{font-size:13px;color:var(--rail-text);opacity:.9;margin-top:15px;line-height:1.85}
+
+    /* vertical stepper */
+    .vstep{list-style:none;margin:32px 0 0}
     .vstep li{display:flex;gap:14px}
     .vs-rail{display:flex;flex-direction:column;align-items:center;flex:none}
-    .vs-dot{width:30px;height:30px;border-radius:50%;display:grid;place-items:center;font-family:var(--font-num);font-size:13px;font-weight:600;background:oklch(100% 0 0/0.10);color:oklch(85% 0.02 255);border:1px solid oklch(100% 0 0/0.20)}
+    .vs-dot{width:30px;height:30px;border-radius:var(--r);display:grid;place-items:center;font-family:var(--font-num);font-size:13px;font-weight:600;background:oklch(33% 0.02 258);color:var(--rail-faint);border:1px solid var(--rail-line);transition:background .3s var(--ease),color .3s,box-shadow .3s}
     .vs-dot svg{width:14px;height:14px}
-    .vs-line{width:2px;flex:1;min-height:22px;background:oklch(100% 0 0/0.16);margin:4px 0}
+    .vs-line{width:2px;flex:1;min-height:22px;background:var(--rail-line);margin:5px 0;border-radius:1px}
     .vstep li:last-child .vs-line{display:none}
-    .vs-body{padding-top:3px;padding-bottom:18px}
-    .vs-t{font-size:14px;font-weight:600;color:oklch(91% 0.012 255)}
-    .vs-d{font-size:11.5px;color:oklch(70% 0.018 255);margin-top:2px}
-    .vstep li.active .vs-dot{background:var(--brass);color:var(--brand-deep);border-color:var(--brass);box-shadow:0 0 0 5px oklch(100% 0 0/0.08)}
-    .vstep li.active .vs-t{color:#fff}
-    .vstep li.done .vs-dot{background:oklch(100% 0 0/0.16);color:var(--brass)}
-    .vstep li.done .vs-line{background:var(--brass);opacity:.6}
-    .iz-trust{display:flex;flex-wrap:wrap;gap:8px 14px}
-    .tb{display:inline-flex;align-items:center;gap:6px;font-size:11px;color:oklch(78% 0.02 255)}
-    .tb svg{width:13px;height:13px}
-    .copy{font-size:10.5px;color:oklch(60% 0.018 256);margin-top:14px}
-    .iz-main{display:flex;align-items:flex-start;justify-content:center;padding:56px 48px;overflow-y:auto}
+    .vs-body{padding-top:4px;padding-bottom:18px}
+    .vs-t{font-size:13.5px;font-weight:600;color:var(--rail-text)}
+    .vs-d{font-size:11.5px;color:var(--rail-faint);margin-top:2px}
+    .vstep li.active .vs-dot{background:var(--brass);color:var(--rail);border-color:var(--brass);box-shadow:0 0 0 4px oklch(60% 0.092 73/0.16)}
+    .vstep li.active .vs-t{color:oklch(96% 0.01 83)}
+    .vstep li.done .vs-dot{background:oklch(33% 0.02 258);color:var(--brass);border-color:var(--rail-line)}
+    .vstep li.done .vs-line{background:var(--brass);opacity:.5}
+
+    /* trust row + copy */
+    .iz-trust{display:flex;flex-wrap:wrap;gap:9px 16px}
+    .tb{display:inline-flex;align-items:center;gap:6px;font-size:11px;color:var(--rail-faint)}
+    .tb svg{width:13px;height:13px;stroke:var(--brass);opacity:.9}
+    .copy{font-size:10.5px;color:var(--rail-faint);margin-top:16px;letter-spacing:.02em}
+
+    /* ── form column ── */
+    .iz-main{display:flex;align-items:flex-start;justify-content:center;padding:56px 48px;overflow-y:auto;
+      background:radial-gradient(120% 60% at 50% -10%,oklch(96% 0.012 83) 0%,var(--bg) 55%)}
     .iz-form{width:100%;max-width:560px}
+
+    /* horizontal stepper (mobile) */
     .hstep{display:none;gap:8px;margin-bottom:26px}
-    .hs{flex:1;text-align:center;font-size:11.5px;font-weight:600;padding:8px 4px;border-radius:var(--radius-sm);color:var(--fg-faint);background:var(--surface-sunk);border:1px solid var(--border)}
-    .hs.active{background:var(--brand);color:var(--on-brand);border-color:var(--brand)}
-    .hs.done{background:var(--brand-soft);color:var(--brand-strong)}
+    .hs{flex:1;text-align:center;font-size:11.5px;font-weight:600;padding:9px 4px;border-radius:var(--r);color:var(--fg-faint);background:var(--surface);border:1px solid var(--line-2);transition:background .2s,color .2s}
+    .hs.active{background:var(--navy);color:var(--on-brand);border-color:var(--navy)}
+    .hs.done{background:var(--navy-soft);color:var(--navy-deep);border-color:var(--navy-line)}
     .hs.done::before{content:"✓ "}
-    .iz-head{font-size:24px;font-weight:700;letter-spacing:.01em}
-    .iz-headsub{font-size:13px;color:var(--fg-muted);margin:10px 0 24px;line-height:1.9}
-    .alert{display:flex;gap:12px;padding:14px 16px;border-radius:var(--radius);margin-bottom:20px;font-size:13px;border:1px solid}
-    .alert>svg{width:18px;height:18px;flex:none;margin-top:2px}
-    .alert.ok{background:var(--ok-soft);border-color:color-mix(in oklch,var(--ok) 30%,transparent);color:var(--ok)}
-    .alert.error{background:var(--danger-soft);border-color:color-mix(in oklch,var(--danger) 30%,transparent);color:var(--danger)}
-    .alert.warn{background:var(--warn-soft);border-color:color-mix(in oklch,var(--warn) 35%,transparent);color:oklch(42% 0.07 70)}
+
+    /* eyebrow + title */
+    .iz-head{font-family:var(--font-serif);font-size:25px;font-weight:600;letter-spacing:-.01em;color:var(--ink-2);position:relative;padding-left:16px}
+    .iz-head::before{content:"";position:absolute;left:0;top:2px;bottom:2px;width:3px;border-radius:1px;background:var(--brass)}
+    .iz-headsub{font-size:13px;color:var(--fg-muted);margin:11px 0 24px;line-height:1.85}
+
+    /* ============================================================
+       ALERTS / CALLOUTS
+       ============================================================ */
+    .alert{display:flex;gap:12px;padding:14px 16px;border-radius:var(--r-md);margin-bottom:20px;font-size:13px;line-height:1.55;border:1px solid}
+    .alert>svg{width:18px;height:18px;flex:none;margin-top:1px;stroke:currentColor}
+    .alert.ok{background:var(--success-soft);border-color:var(--success);color:var(--success)}
+    .alert.error{background:var(--danger-soft);border-color:var(--danger);color:var(--danger-hover)}
+    .alert.warn{background:var(--warning-soft);border-color:var(--warning);color:oklch(40% 0.09 60)}
     .a-title{font-weight:700}
-    .a-text{margin-top:2px;color:inherit;opacity:.92;line-height:1.75}
+    .a-text{margin-top:2px;color:inherit;opacity:.94;line-height:1.7}
     .alert details{margin-top:8px}
     .alert summary{cursor:pointer;font-size:12px;font-weight:600}
-    .alert .det{font-family:var(--font-num);font-size:11.5px;white-space:pre-wrap;word-break:break-all;background:oklch(100% 0 0/0.55);border-radius:6px;padding:8px 10px;margin-top:6px}
-    .reqs{list-style:none;margin:0 0 24px;border:1px solid var(--border);border-radius:var(--radius);overflow:hidden}
-    .reqs li{display:flex;gap:13px;padding:13px 16px;border-bottom:1px solid var(--border);background:var(--surface)}
+    .alert .det{font-family:var(--font-num);font-size:11.5px;white-space:pre-wrap;word-break:break-all;background:oklch(100% 0 0/0.6);border-radius:var(--r);padding:8px 10px;margin-top:6px}
+
+    /* ============================================================
+       REQUIREMENTS LIST
+       ============================================================ */
+    .reqs{list-style:none;margin:0 0 24px;border:1px solid var(--line);border-radius:var(--r-md);overflow:hidden;box-shadow:var(--shadow-sm)}
+    .reqs li{display:flex;gap:13px;padding:14px 16px;border-bottom:1px solid var(--line);background:var(--surface);transition:background .15s}
     .reqs li:last-child{border-bottom:none}
-    .reqs .ic{width:22px;height:22px;flex:none;border-radius:50%;display:grid;place-items:center;margin-top:2px}
-    .reqs .ic svg{width:12px;height:12px}
-    .reqs li.pass .ic{background:var(--ok-soft);color:var(--ok)}
+    .reqs li:hover{background:var(--surface-2)}
+    .reqs .ic{width:22px;height:22px;flex:none;border-radius:var(--r-full);display:grid;place-items:center;margin-top:1px}
+    .reqs .ic svg{width:12px;height:12px;stroke:currentColor}
+    .reqs li.pass .ic{background:var(--success-soft);color:var(--success)}
     .reqs li.fail .ic{background:var(--danger-soft);color:var(--danger)}
-    .rq-t{font-size:13.5px;font-weight:600}
+    .rq-t{font-size:13.5px;font-weight:600;color:var(--ink-2)}
     .rq-d{font-size:12px;color:var(--fg-subtle);font-family:var(--font-num)}
-    .rq-fix{font-size:12px;color:var(--danger);margin-top:6px;line-height:1.7}
+    .rq-fix{font-size:12px;color:var(--danger-hover);margin-top:6px;line-height:1.7}
+
+    /* ============================================================
+       FORM FIELDS
+       ============================================================ */
     .field{margin-bottom:18px}
-    .label{display:flex;align-items:center;gap:6px;font-size:13px;font-weight:600;margin-bottom:7px}
+    .label{display:flex;align-items:center;gap:6px;font-size:13px;font-weight:600;margin-bottom:7px;color:var(--ink-2)}
     .req{color:var(--danger)}
     .opt{font-size:11px;font-weight:500;color:var(--fg-subtle)}
-    .input,.select{width:100%;padding:10px 12px;font-size:14px;font-family:inherit;color:var(--fg);background:var(--surface);border:1px solid var(--border-strong);border-radius:var(--radius-sm);transition:border-color .15s, box-shadow .15s}
-    .input:focus,.select:focus{outline:none;border-color:var(--brand);box-shadow:var(--ring)}
+    .input,.select{width:100%;padding:10px 12px;font-size:14px;font-family:inherit;color:var(--ink-2);background:var(--surface);border:1px solid var(--line-2);border-radius:var(--r);transition:border-color .14s,box-shadow .14s}
+    .input::placeholder{color:var(--text-faint)}
+    .input:focus,.select:focus{outline:none;border-color:var(--navy);box-shadow:var(--ring)}
     .input.mono{font-family:var(--font-num);font-size:13.5px}
-    .input.is-error{border-color:var(--danger);box-shadow:0 0 0 3px oklch(49% 0.115 28 / 0.15)}
-    .hint{font-size:11.5px;color:var(--fg-subtle);margin-top:6px;line-height:1.7}
-    .err-text{display:flex;align-items:center;gap:5px;font-size:12px;color:var(--danger);font-weight:600;margin-top:6px}
+    .input.is-error{border-color:var(--danger);box-shadow:0 0 0 3px oklch(56% 0.097 33/0.15)}
+    .select{appearance:none;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%236b6456' stroke-width='2.5'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");background-repeat:no-repeat;background-position:right 12px center;padding-right:32px}
+    .hint{font-size:11.5px;color:var(--fg-subtle);margin-top:6px;line-height:1.65}
+    .err-text{display:flex;align-items:center;gap:5px;font-size:12px;color:var(--danger-hover);font-weight:600;margin-top:6px;animation:shake .4s var(--ease)}
     .err-text svg{width:13px;height:13px}
     .form-row2{display:grid;grid-template-columns:1fr 140px;gap:14px}
-    .tip{position:relative;display:inline-grid;place-items:center;width:16px;height:16px;border-radius:50%;background:var(--surface-sunk);border:1px solid var(--border-strong);color:var(--fg-subtle);font-size:10.5px;font-weight:700;cursor:help}
-    .tip-body{position:absolute;left:50%;bottom:calc(100% + 8px);transform:translateX(-50%);width:260px;background:var(--brand-deep);color:oklch(93% 0.008 255);font-size:11.5px;font-weight:400;line-height:1.7;padding:10px 12px;border-radius:8px;opacity:0;pointer-events:none;transition:opacity .12s;z-index:10}
-    .tip:hover .tip-body,.tip:focus .tip-body{opacity:1}
+    .tip{position:relative;display:inline-grid;place-items:center;width:16px;height:16px;border-radius:var(--r-full);background:var(--sunk);border:1px solid var(--line-2);color:var(--fg-subtle);font-size:10.5px;font-weight:700;cursor:help}
+    .tip-body{position:absolute;left:50%;bottom:calc(100% + 8px);transform:translateX(-50%) translateY(4px);width:260px;background:var(--rail);color:oklch(93% 0.008 255);font-size:11.5px;font-weight:400;line-height:1.7;padding:10px 12px;border-radius:var(--r-md);box-shadow:var(--shadow-lg);opacity:0;pointer-events:none;transition:opacity .16s,transform .16s var(--ease-out);z-index:10}
+    .tip:hover .tip-body,.tip:focus .tip-body{opacity:1;transform:translateX(-50%) translateY(0)}
     .pw-wrap{position:relative}
     .pw-wrap .input{padding-right:42px}
-    .pw-eye{position:absolute;right:6px;top:50%;transform:translateY(-50%);width:30px;height:30px;display:grid;place-items:center;background:none;border:0;border-radius:6px;color:var(--fg-subtle);cursor:pointer}
-    .pw-eye:hover{background:var(--surface-sunk)}
+    .pw-eye{position:absolute;right:6px;top:50%;transform:translateY(-50%);width:30px;height:30px;display:grid;place-items:center;background:none;border:0;border-radius:var(--r);color:var(--fg-subtle);cursor:pointer;transition:background .12s,color .12s}
+    .pw-eye:hover{background:var(--sunk);color:var(--ink-2)}
     .pw-eye svg{width:17px;height:17px}
+
+    /* ============================================================
+       BUTTONS
+       ============================================================ */
     .btn-row{display:flex;gap:10px;margin-top:26px}
-    .btn{display:inline-flex;align-items:center;justify-content:center;gap:8px;padding:12px 22px;font-size:14px;font-weight:700;font-family:inherit;border-radius:var(--radius);border:1px solid transparent;cursor:pointer;text-decoration:none;transition:filter .15s}
-    .btn svg{width:16px;height:16px}
-    .btn-primary{background:var(--brand);color:var(--on-brand);flex:1}
-    .btn-primary:hover{filter:brightness(1.1)}
-    .btn-ghost{background:var(--surface);border-color:var(--border-strong);color:var(--fg-muted)}
+    .btn{display:inline-flex;align-items:center;justify-content:center;gap:8px;padding:11px 22px;font-size:14px;font-weight:600;font-family:inherit;border-radius:var(--r);border:1px solid transparent;cursor:pointer;text-decoration:none;transition:background .14s,border-color .14s,box-shadow .14s,transform .05s}
+    .btn svg{width:16px;height:16px;stroke:currentColor;transition:transform .18s var(--ease-out)}
+    .btn:active{transform:translateY(1px)}
+    .btn-primary{background:var(--navy);color:var(--on-brand);flex:1;box-shadow:var(--shadow-sm)}
+    .btn-primary:hover{background:var(--navy-hover);box-shadow:var(--shadow)}
+    .btn-primary:hover svg:last-child{transform:translateX(3px)}
+    .btn-ghost{background:var(--surface);border-color:var(--line-strong);color:var(--fg-muted)}
+    .btn-ghost:hover{background:var(--sunk);border-color:var(--text-faint);color:var(--ink-2)}
     .btn-block{width:100%}
     .btn-lg{padding:14px 24px;font-size:15px}
-    .btn-back{flex:none;padding:12px 14px}
-    .host-help{background:var(--surface-sunk);border:1px solid var(--border);border-radius:var(--radius);padding:14px 16px;margin-bottom:20px}
-    .hh-q{display:flex;align-items:center;gap:7px;font-size:13px;font-weight:700}
-    .hh-q svg{width:15px;height:15px;color:var(--fg-subtle)}
-    .hh-sub{font-size:11.5px;color:var(--fg-subtle);margin:4px 0 10px}
+    .btn-back{flex:none;padding:11px 14px}
+
+    /* ============================================================
+       HOST HELP + CONTROL-PANEL DIAGRAM
+       ============================================================ */
+    .host-help{background:var(--surface-2);border:1px solid var(--line);border-radius:var(--r-md);padding:15px 16px;margin-bottom:20px}
+    .hh-q{display:flex;align-items:center;gap:7px;font-size:13px;font-weight:700;color:var(--ink-2)}
+    .hh-q svg{width:15px;height:15px;color:var(--brass-deep);stroke:currentColor}
+    .hh-sub{font-size:11.5px;color:var(--fg-subtle);margin:5px 0 11px;line-height:1.6}
     .host-chips{display:flex;flex-wrap:wrap;gap:7px}
-    .host-chip{padding:6px 13px;font-size:12px;font-weight:600;font-family:inherit;background:var(--surface);border:1px solid var(--border-strong);border-radius:99px;color:var(--fg-muted);cursor:pointer}
-    .host-chip.on{background:var(--brand);border-color:var(--brand);color:var(--on-brand)}
+    .host-chip{padding:6px 13px;font-size:12px;font-weight:600;font-family:inherit;white-space:nowrap;background:var(--surface);border:1px solid var(--line-2);border-radius:var(--r-full);color:var(--fg-muted);cursor:pointer;transition:background .14s,border-color .14s,color .14s,transform .06s}
+    .host-chip:hover{border-color:var(--line-strong);color:var(--ink-2);transform:translateY(-1px)}
+    .host-chip.on{background:var(--navy);border-color:var(--navy);color:var(--on-brand);transform:none}
     .linkbtn{background:none;border:0;padding:0;font-family:inherit;font-size:12px;font-weight:600;color:var(--brass-deep);cursor:pointer;margin-top:12px;display:inline-flex;align-items:center;gap:4px}
-    .linkbtn svg{width:13px;height:13px;transition:transform .15s}
+    .linkbtn:hover{color:var(--brass);text-decoration:underline;text-underline-offset:2px}
+    .linkbtn svg{width:13px;height:13px;transition:transform .18s var(--ease)}
     .linkbtn.open svg{transform:rotate(180deg)}
-    .cp-diagram{margin-top:12px;border:1px solid var(--border-strong);border-radius:var(--radius);overflow:hidden;background:var(--surface)}
-    .cp-bar{display:flex;align-items:center;gap:5px;padding:7px 12px;background:var(--surface-sunk);border-bottom:1px solid var(--border)}
-    .cp-bar .dot{width:8px;height:8px;border-radius:50%;background:var(--border-strong)}
+    .cp-diagram{margin-top:12px;border:1px solid var(--line-2);border-radius:var(--r-md);overflow:hidden;background:var(--surface);box-shadow:var(--shadow-sm);animation:reveal .28s var(--ease-out)}
+    .cp-bar{display:flex;align-items:center;gap:5px;padding:8px 12px;background:var(--sunk);border-bottom:1px solid var(--line)}
+    .cp-bar .dot{width:8px;height:8px;border-radius:50%;background:var(--line-strong)}
     .cp-url{font-family:var(--font-num);font-size:10.5px;color:var(--fg-faint);margin-left:8px}
     .cp-grid{display:grid;grid-template-columns:120px 1fr}
-    .cp-menu{border-right:1px solid var(--border);padding:10px 0}
+    .cp-menu{border-right:1px solid var(--line);padding:10px 0}
     .cp-mi{display:flex;align-items:center;gap:7px;font-size:11px;color:var(--fg-subtle);padding:6px 12px}
-    .cp-mi.hot{background:var(--brand-soft);color:var(--brand-strong);font-weight:700}
+    .cp-mi.hot{background:var(--navy-soft);color:var(--navy-deep);font-weight:700}
     .cp-bullet{width:5px;height:5px;border-radius:50%;background:currentColor;opacity:.5}
     .cp-body{padding:12px 16px}
-    .cp-h{font-size:12px;font-weight:700;margin-bottom:8px}
+    .cp-h{font-size:12px;font-weight:700;margin-bottom:8px;color:var(--ink-2)}
     .cp-kv{display:grid;grid-template-columns:auto 1fr;gap:4px 14px;font-size:11.5px}
     .cp-kv .k{color:var(--fg-subtle)}
-    .cp-kv .v{font-family:var(--font-num)}
-    .cp-kv .v.hl{background:oklch(93% 0.06 85);border-radius:4px;padding:0 5px;font-weight:700}
-    .cp-note{font-size:11px;color:var(--fg-subtle);margin-top:9px;line-height:1.7}
+    .cp-kv .v{font-family:var(--font-num);color:var(--ink-2)}
+    .cp-kv .v.hl{background:var(--brass-soft);border-radius:var(--r);padding:0 5px;font-weight:700;color:var(--brass-deep)}
+    .cp-note{font-size:11px;color:var(--fg-subtle);margin-top:9px;line-height:1.65}
+
+    /* tenant + section headers */
     .tenant-sec{margin-bottom:10px}
-    .ts-h{display:flex;align-items:center;gap:7px;font-size:13px;font-weight:700;margin-bottom:10px}
-    .ts-h svg{width:15px;height:15px;color:var(--fg-subtle)}
-    .ld-h{font-size:22px;font-weight:700}
-    .ld-sub{font-size:13px;color:var(--fg-muted);margin:8px 0 22px;line-height:1.8}
-    .ld-bar{height:6px;border-radius:99px;background:var(--surface-sunk);overflow:hidden;margin-bottom:20px}
-    .ld-bar span{display:block;height:100%;width:0;border-radius:99px;background:var(--brand);transition:width .5s}
+    .ts-h{display:flex;align-items:center;gap:7px;font-size:13px;font-weight:700;margin-bottom:12px;color:var(--ink-2)}
+    .ts-h::before{content:"";width:3px;height:14px;border-radius:1px;background:var(--brass);flex:none}
+    .ts-h svg{width:15px;height:15px;color:var(--brass-deep);stroke:currentColor}
+
+    /* ============================================================
+       LOADING / SUBSTEPS
+       ============================================================ */
+    .ld-h{font-family:var(--font-serif);font-size:23px;font-weight:600;color:var(--ink-2)}
+    .ld-sub{font-size:13px;color:var(--fg-muted);margin:9px 0 22px;line-height:1.75}
+    .ld-bar{height:6px;border-radius:var(--r-full);background:var(--sunk);overflow:hidden;margin-bottom:20px;border:1px solid var(--line)}
+    .ld-bar span{display:block;height:100%;width:0;border-radius:var(--r-full);background:linear-gradient(90deg,var(--navy),var(--navy-hover));transition:width .55s var(--ease);position:relative;overflow:hidden}
+    .ld-bar span::after{content:"";position:absolute;inset:0;background:linear-gradient(90deg,transparent,oklch(100% 0 0/0.35),transparent);transform:translateX(-100%);animation:sheen 1.4s ease-in-out infinite}
     .substeps{list-style:none}
-    .substeps li{display:flex;align-items:center;gap:13px;padding:12px 0;border-bottom:1px solid var(--border)}
+    .substeps li{display:flex;align-items:center;gap:13px;padding:13px 0;border-bottom:1px solid var(--line);transition:opacity .3s}
     .substeps li:last-child{border-bottom:none}
-    .ss-ic{width:22px;height:22px;flex:none;border-radius:50%;display:grid;place-items:center;background:var(--surface-sunk);color:var(--ok)}
-    .ss-ic svg{width:12px;height:12px}
-    .ss-t{font-size:13.5px;font-weight:600}
+    .ss-ic{width:22px;height:22px;flex:none;border-radius:var(--r-full);display:grid;place-items:center;background:var(--sunk);color:var(--success);transition:background .3s}
+    .ss-ic svg{width:12px;height:12px;stroke:currentColor}
+    .ss-t{font-size:13.5px;font-weight:600;color:var(--ink-2)}
     .ss-d{font-size:11.5px;color:var(--fg-subtle)}
     .ss-meta{margin-left:auto;font-size:11px;font-weight:600;color:var(--fg-faint)}
-    .ss-done .ss-ic{background:var(--ok-soft)}
-    .ss-done .ss-meta{color:var(--ok)}
+    .ss-done .ss-ic{background:var(--success-soft)}
+    .ss-done .ss-ic svg{animation:pop .3s var(--ease-out)}
+    .ss-done .ss-meta{color:var(--success)}
+    .ss-active .ss-t{color:var(--ink-2)}
+    .ss-active .ss-meta{color:var(--navy)}
     .ss-pending{opacity:.5}
-    .spinner{width:13px;height:13px;border:2px solid var(--border-strong);border-top-color:var(--brand);border-radius:50%;animation:spin .7s linear infinite;display:inline-block}
-    @keyframes spin{to{transform:rotate(360deg)}}
-    .ld-warn{display:flex;align-items:center;gap:8px;font-size:12px;color:var(--warn);margin-top:18px}
-    .ld-warn svg{width:14px;height:14px}
-    .done-mark{width:64px;height:64px;border-radius:50%;background:var(--ok-soft);color:var(--ok);display:grid;place-items:center;margin:8px 0 18px;animation:pop .35s ease-out}
-    .done-mark svg{width:30px;height:30px}
-    @keyframes pop{0%{transform:scale(.6);opacity:0}100%{transform:scale(1);opacity:1}}
-    .done-title{font-size:24px;font-weight:700}
-    .done-sub{font-size:13.5px;color:var(--fg-muted);margin:10px 0 22px;line-height:1.9}
-    .sec-warn{display:flex;gap:13px;background:var(--danger-soft);border:1px solid color-mix(in oklch,var(--danger) 30%,transparent);border-radius:var(--radius);padding:15px 17px;margin-bottom:24px}
-    .sw-ico{width:20px;height:20px;flex:none;color:var(--danger);margin-top:2px}
-    .sw-ico svg{width:100%;height:100%}
-    .sw-t{font-size:13.5px;font-weight:700;color:var(--danger)}
-    .sw-d{font-size:12.5px;color:oklch(40% 0.08 28);margin-top:3px;line-height:1.75}
-    .next-h{font-size:13px;font-weight:700;margin-bottom:10px}
-    .next-list{list-style:none;margin-bottom:26px}
-    .next-list li{display:flex;gap:12px;padding:10px 0;border-bottom:1px solid var(--border);font-size:13px}
+    .spinner{width:13px;height:13px;border:2px solid var(--line-strong);border-top-color:var(--navy);border-radius:50%;animation:spin .7s linear infinite;display:inline-block}
+    .ld-warn{display:flex;align-items:center;gap:8px;font-size:12px;color:var(--warning);margin-top:18px}
+    .ld-warn svg{width:14px;height:14px;stroke:currentColor}
+
+    /* ============================================================
+       COMPLETION
+       ============================================================ */
+    .done-mark{position:relative;width:66px;height:66px;border-radius:var(--r-full);background:var(--success-soft);color:var(--success);display:grid;place-items:center;margin:8px 0 20px;animation:pop .4s var(--ease-out)}
+    .done-mark::before{content:"";position:absolute;inset:-8px;border-radius:var(--r-full);border:2px solid var(--success);opacity:0;animation:ring .7s var(--ease-out) .15s}
+    .done-mark svg{width:30px;height:30px;stroke:currentColor}
+    .done-title{font-family:var(--font-serif);font-size:25px;font-weight:600;color:var(--ink-2)}
+    .done-sub{font-size:13.5px;color:var(--fg-muted);margin:11px 0 22px;line-height:1.85}
+    .sec-warn{display:flex;gap:13px;background:var(--danger-soft);border:1px solid var(--danger);border-radius:var(--r-md);padding:15px 17px;margin-bottom:24px}
+    .sw-ico{width:20px;height:20px;flex:none;color:var(--danger);margin-top:1px}
+    .sw-ico svg{width:100%;height:100%;stroke:currentColor}
+    .sw-t{font-size:13.5px;font-weight:700;color:var(--danger-hover)}
+    .sw-d{font-size:12.5px;color:oklch(40% 0.08 33);margin-top:3px;line-height:1.75}
+    .next-h{font-size:12px;font-weight:700;margin-bottom:10px;color:var(--brass-deep);text-transform:uppercase;letter-spacing:.1em}
+    .next-list{list-style:none;margin-bottom:26px;counter-reset:nl}
+    .next-list li{display:flex;gap:12px;padding:11px 0;border-bottom:1px solid var(--line);font-size:13px;color:var(--ink-2)}
     .next-list li:last-child{border-bottom:none}
-    .nl-n{width:22px;height:22px;flex:none;border-radius:50%;background:var(--brand-soft);color:var(--brand-strong);display:grid;place-items:center;font-family:var(--font-num);font-size:11.5px;font-weight:700}
+    .nl-n{width:22px;height:22px;flex:none;border-radius:var(--r-full);background:var(--navy-soft);color:var(--navy-deep);display:grid;place-items:center;font-family:var(--font-num);font-size:11.5px;font-weight:700}
     .nl-d{font-size:12px;color:var(--fg-subtle);margin-top:2px;font-weight:400}
+
     [hidden]{display:none !important}
+
+    /* ============================================================
+       MOTION — entrance & emphasis (CSS only; installer.js unchanged)
+       ============================================================ */
+    @keyframes spin{to{transform:rotate(360deg)}}
+    @keyframes pop{0%{transform:scale(.55);opacity:0}60%{transform:scale(1.08)}100%{transform:scale(1);opacity:1}}
+    @keyframes ring{0%{opacity:.55;transform:scale(.7)}100%{opacity:0;transform:scale(1.15)}}
+    @keyframes sheen{0%{transform:translateX(-100%)}55%,100%{transform:translateX(220%)}}
+    @keyframes reveal{from{opacity:0;transform:translateY(-6px)}to{opacity:1;transform:translateY(0)}}
+    @keyframes shake{10%,90%{transform:translateX(-1px)}30%,70%{transform:translateX(2px)}50%{transform:translateX(-2px)}}
+    @keyframes rise{from{opacity:0;transform:translateY(14px)}to{opacity:1;transform:translateY(0)}}
+    @keyframes slideInAside{from{opacity:0;transform:translateX(-16px)}to{opacity:1;transform:translateX(0)}}
+    @keyframes fadeInDot{from{opacity:0;transform:scale(.7)}to{opacity:1;transform:scale(1)}}
+
+    @media (prefers-reduced-motion:no-preference){
+      /* brand panel eases in from the left, its inner blocks stagger */
+      .iz-aside{animation:slideInAside .5s var(--ease-out) both}
+      .iz-bs-top{animation:rise .5s var(--ease-out) .08s both}
+      .iz-bs-mid{animation:rise .55s var(--ease-out) .16s both}
+      .iz-bs-foot{animation:rise .55s var(--ease-out) .28s both}
+      .vstep li{animation:rise .5s var(--ease-out) both}
+      .vstep li:nth-child(1){animation-delay:.22s}
+      .vstep li:nth-child(2){animation-delay:.30s}
+      .vstep li:nth-child(3){animation-delay:.38s}
+      .vstep li.active .vs-dot{animation:fadeInDot .5s var(--ease-out) .42s both,pulse 2.6s ease-in-out .9s infinite}
+
+      /* form column: direct children rise & stagger */
+      #izView>*{animation:rise .5s var(--ease-out) both}
+      #izView>*:nth-child(1){animation-delay:.10s}
+      #izView>*:nth-child(2){animation-delay:.16s}
+      #izView>*:nth-child(3){animation-delay:.22s}
+      #izView>*:nth-child(4){animation-delay:.28s}
+      #izView>*:nth-child(5){animation-delay:.34s}
+      #izView>*:nth-child(6){animation-delay:.40s}
+      #izView>*:nth-child(n+7){animation-delay:.46s}
+
+      /* loading view rows fade up when it becomes visible */
+      #izLoading:not([hidden])>*{animation:rise .45s var(--ease-out) both}
+      #izLoading:not([hidden])>*:nth-child(2){animation-delay:.05s}
+      #izLoading:not([hidden])>*:nth-child(3){animation-delay:.12s}
+      #izLoading:not([hidden])>*:nth-child(4){animation-delay:.18s}
+      #izLoading:not([hidden]) .substeps li{animation:rise .4s var(--ease-out) both}
+      #izLoading:not([hidden]) .substeps li:nth-child(2){animation-delay:.06s}
+      #izLoading:not([hidden]) .substeps li:nth-child(3){animation-delay:.12s}
+
+      @keyframes pulse{0%,100%{box-shadow:0 0 0 4px oklch(60% 0.092 73/0.16)}50%{box-shadow:0 0 0 7px oklch(60% 0.092 73/0.05)}}
+    }
+
+    /* ============================================================
+       RESPONSIVE
+       ============================================================ */
     @media (max-width:900px){
       .iz-stage{grid-template-columns:1fr}
-      .iz-aside{padding:30px 26px 26px;flex-direction:row;align-items:center;justify-content:space-between;gap:16px}
+      .iz-aside{padding:26px;flex-direction:row;align-items:center;justify-content:space-between;gap:16px}
       .iz-aside .iz-bs-mid,.iz-aside .iz-bs-foot{display:none}
       .iz-main{padding:32px 22px 48px}
       .hstep{display:flex}
     }
-    @media (max-width:520px){.form-row2{grid-template-columns:1fr}.iz-head,.done-title{font-size:21px}}
-    @media (prefers-reduced-motion:reduce){.done-mark{animation:none}}
+    @media (max-width:520px){.form-row2{grid-template-columns:1fr}.iz-head,.done-title{font-size:22px}}
+    @media (prefers-reduced-motion:reduce){.done-mark{animation:none}.done-mark::before{display:none}.ld-bar span::after{display:none}}
     CSS;
 }
 


### PR DESCRIPTION
Applies the 2026-07-10 vault installer delivery (#134): CSS swap + the SPA's keyhole brand mark and matching favicon — the only markup deltas in the whole delivery; `installer.js` and the parts-canvas styles came back byte-identical. Verified by re-running `--export-patterns` and confirming **19/19 files identical** to the delivery (tag-boundary-normalized; the raw diff was one trailing newline inside `<style>`). Headless render checked; `composer check` green. Ships with the next release zip — the live box has no installer (self-unlinked).

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)