### PR TITLE
fix(demo): parse sweep created_at in the host default timezone; ship tools/ in the release zip (#143, #145)

### DIFF
--- a/docs/demo.md
+++ b/docs/demo.md
@@ -60,9 +60,11 @@ php tools/sweep-demo.php
 
 Reaps demo orgs (`demo-` slug prefix only) past `DEMO_TTL_HOURS`, enforces
 `DEMO_MAX_ORGS` overflow, deletes each org's DB rows **and storage tree**,
-and prunes stale throttle files. Idempotent. `created_at` is parsed as UTC
-explicitly — on a JST host a bare parse would reap fresh orgs on the spot
-(clear #280 / deal #72; regression-tested in `tests/Demo/SweepDemoScriptTest`).
+and prunes stale throttle files. Idempotent. `created_at` is parsed in the
+host's default timezone — the same timezone `date()` wrote it in (#143;
+Vault differs from clear/deal here, which write UTC and need the UTC-explicit
+parse of clear #280 / deal #72). Regression-tested for JST and UTC hosts in
+`tests/Demo/SweepDemoScriptTest`.
 
 Production wrapper: `~/bin/sweep-vault-demo.sh`, registered hourly in the
 HETEML panel (offset the minute from sibling crons; `:40` is free).

--- a/tests/Demo/SweepDemoScriptTest.php
+++ b/tests/Demo/SweepDemoScriptTest.php
@@ -9,13 +9,16 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Runs the real `tools/sweep-demo.php` as a subprocess with the host timezone
- * pinned to Asia/Tokyo — the production (HETEML) configuration where the
- * clear #280 / deal #72 bug bit live. `created_at` is written in UTC, so a
- * bare `DateTimeImmutable` parse reads every org as 9 hours older than it is
- * and the hourly cron reaps freshly provisioned demo orgs on the spot. The
- * script must parse UTC explicitly: fresh orgs survive, genuinely expired
- * ones are still reaped — and the reaped org's document storage tree goes
- * with it.
+ * pinned to Asia/Tokyo — the production (HETEML) configuration — and to UTC.
+ *
+ * Vault writes `organizations.created_at` with `date()` in the host's default
+ * timezone (unlike clear/deal, which write UTC), so the sweep must parse it
+ * with that same default timezone (#143): each scenario here writes
+ * `created_at` in the timezone the subprocess sweeps under and expects the
+ * same outcome — fresh orgs survive, genuinely expired ones are reaped, and
+ * the reaped org's document storage tree goes with it. (A UTC-forced parse on
+ * the JST host — the transplanted clear #280 / deal #72 shape — read every
+ * org as 9 h in the future and stretched the 3 h TTL to 12 h.)
  */
 final class SweepDemoScriptTest extends TestCase
 {
@@ -52,10 +55,11 @@ final class SweepDemoScriptTest extends TestCase
 
     public function test_fresh_org_survives_and_expired_org_is_reaped_on_a_jst_host(): void
     {
-        $nowUtc = time();
-        $this->insertOrg(1, 'demo-fresh', gmdate('Y-m-d H:i:s', $nowUtc - 60));          // 1 minute old
-        $this->insertOrg(2, 'demo-expired', gmdate('Y-m-d H:i:s', $nowUtc - 4 * 3600));  // past the 3h TTL
-        $this->insertOrg(3, 'ayane', gmdate('Y-m-d H:i:s', $nowUtc - 30 * 24 * 3600));   // fixed showcase org (no prefix)
+        // created_at written the way the app writes it on a JST host: date()
+        // in Asia/Tokyo — the sweep subprocess below runs under the same TZ.
+        $this->insertOrg(1, 'demo-fresh', $this->localStamp('Asia/Tokyo', 60));               // 1 minute old
+        $this->insertOrg(2, 'demo-expired', $this->localStamp('Asia/Tokyo', 4 * 3600));       // past the 3h TTL
+        $this->insertOrg(3, 'ayane', $this->localStamp('Asia/Tokyo', 30 * 24 * 3600));        // fixed showcase org (no prefix)
 
         // Child rows + a storage tree for the org that must be reaped.
         $this->pdo->exec('INSERT INTO users (organization_id) VALUES (2)');
@@ -74,9 +78,8 @@ final class SweepDemoScriptTest extends TestCase
 
     public function test_behaves_identically_on_a_utc_host_and_is_idempotent(): void
     {
-        $nowUtc = time();
-        $this->insertOrg(1, 'demo-fresh', gmdate('Y-m-d H:i:s', $nowUtc - 60));
-        $this->insertOrg(2, 'demo-expired', gmdate('Y-m-d H:i:s', $nowUtc - 4 * 3600));
+        $this->insertOrg(1, 'demo-fresh', $this->localStamp('UTC', 60));
+        $this->insertOrg(2, 'demo-expired', $this->localStamp('UTC', 4 * 3600));
 
         $output = $this->runSweep('UTC');
         self::assertStringContainsString('2 org(s) total, 1 expired, 0 overflow, 1 reaped', $output);
@@ -88,12 +91,20 @@ final class SweepDemoScriptTest extends TestCase
         self::assertSame(['demo-fresh'], $this->remainingSlugs());
     }
 
-    private function insertOrg(int $id, string $slug, string $createdAtUtc): void
+    /** A created_at string as the app's date() would write it in $timezone, $secondsAgo in the past. */
+    private function localStamp(string $timezone, int $secondsAgo): string
+    {
+        return (new \DateTimeImmutable('@' . (time() - $secondsAgo)))
+            ->setTimezone(new \DateTimeZone($timezone))
+            ->format('Y-m-d H:i:s');
+    }
+
+    private function insertOrg(int $id, string $slug, string $createdAt): void
     {
         $stmt = $this->pdo->prepare(
             "INSERT INTO organizations (id, slug, name, created_at, updated_at) VALUES (?, ?, 'Demo', ?, ?)",
         );
-        $stmt->execute([$id, $slug, $createdAtUtc, $createdAtUtc]);
+        $stmt->execute([$id, $slug, $createdAt, $createdAt]);
     }
 
     private function countRows(string $sql): int

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -61,6 +61,11 @@ find "$STAGING/vendor" -maxdepth 3 -type l | while read -r link; do
 done
 rsync -a \
     "$ROOT/locales/"   "$STAGING/locales/"
+# CLI tools ship with the release: the demo sweep/reseed crons (#141) and the
+# email-inbound entry point live here — a zip without tools/ leaves a Tier A
+# install with no cron targets at all (#145).
+rsync -a \
+    "$ROOT/tools/"     "$STAGING/tools/"
 rsync -a \
     "$ROOT/database/"  "$STAGING/database/"
 rsync -a \

--- a/tools/sweep-demo.php
+++ b/tools/sweep-demo.php
@@ -54,11 +54,15 @@ $records = [];
 foreach ($rows as $row) {
     $records[] = new DemoOrgRecord(
         orgId: (int) $row['id'],
-        // created_at is written in UTC (the app-wide UtcClock). Parse it as
-        // UTC explicitly: on a host whose default timezone is ahead of UTC
-        // (production runs Asia/Tokyo) a bare parse would read every fresh
-        // org as hours old and expire it on the spot (clear #280, deal #72).
-        createdAt: new DateTimeImmutable((string) $row['created_at'], new DateTimeZone('UTC')),
+        // Parse created_at in the timezone it was WRITTEN in (#143). Vault's
+        // PdoOrganizationRepository stamps it with date() — the host's default
+        // timezone — unlike clear/deal, which write UTC and therefore need the
+        // UTC-explicit parse (clear #280, deal #72). Web SAPI and this CLI
+        // share php.ini date.timezone on the target host, so the bare parse
+        // is the consistent one: forcing UTC on a JST host read every org as
+        // 9 h in the future and stretched the 3 h TTL to 12 h (caught in the
+        // #141 production acceptance).
+        createdAt: new DateTimeImmutable((string) $row['created_at']),
     );
 }
 


### PR DESCRIPTION
## 目的

#141 の本番実打検収で見つかった運用バグ 2 件の修正。

## 変更点

1. **#143 — sweep の TZ 逆罠**: vault は `organizations.created_at` を `date()`（ホストローカル＝本番 JST）で書く（clear/deal は UtcClock で UTC 書き）。clear #280 / deal #72 から移植した UTC 明示パースは vault では逆効果で、本番実測で org が「9時間未来」扱い → TTL 3h が実質 12h に伸びていた（fail-safe 方向だが誤り。UTC より遅いホストなら即 reap 側に反転する）。「**書いた TZ で読む**」= プロセス既定 TZ の素直なパースへ修正。回帰テストは「書き込み TZ と sweep 実行 TZ を揃えた」JST/UTC 両シナリオに更新（fresh 生存・expired reap・storage ツリー削除・冪等）。
2. **#145 — release zip に tools/ が無い**: `build-release.sh` が `tools/` を staging しておらず、zip からの Tier A インストールに cron 対象（sweep/seed/email-inbound）が一切入らなかった。staging に追加。

## 検証

- `composer test` 337 / 858 全緑（SweepDemoScriptTest は JST 書き/JST 掃き・UTC 書き/UTC 掃きの両形）
- `composer analyse` / `cs` 緑・`bash -n tools/build-release.sh` OK

Self-review: backend-api, release-ci

Closes #143
Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)