### PR TITLE
Demo amounts in whole yen + interpolated upload-hint size

### DIFF
--- a/docs/terms.md
+++ b/docs/terms.md
@@ -468,6 +468,7 @@ Base URL: `https://nene-vault.dev/problems/`
 | `NENE_VAULT_PORT` | Optional | HTTP port (default 8080) | `PORT`, `VAULT_PORT`, `APP_PORT` |
 | `NENE_VAULT_APP_ENV` | Optional | `local` / `test` / `production` | `APP_ENV`, `ENV`, `ENVIRONMENT` |
 | `NENE_VAULT_MAX_FILE_SIZE_MB` | Optional | Max upload size in MB (default 20) | `MAX_FILE_SIZE`, `UPLOAD_LIMIT` |
+| `VITE_NENE_VAULT_MAX_FILE_SIZE_MB` | Optional | Frontend build-time mirror of `NENE_VAULT_MAX_FILE_SIZE_MB` for the upload hint (default 20; #137) | `VITE_MAX_FILE_SIZE` |
 | `NENE_VAULT_DEMO_ADMIN_PASSWORD` | Optional | Fixed hand-out demo admin password for `tools/seed-demo.php` (#118) | `DEMO_PASSWORD`, `DEMO_ADMIN_PASS` |
 | `DEMO_MODE` | Optional | Strict opt-in gate for the demo seat route (`Nene2\Config\ConfigLoader`-parsed; #127) | `DEMO`, `DEMO_ENABLED` |
 | `NENE_VAULT_DEMO_VIEWER_PASSWORD` | Optional | Fixed hand-out demo viewer password for `tools/seed-demo.php` (#118) | `DEMO_VIEWER_PASS` |

--- a/frontend/src/features/document-upload/ui/DocumentUploadModal.test.tsx
+++ b/frontend/src/features/document-upload/ui/DocumentUploadModal.test.tsx
@@ -1,0 +1,25 @@
+import { screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '@tests/render/render-with-providers';
+import { env } from '@/shared/config/env';
+import { DocumentUploadModal } from './DocumentUploadModal';
+
+/**
+ * Regression test for #137: the file hint's {{max_size_mb}} placeholder was
+ * rendered literally because the modal never passed interpolation params.
+ * The hint must show the configured limit (backend NENE_VAULT_MAX_FILE_SIZE_MB
+ * mirror, default 20) as a real number.
+ */
+describe('DocumentUploadModal file hint', () => {
+  it('interpolates the max upload size instead of showing the raw placeholder', () => {
+    renderWithProviders(<DocumentUploadModal onClose={vi.fn()} />);
+
+    const hint = screen.getByText(/PDF/);
+    expect(hint.textContent).toContain(`${String(env.uploadMaxFileSizeMb)} MB`);
+    expect(hint.textContent).not.toContain('{{');
+  });
+
+  it('defaults the mirrored limit to the backend default of 20 MB', () => {
+    expect(env.uploadMaxFileSizeMb).toBe(20);
+  });
+});

--- a/frontend/src/features/document-upload/ui/DocumentUploadModal.tsx
+++ b/frontend/src/features/document-upload/ui/DocumentUploadModal.tsx
@@ -1,3 +1,4 @@
+import { env } from '@/shared/config/env';
 import { useTranslation } from '@/shared/i18n/use-translation';
 import { Button, Field, Input, Modal, Select } from '@/shared/ui';
 import { useDocumentUpload } from '../hooks/use-document-upload';
@@ -29,7 +30,7 @@ export function DocumentUploadModal({ onClose }: DocumentUploadModalProps) {
         <Field
           label={t('document.upload.file_label')}
           required
-          hint={t('document.upload.file_hint')}
+          hint={t('document.upload.file_hint', { max_size_mb: env.uploadMaxFileSizeMb })}
           error={errors.file !== undefined ? requiredMarker : undefined}
         >
           <input

--- a/frontend/src/shared/config/env.ts
+++ b/frontend/src/shared/config/env.ts
@@ -4,10 +4,16 @@ import { z } from 'zod';
 // to the browser; never put secrets in frontend env.
 const envSchema = z.object({
   apiBaseUrl: z.string().default(''),
+  // Mirrors the backend NENE_VAULT_MAX_FILE_SIZE_MB (default 20). If the
+  // server env overrides the limit, set VITE_NENE_VAULT_MAX_FILE_SIZE_MB to
+  // the same value at build time so the upload hint keeps telling the truth.
+  uploadMaxFileSizeMb: z.coerce.number().int().positive().default(20),
 });
 
 const rawBaseUrl: unknown = import.meta.env.VITE_NENE_VAULT_API_BASE_URL;
+const rawMaxFileSizeMb: unknown = import.meta.env.VITE_NENE_VAULT_MAX_FILE_SIZE_MB;
 
 export const env = envSchema.parse({
   apiBaseUrl: typeof rawBaseUrl === 'string' ? rawBaseUrl : '',
+  uploadMaxFileSizeMb: typeof rawMaxFileSizeMb === 'string' ? rawMaxFileSizeMb : undefined,
 });

--- a/src/Demo/DemoDataSeeder.php
+++ b/src/Demo/DemoDataSeeder.php
@@ -119,7 +119,9 @@ final readonly class DemoDataSeeder
                     counterpartyName: $vendor[0],
                     category: $category,
                     transactionDate: $txDate->format('Y-m-d'),
-                    amountCents: $total * 100,
+                    // JPY has no minor unit: amount_cents stores whole yen
+                    // (naming-conventions), matching the PDF total. Never x100.
+                    amountCents: $total,
                     tags: $i % 3 === 0 ? ['月次'] : [],
                     source: 'web_upload',
                     confirmDuplicate: true,

--- a/tests/Demo/DemoSeedLifecycleTest.php
+++ b/tests/Demo/DemoSeedLifecycleTest.php
@@ -96,6 +96,17 @@ final class DemoSeedLifecycleTest extends ApiTestCase
         self::assertFileExists($absolute);
         self::assertSame((string) $version['file_sha256'], hash_file('sha256', $absolute));
 
+        // Amounts are whole yen (JPY has no minor unit — naming-conventions):
+        // the line generator yields ¥33,000–¥3,300,000 per document. A ×100
+        // regression (#136) would blow past the upper bound on every row.
+        $amounts = $this->query()->fetchOne(
+            'SELECT MIN(amount_cents) AS lo, MAX(amount_cents) AS hi FROM vault_documents WHERE organization_id = ?',
+            [$org->id],
+        );
+        self::assertIsArray($amounts);
+        self::assertGreaterThanOrEqual(33_000, (int) $amounts['lo']);
+        self::assertLessThanOrEqual(3_300_000, (int) $amounts['hi']);
+
         // Dates are spread — not a single bulk-upload day.
         $range = $this->query()->fetchOne(
             'SELECT MIN(transaction_date) AS lo, MAX(transaction_date) AS hi FROM vault_documents WHERE organization_id = ?',


### PR DESCRIPTION
Fixes #136, fixes #137. Both bugs surfaced while shooting README screenshots on production.

## Demo seed amounts (#136)

`DemoDataSeeder` multiplied totals by 100, but JPY has no minor unit — `amount_cents` stores whole yen (see `frontend/src/shared/lib/format.ts`, `docs/development/naming-conventions.md`). The demo document list showed ¥149,300,000 where the generated PDF said ¥1,493,000.

- Store `$total` as-is with a comment pinning the convention.
- The line generator already yields a realistic received-invoice band (¥33,000–¥3,300,000, 1–2 lines of ¥33k–¥1,650k), consistent with the invoice/deal demo world — no value redesign needed.
- `DemoSeedLifecycleTest` now asserts MIN/MAX `amount_cents` stay inside that band; a reintroduced ×100 blows the upper bound on every row.

## Upload dialog hint (#137)

`document.upload.file_hint` rendered its `{{max_size_mb}}` placeholder literally because `DocumentUploadModal` passed no interpolation params.

- Authoritative limit: backend `NENE_VAULT_MAX_FILE_SIZE_MB` (default 20, `DocumentServiceProvider`). Mirrored into frontend config as `env.uploadMaxFileSizeMb` (`VITE_NENE_VAULT_MAX_FILE_SIZE_MB`, default 20, zod-validated) and passed to `t()`.
- New `DocumentUploadModal.test.tsx` pins the rendered hint (contains "20 MB", never "{{").
- Documented the new env var in `docs/terms.md` §20.

## Cross-check for the same bug class

Audited every `{{…}}` key in `locales/ja.json` / `locales/en.json` (the only two locales) against all `t()` call sites, static and template-literal: `file_hint` was the only key rendered without its params. Three parameterized keys (`document.detail.version_number`, `document.search.results_count`, `organization.messages.delete_confirm`) are currently unreferenced by the frontend — dormant, not user-visible; left as-is.

## Verification

- `composer check` green (308 tests, PHPStan, CS, locales, OpenAPI, MCP, conformance)
- `npm run check --prefix frontend` green (type-check, lint, tests incl. new regression tests, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)