### PR TITLE
docs(journal): record 2026-07-10 — demo day (fixed org → #141 disposable) and cron ops

### DIFF
--- a/docs/journal/2026-07-10.md
+++ b/docs/journal/2026-07-10.md
@@ -1,0 +1,59 @@
+# 2026-07-10 — Demo day: fixed org ships in the morning, disposable orgs by midnight (#118 → #141)
+
+The whole day was demo work, in three waves. (Spills into the small hours of
+07-11; recorded here as one day.)
+
+## Fixed-org demo live + Tier A fallout (morning)
+
+`https://vault.ayane.co.jp` went live on the fixed `ayane` org (T-relative
+seed, ~20 generated received-invoice PDFs, void/restore history). Shipping to
+real shared hosting surfaced four genuine Tier A bugs, all fixed same day:
+installer unreachable at the documented docroot (#120), release zip shipping
+no framework because the path-repo symlink was never dereferenced (#122),
+`.env` never reaching raw `getenv()` readers (#124), and HETEML's front proxy
+stripping `Authorization` (#118, `X-Authorization` mirror). The public seat
+was then demoted from admin to viewer (#130 → PR #133) — upload/void 403
+verified in production — making `/demo/standard` distributable. The installer
+also got the ClaudeDesign visual treatment (#134).
+
+## Disposable-org demo (#141, PR #142; follow-ups #143/#145 → PR #146)
+
+The `Nene2\Demo` consumer work landed overnight — see
+`_work/handoff-vault-demo-consumer-2026-07-10-work-order.md` / `-report.md`
+for the full account. The #118 architectural blocker ("tenant resolves from
+host/env, so disposable orgs are unreachable on a single domain") fell to
+claim-based resolution: `AdminApiAuthMiddleware` now runs before
+`OrgResolverMiddleware`, and a verified bearer's `org_id` claim resolves the
+tenant ahead of the host/env strategy (superadmin `null` and unauthenticated
+requests fall back to the existing three strategies, untouched). Reaped-org
+tokens fail closed as 404. `/demo/standard` is now the distribution link —
+disposable org, **admin seat**, so prospects can walk upload → SHA-256 →
+audit log and it all evaporates at TTL 3 h. The fixed viewer seat moved to
+`/demo/guided`. Merged, deployed, live-verified; CI green throughout.
+
+## Demo cron ops (owner + session Rina)
+
+All demo maintenance crons were registered in the HETEML panel and verified:
+
+| command (home-relative) | schedule | verified |
+|---|---|---|
+| `bin/sweep-invoice-demo.sh` | `0 * * * *` | pre-existing; fired 16:00/17:00 |
+| `bin/sweep-clear-demo.sh` | `10 * * * *` | fired 18:10 (4 orgs reaped) |
+| `bin/reseed-clear-demo.sh` | `0 4 * * *` | first firing 07-11 — check log |
+| `bin/reseed-vault-demo.sh` | `30 4 * * *` | wrapper manual run EXIT=0; first firing 07-11 — check log |
+
+Operational lesson, the hard way: the panel **prepends `$HOME` to the command
+path**, so entries must be written home-relative (`bin/xxx.sh`). A full-path
+entry gets double-prefixed and silently never fires — this is why the clear
+sweep missed its 17:10 slot before being corrected. The 07-08 workspace note
+claiming "full home paths work as-is" was wrong and has been corrected in
+`_work/discussion-log/2026-07-08.md`.
+
+## Carry-over
+
+- **Owner (board, due 07-11):** register `bin/sweep-vault-demo.sh` at
+  `40 * * * *` — wrapper installed; until then disposable orgs accumulate but
+  the 200-org cap + 503 keeps it fail-safe. Verify the 04:30 reseed firing in
+  `vault/var/reseed.log` next session.
+- README Live-demo screenshots (workspace board, due 07-13) and the second
+  Doi follow-up (due 07-17) reference this demo.


### PR DESCRIPTION
Docs-only. Adds `docs/journal/` (mirroring nene-clear's convention) with the 2026-07-10 entry: fixed-org demo live + four Tier A fixes, the #141 disposable-org ship, demo-cron registration/verification incl. the HETEML panel home-relative-path lesson, and carry-over (vault sweep cron, 04:30 reseed check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)