### PR TITLE
fix(auth): harden session posture — 1 h token TTL, sessionStorage, login throttle, status check (#148)

### DIFF
--- a/database/migrations/20260711000001_create_login_attempts_table.php
+++ b/database/migrations/20260711000001_create_login_attempts_table.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateLoginAttemptsTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('login_attempts')
+            ->addColumn('identifier_hash', 'string', ['limit' => 64, 'null' => false])
+            ->addColumn('attempt_count', 'integer', ['default' => 0, 'null' => false])
+            ->addColumn('window_started_at', 'datetime', ['null' => false])
+            ->addColumn('locked_until', 'datetime', ['null' => true, 'default' => null])
+            ->addColumn('created_at', 'datetime', ['null' => true, 'default' => null])
+            ->addIndex(['identifier_hash'], ['unique' => true, 'name' => 'uniq_login_attempts_identifier_hash'])
+            ->create();
+    }
+}

--- a/docker/bootstrap-schema.php
+++ b/docker/bootstrap-schema.php
@@ -97,6 +97,16 @@ $pdo->exec('CREATE TABLE IF NOT EXISTS vault_documents (
     void_note TEXT
 )');
 
+$pdo->exec('CREATE TABLE IF NOT EXISTS login_attempts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    identifier_hash VARCHAR(64) NOT NULL,
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    window_started_at DATETIME NOT NULL,
+    locked_until DATETIME,
+    created_at DATETIME,
+    UNIQUE(identifier_hash)
+)');
+
 $pdo->exec('CREATE TABLE IF NOT EXISTS document_versions (
     id CHAR(26) PRIMARY KEY,
     vault_document_id CHAR(26) NOT NULL,

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -41,7 +41,7 @@ Schema: `php docker/bootstrap-schema.php` (sqlite) or phinx/installer (MySQL).
 has no cross-process memory) and org-ceiling check (`DEMO_MAX_ORGS`, 503
 when full) → provision org + throwaway admin (random undisclosed password,
 slug-namespaced email) through the real create-org/create-user use cases →
-seed → seat page stores the SPA's `AuthSession` in `localStorage` and lands
+seed → seat page stores the SPA's `AuthSession` in `sessionStorage` and lands
 in the app signed in.
 
 Tenancy: the minted token carries the disposable org in its `org_id` claim,
@@ -102,7 +102,7 @@ not seeded.
 
 - OCR / email-inbound stay disabled in the demo (external dependencies).
 - Disposable sessions last `DEMO_TTL_HOURS` (token TTL matches the org TTL);
-  fixed-org sessions last 24 h.
+  fixed-org sessions last 1 h (the login TTL, #148).
 - A swept org's leftover token fails closed with 404 `org-not-found` — the
   visitor just re-opens the link.
 

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -83,6 +83,8 @@ paths:
           $ref: '#/components/responses/InvalidCredentials'
         '422':
           $ref: '#/components/responses/ValidationFailed'
+        '429':
+          $ref: '#/components/responses/TooManyLoginAttempts'
 
   /admin/organizations:
     get:
@@ -1486,6 +1488,17 @@ components:
             type: https://nene-vault.dev/problems/invalid-credentials
             title: Invalid Credentials
             status: 401
+    TooManyLoginAttempts:
+      description: Too many failed login attempts for this account/IP; retry after the indicated delay.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+          example:
+            type: https://nene-vault.dev/problems/too-many-login-attempts
+            title: Too Many Login Attempts
+            status: 429
+            retry_after_seconds: 900
     ValidationFailed:
       description: Request body failed validation.
       content:

--- a/docs/terms.md
+++ b/docs/terms.md
@@ -116,6 +116,7 @@ These are patterns, not registered individual class names. Follow them exactly.
 | `document_links` | `DocumentLink` | 関連書類リンク | `links`, `sibling_links`, `doc_links` |
 | `audit_events` | `AuditEvent` | 監査ログ | `audit_logs`, `logs`, `events` |
 | `vault_settings` | `VaultSettings` | 保管設定 | `settings`, `configs`, `vault_config` |
+| `login_attempts` | — (throttle state, no entity) | ログイン試行 | `login_throttle`, `failed_logins`, `auth_attempts` |
 
 ---
 
@@ -200,6 +201,18 @@ These are patterns, not registered individual class names. Follow them exactly.
 | `clear_api_base_url` | VARCHAR nullable | Clear API ベースURL | `clear_url`, `clear_api_url` |
 | `clear_api_token` | VARCHAR nullable | Clear API トークン | `clear_token`, `clear_api_key` |
 | `updated_by` | UUID FK → users | 更新者 | `modified_by`, `changed_by` |
+
+### login_attempts columns
+
+Not tenant-scoped: transient brute-force counters keyed on a hashed
+email + client-IP identifier (raw identifiers are never stored).
+
+| Canonical form | Type | Japanese label | DO NOT use |
+| --- | --- | --- | --- |
+| `identifier_hash` | VARCHAR(64) UNIQUE | 識別子ハッシュ | `identifier`, `email_hash`, `key_hash` |
+| `attempt_count` | INT | 失敗回数 | `attempts`, `failures`, `count` |
+| `window_started_at` | TIMESTAMP | ウィンドウ開始 | `window_start`, `first_attempt_at` |
+| `locked_until` | TIMESTAMP nullable | ロック解除時刻 | `lock_expires_at`, `blocked_until` |
 
 ---
 
@@ -373,6 +386,7 @@ Standard fields used across multiple responses:
 | `tags` | array of strings | タグ | `labels`, `keywords` |
 | `file_sha256` | string (64-char hex) | SHA-256ハッシュ | `sha256`, `hash`, `checksum` |
 | `mime_type` | string | MIMEタイプ | `content_type`, `type` alone |
+| `retry_after_seconds` | integer | ロック解除までの秒数 | `retry_after`, `wait_seconds`, `lockout_seconds` |
 | `original_filename` | string | 元ファイル名 | `filename`, `file_name`, `name` |
 | `file_size_bytes` | integer | ファイルサイズ | `size`, `file_size` |
 | `source` | string enum | アップロード元 | `origin`, `channel` |
@@ -454,6 +468,8 @@ Base URL: `https://nene-vault.dev/problems/`
 | `file-too-large` | `…/file-too-large` | 413 | `payload-too-large`, `file-size-exceeded` |
 | `duplicate-file` | `…/duplicate-file` | 409 | `file-exists`, `duplicate-hash`, `file-duplicate` |
 | `organization-not-found` | `…/organization-not-found` | 404 | `tenant-not-found` |
+| `invalid-credentials` | `…/invalid-credentials` | 401 | `login-failed`, `bad-credentials`, `wrong-password` |
+| `too-many-login-attempts` | `…/too-many-login-attempts` | 429 | `rate-limited`, `login-locked`, `too-many-requests` |
 | `unauthorized` | `…/unauthorized` | 401 | `not-authenticated`, `authentication-required` |
 | `forbidden` | `…/forbidden` | 403 | `access-denied`, `not-authorized`, `permission-denied` |
 | `internal-server-error` | `…/internal-server-error` | 500 | `server-error`, `unexpected-error` |

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -74,6 +74,18 @@ pre-production go-live gate (税理士 Review 3) and Tier A live testing.**
 - [x] Optional email inbound (mailbox → auto-upload via IMAP/MIME parser) — `src/Email/` + `tools/email-inbound.php` (PR #74)
 - [x] OCR assist — suggest metadata from PDF/image, human confirm (PR #76)
 
+## Audit remediation 2026-07-11 — In progress
+
+Fleet structural-alignment audit remediation (#148 / #149 / #150).
+
+- [x] **#148 session posture** — access-token TTL 24 h → 1 h, token storage
+      localStorage → sessionStorage (SPA + both demo seat pages), login throttle
+      (`PdoLoginThrottle`, 5 attempts / 15 min per email+IP, 429 + `retry_after_seconds`),
+      `users.status = 'active'` login check + timing equalization (#150 item).
+- [ ] #150 backend standardization (JWT claims, BearerTokenMiddleware, Packagist
+      NENE2, UTC created_at, HealthCheck/Ulid, release checksum)
+- [ ] #149 frontend generation upgrade (+ typed i18n, auth-gate 401 handling)
+
 ## Go-live gate — Open 🔲
 
 These are the only items between the current (complete, all-green) codebase and

--- a/frontend/src/app/auth-gate.test.tsx
+++ b/frontend/src/app/auth-gate.test.tsx
@@ -5,7 +5,7 @@ import { authStore } from '@/entities/auth';
 import { AuthGate } from './auth-gate';
 
 afterEach(() => {
-  localStorage.clear();
+  sessionStorage.clear();
 });
 
 describe('AuthGate', () => {

--- a/frontend/src/entities/auth/model.test.ts
+++ b/frontend/src/entities/auth/model.test.ts
@@ -10,7 +10,7 @@ const SESSION = {
 };
 
 afterEach(() => {
-  localStorage.clear();
+  sessionStorage.clear();
 });
 
 describe('authStore.setSession / getSession', () => {
@@ -58,8 +58,8 @@ describe('authStore.clearSession', () => {
 });
 
 describe('authStore resilience', () => {
-  it('returns null when localStorage contains malformed JSON', () => {
-    localStorage.setItem('nene_vault_token', '{bad json');
+  it('returns null when sessionStorage contains malformed JSON', () => {
+    sessionStorage.setItem('nene_vault_token', '{bad json');
     expect(authStore.getSession()).toBeNull();
   });
 });

--- a/frontend/src/entities/auth/model.ts
+++ b/frontend/src/entities/auth/model.ts
@@ -1,5 +1,6 @@
-// Auth session store. Same pattern as NeNe Records: the JWT session lives in
-// localStorage; the API client reads getToken() and sends it as a Bearer token.
+// Auth session store. The JWT session lives in sessionStorage (fleet-standard
+// XSS blast-radius mitigation, #148: the token does not persist across browser
+// restarts); the API client reads getToken() and sends it as a Bearer token.
 
 export interface AuthSession {
   token: string;
@@ -14,7 +15,7 @@ const STORAGE_KEY = 'nene_vault_token';
 export const authStore = {
   getSession(): AuthSession | null {
     try {
-      const raw = localStorage.getItem(STORAGE_KEY);
+      const raw = sessionStorage.getItem(STORAGE_KEY);
       if (raw === null) {
         return null;
       }
@@ -26,7 +27,7 @@ export const authStore = {
 
   setSession(session: AuthSession): void {
     try {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(session));
+      sessionStorage.setItem(STORAGE_KEY, JSON.stringify(session));
     } catch {
       // ignore persistence failure
     }
@@ -34,7 +35,7 @@ export const authStore = {
 
   clearSession(): void {
     try {
-      localStorage.removeItem(STORAGE_KEY);
+      sessionStorage.removeItem(STORAGE_KEY);
     } catch {
       // ignore
     }

--- a/frontend/tests/setup/vitest-setup.ts
+++ b/frontend/tests/setup/vitest-setup.ts
@@ -9,6 +9,7 @@ beforeAll(() => {
 afterEach(() => {
   server.resetHandlers();
   localStorage.clear();
+  sessionStorage.clear();
 });
 
 afterAll(() => {

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -17,6 +17,7 @@ use NeneVault\Audit\AuditRouteRegistrar;
 use NeneVault\Audit\AuditServiceProvider;
 use NeneVault\Auth\AuthRouteRegistrar;
 use NeneVault\Auth\InvalidCredentialsExceptionHandler;
+use NeneVault\Auth\TooManyLoginAttemptsExceptionHandler;
 use NeneVault\Auth\UserRepositoryInterface;
 use NeneVault\Demo\DemoServiceProvider;
 use NeneVault\Demo\GuidedDemoRouteRegistrar;
@@ -217,6 +218,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
             static function (ContainerInterface $c): array {
                 return [
                     $c->get(InvalidCredentialsExceptionHandler::class),
+                    $c->get(TooManyLoginAttemptsExceptionHandler::class),
                     $c->get(OrganizationNotFoundExceptionHandler::class),
                     $c->get(OrganizationSlugConflictExceptionHandler::class),
                     $c->get(VaultDocumentNotFoundExceptionHandler::class),

--- a/src/Auth/AuthServiceProvider.php
+++ b/src/Auth/AuthServiceProvider.php
@@ -10,6 +10,7 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use Psr\Container\ContainerInterface;
 
@@ -48,10 +49,28 @@ final readonly class AuthServiceProvider implements ServiceProviderInterface
                 },
             )
             ->set(
+                LoginThrottleInterface::class,
+                static function (ContainerInterface $c): LoginThrottleInterface {
+                    $query = $c->get(DatabaseQueryExecutorInterface::class);
+                    $clock = $c->get(ClockInterface::class);
+
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('DatabaseQueryExecutorInterface service is invalid.');
+                    }
+
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
+
+                    return new PdoLoginThrottle($query, $clock);
+                },
+            )
+            ->set(
                 LoginHandler::class,
                 static function (ContainerInterface $c): LoginHandler {
                     $useCase = $c->get(LoginUseCase::class);
                     $json = $c->get(JsonResponseFactory::class);
+                    $throttle = $c->get(LoginThrottleInterface::class);
 
                     if (!$useCase instanceof LoginUseCase) {
                         throw new LogicException('LoginUseCase service is invalid.');
@@ -61,7 +80,11 @@ final readonly class AuthServiceProvider implements ServiceProviderInterface
                         throw new LogicException('JsonResponseFactory service is invalid.');
                     }
 
-                    return new LoginHandler($useCase, $json);
+                    if (!$throttle instanceof LoginThrottleInterface) {
+                        throw new LogicException('LoginThrottleInterface service is invalid.');
+                    }
+
+                    return new LoginHandler($useCase, $json, $throttle);
                 },
             )
             ->set(
@@ -74,6 +97,18 @@ final readonly class AuthServiceProvider implements ServiceProviderInterface
                     }
 
                     return new InvalidCredentialsExceptionHandler($pd);
+                },
+            )
+            ->set(
+                TooManyLoginAttemptsExceptionHandler::class,
+                static function (ContainerInterface $c): TooManyLoginAttemptsExceptionHandler {
+                    $pd = $c->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$pd instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('ProblemDetailsResponseFactory service is invalid.');
+                    }
+
+                    return new TooManyLoginAttemptsExceptionHandler($pd);
                 },
             )
             ->set(

--- a/src/Auth/LoginHandler.php
+++ b/src/Auth/LoginHandler.php
@@ -18,6 +18,7 @@ final readonly class LoginHandler
     public function __construct(
         private LoginUseCase $useCase,
         private JsonResponseFactory $response,
+        private ?LoginThrottleInterface $throttle = null,
     ) {
     }
 
@@ -42,7 +43,26 @@ final readonly class LoginHandler
             throw new ValidationException($errors);
         }
 
-        $output = $this->useCase->execute(new LoginInput(email: $email, password: $password));
+        // Brute-force / credential-stuffing guard keyed on email + client IP (#148).
+        $identifier = strtolower($email) . '|' . $this->clientIp($request);
+
+        if ($this->throttle !== null) {
+            $remaining = $this->throttle->secondsUntilUnlocked($identifier);
+
+            if ($remaining > 0) {
+                throw new TooManyLoginAttemptsException($remaining);
+            }
+        }
+
+        try {
+            $output = $this->useCase->execute(new LoginInput(email: $email, password: $password));
+        } catch (InvalidCredentialsException $e) {
+            $this->throttle?->recordFailure($identifier);
+
+            throw $e;
+        }
+
+        $this->throttle?->clear($identifier);
 
         return $this->response->create([
             'token'      => $output->token,
@@ -52,5 +72,12 @@ final readonly class LoginHandler
             'role'       => $output->role,
             'org_id'     => $output->orgId,
         ]);
+    }
+
+    private function clientIp(ServerRequestInterface $request): string
+    {
+        $params = $request->getServerParams();
+
+        return (string) ($params['REMOTE_ADDR'] ?? 'unknown');
     }
 }

--- a/src/Auth/LoginThrottleInterface.php
+++ b/src/Auth/LoginThrottleInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Auth;
+
+/**
+ * Brute-force / credential-stuffing guard for the login endpoint. Tracks failed
+ * attempts per identifier (email + client IP) and locks the identifier once a
+ * threshold is exceeded within a rolling window. Ported from the sibling
+ * reconciliation product's proven implementation (#148).
+ */
+interface LoginThrottleInterface
+{
+    /**
+     * Seconds remaining on an active lock, or 0 when not locked.
+     */
+    public function secondsUntilUnlocked(string $identifier): int;
+
+    /**
+     * Record a failed attempt. Engages a lock when the threshold is reached.
+     */
+    public function recordFailure(string $identifier): void;
+
+    /**
+     * Clear all attempt state for an identifier (called on successful login).
+     */
+    public function clear(string $identifier): void;
+}

--- a/src/Auth/LoginUseCase.php
+++ b/src/Auth/LoginUseCase.php
@@ -8,7 +8,13 @@ use Nene2\Auth\TokenIssuerInterface;
 
 final readonly class LoginUseCase
 {
-    private const TOKEN_TTL_SECONDS = 86400; // 24 hours
+    public const int TOKEN_TTL_SECONDS = 3600; // 1 hour — fleet standard (#148)
+
+    /**
+     * A valid bcrypt hash used to equalize timing when the email is unknown,
+     * so a failed login does not reveal whether the account exists (#150).
+     */
+    private const string TIMING_EQUALIZER_HASH = '$2y$12$zIm0IdtQKFLbeCP4lZhm7upwJ7hz/JAj4krfZ53eGCIVzLq82RwP6';
 
     public function __construct(
         private UserRepositoryInterface $users,
@@ -20,7 +26,15 @@ final readonly class LoginUseCase
     {
         $user = $this->users->findByEmail($input->email);
 
-        if ($user === null || !password_verify($input->password, $user->passwordHash)) {
+        // Always run password_verify — against a fixed dummy hash when the
+        // email is unknown — so the response time does not leak whether the
+        // account exists.
+        $hash = $user !== null ? $user->passwordHash : self::TIMING_EQUALIZER_HASH;
+        $passwordMatches = password_verify($input->password, $hash);
+
+        // Only `active` users may log in: `invited` users must accept the
+        // invite first, and any future deactivated state must not authenticate.
+        if ($user === null || $user->status !== 'active' || !$passwordMatches) {
             throw new InvalidCredentialsException();
         }
 

--- a/src/Auth/PdoLoginThrottle.php
+++ b/src/Auth/PdoLoginThrottle.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Auth;
+
+use DateTimeImmutable;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\ClockInterface;
+
+/**
+ * DB-backed login throttle. After {@see MAX_ATTEMPTS} failures within
+ * {@see WINDOW_SECONDS}, the identifier is locked for {@see LOCK_SECONDS}.
+ *
+ * The identifier is hashed before storage so raw emails/IPs are never persisted
+ * in the throttle table.
+ */
+final readonly class PdoLoginThrottle implements LoginThrottleInterface
+{
+    private const int MAX_ATTEMPTS = 5;
+    private const int WINDOW_SECONDS = 900;  // 15 minutes
+    private const int LOCK_SECONDS = 900;    // 15 minutes
+
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+        private ClockInterface $clock,
+    ) {
+    }
+
+    public function secondsUntilUnlocked(string $identifier): int
+    {
+        $row = $this->query->fetchOne(
+            'SELECT locked_until FROM login_attempts WHERE identifier_hash = ?',
+            [$this->hash($identifier)],
+        );
+
+        if ($row === null || ($row['locked_until'] ?? null) === null) {
+            return 0;
+        }
+
+        $now = $this->clock->now();
+        $lockedUntil = new DateTimeImmutable((string) $row['locked_until']);
+        $remaining = $lockedUntil->getTimestamp() - $now->getTimestamp();
+
+        return max(0, $remaining);
+    }
+
+    public function recordFailure(string $identifier): void
+    {
+        $hash = $this->hash($identifier);
+        $now = $this->clock->now();
+        $nowStr = $now->format('Y-m-d H:i:s');
+
+        $row = $this->query->fetchOne(
+            'SELECT attempt_count, window_started_at FROM login_attempts WHERE identifier_hash = ?',
+            [$hash],
+        );
+
+        if ($row === null) {
+            $this->query->execute(
+                'INSERT INTO login_attempts (identifier_hash, attempt_count, window_started_at, locked_until) VALUES (?, 1, ?, NULL)',
+                [$hash, $nowStr],
+            );
+
+            return;
+        }
+
+        $windowStart = new DateTimeImmutable((string) $row['window_started_at']);
+        $windowAge = $now->getTimestamp() - $windowStart->getTimestamp();
+
+        // Window expired → start a fresh window.
+        if ($windowAge > self::WINDOW_SECONDS) {
+            $this->query->execute(
+                'UPDATE login_attempts SET attempt_count = 1, window_started_at = ?, locked_until = NULL WHERE identifier_hash = ?',
+                [$nowStr, $hash],
+            );
+
+            return;
+        }
+
+        $count = (int) $row['attempt_count'] + 1;
+        $lockedUntil = $count >= self::MAX_ATTEMPTS
+            ? $now->modify('+' . self::LOCK_SECONDS . ' seconds')->format('Y-m-d H:i:s')
+            : null;
+
+        $this->query->execute(
+            'UPDATE login_attempts SET attempt_count = ?, locked_until = ? WHERE identifier_hash = ?',
+            [$count, $lockedUntil, $hash],
+        );
+    }
+
+    public function clear(string $identifier): void
+    {
+        // Intentional hard delete: login_attempts holds transient rate-limit
+        // counters, not auditable business history. Resetting the counter on a
+        // successful login is the table's purpose, so the no-hard-delete rule
+        // (which covers vault documents) does not apply here.
+        $this->query->execute(
+            'DELETE FROM login_attempts WHERE identifier_hash = ?',
+            [$this->hash($identifier)],
+        );
+    }
+
+    private function hash(string $identifier): string
+    {
+        return hash('sha256', strtolower($identifier));
+    }
+}

--- a/src/Auth/TooManyLoginAttemptsException.php
+++ b/src/Auth/TooManyLoginAttemptsException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Auth;
+
+use RuntimeException;
+
+/**
+ * Thrown when an identifier (email + client IP) exceeds the allowed number of
+ * failed login attempts within the window. Maps to HTTP 429.
+ */
+final class TooManyLoginAttemptsException extends RuntimeException
+{
+    public function __construct(public readonly int $retryAfterSeconds)
+    {
+        parent::__construct('Too many login attempts.');
+    }
+}

--- a/src/Auth/TooManyLoginAttemptsExceptionHandler.php
+++ b/src/Auth/TooManyLoginAttemptsExceptionHandler.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Auth;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class TooManyLoginAttemptsExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $e): bool
+    {
+        return $e instanceof TooManyLoginAttemptsException;
+    }
+
+    public function handle(Throwable $e, ServerRequestInterface $request): ResponseInterface
+    {
+        assert($e instanceof TooManyLoginAttemptsException);
+
+        return $this->problemDetails->create(
+            $request,
+            'too-many-login-attempts',
+            'Too Many Login Attempts',
+            429,
+            $e->getMessage(),
+            ['retry_after_seconds' => $e->retryAfterSeconds],
+        );
+    }
+}

--- a/src/Demo/DemoServiceProvider.php
+++ b/src/Demo/DemoServiceProvider.php
@@ -28,7 +28,7 @@ use Psr\Container\ContainerInterface;
 /**
  * Wires the disposable-demo domain as a `Nene2\Demo` consumer (#141): the
  * product concretes (provisioner over the real create-org/create-user use
- * cases, the #118 seeder behind the framework contract, the localStorage
+ * cases, the #118 seeder behind the framework contract, the sessionStorage
  * seat page), the creation-time capacity guard (per-IP file-backed throttle +
  * instance-wide org ceiling), the branded browser error page, and the
  * framework handler + route registrar. No auth code is added — the seater

--- a/src/Demo/DemoSessionSeater.php
+++ b/src/Demo/DemoSessionSeater.php
@@ -22,13 +22,15 @@ use Psr\Http\Message\ServerRequestInterface;
  * shape and secret as {@see \NeneVault\Auth\LoginUseCase}; the token's
  * `org_id` claim is what {@see \NeneVault\Organization\Resolution\OrgResolverMiddleware}
  * resolves the tenant from — and serves a one-shot seat page whose nonce'd
- * inline script stores the SPA's `AuthSession` JSON in `localStorage`
+ * inline script stores the SPA's `AuthSession` JSON in `sessionStorage`
  * (key `nene_vault_token`, the exact shape `frontend/src/entities/auth/model.ts`
  * persists after a login) and replaces into the app. Zero frontend change.
  *
- * The token TTL matches the demo org TTL ({@see DemoConfig::$ttlHours}) rather
- * than the 24 h login TTL: the org is swept by then, and a shorter token means
- * the stale session dies with its data instead of 404-ing for another day.
+ * The token TTL deliberately matches the demo org TTL ({@see DemoConfig::$ttlHours},
+ * 3 h) rather than the 1 h login TTL: the disposable org lives exactly that
+ * long, so the seat stays usable for the whole hands-on session and the stale
+ * token dies with its data when the org is swept (semantics pinned by
+ * {@see \NeneVault\Tests\Demo\DemoSessionSeaterTest}).
  *
  * The page carries its own per-response CSP — the app-wide policy would block
  * the inline script (the invoice #612 trap; the security-headers middleware
@@ -83,7 +85,7 @@ final readonly class DemoSessionSeater implements DemoSessionSeaterInterface
         <noscript><p>デモの開始には JavaScript が必要です。ブラウザの JavaScript を有効にして、もう一度お試しください。</p></noscript>
         <p>デモを準備しています…</p>
         <script nonce="{$nonce}">
-        localStorage.setItem('nene_vault_token', JSON.stringify({$session}));
+        sessionStorage.setItem('nene_vault_token', JSON.stringify({$session}));
         location.replace('/');
         </script>
         </body>

--- a/src/Demo/SeatFixedDemoHandler.php
+++ b/src/Demo/SeatFixedDemoHandler.php
@@ -7,6 +7,7 @@ namespace NeneVault\Demo;
 use Nene2\Auth\TokenIssuerInterface;
 use Nene2\Demo\DemoConfig;
 use Nene2\Http\ClockInterface;
+use NeneVault\Auth\LoginUseCase;
 use NeneVault\Auth\Role;
 use NeneVault\Auth\UserRepositoryInterface;
 use Nyholm\Psr7\Factory\Psr17Factory;
@@ -15,10 +16,10 @@ use Psr\Http\Message\ServerRequestInterface;
 
 /**
  * Auto-login for the fixed demo organization (#127, viewer-scoped per #130,
- * served at `GET /demo/guided` since #141): mints a normal 24 h access token
- * for the seeded demo VIEWER and serves a
+ * served at `GET /demo/guided` since #141): mints a normal access token
+ * (same 1 h TTL as {@see LoginUseCase}) for the seeded demo VIEWER and serves a
  * one-shot seat page whose nonce'd inline script stores the SPA's
- * `AuthSession` JSON in `localStorage` and replaces into the app — the
+ * `AuthSession` JSON in `sessionStorage` and replaces into the app — the
  * invoice/clear "open one URL, land signed in" experience against the
  * shared, nightly-reseeded showcase org. The disposable-org demo
  * ({@see DemoSessionSeater}, `/demo/standard`) is the distribution link;
@@ -42,7 +43,7 @@ final readonly class SeatFixedDemoHandler
 {
     public const string DEMO_VIEWER_EMAIL = 'demo-viewer@nene-vault.dev';
 
-    private const int TOKEN_TTL_SECONDS = 86400; // mirror LoginUseCase
+    private const int TOKEN_TTL_SECONDS = LoginUseCase::TOKEN_TTL_SECONDS; // same TTL as a normal login (#148)
 
     public function __construct(
         private DemoConfig $config,
@@ -102,7 +103,7 @@ final readonly class SeatFixedDemoHandler
         <noscript><p>デモの開始には JavaScript が必要です。ブラウザの JavaScript を有効にして、もう一度お試しください。</p></noscript>
         <p>デモを準備しています…</p>
         <script nonce="{$nonce}">
-        localStorage.setItem('nene_vault_token', JSON.stringify({$session}));
+        sessionStorage.setItem('nene_vault_token', JSON.stringify({$session}));
         location.replace('/');
         </script>
         </body>

--- a/tests/Auth/LoginBoundaryTest.php
+++ b/tests/Auth/LoginBoundaryTest.php
@@ -104,6 +104,83 @@ final class LoginBoundaryTest extends ApiTestCase
         $this->assertArrayNotHasKey('password', $body);
     }
 
+    // ── Throttle (#148) ────────────────────────────────────────────────────────
+
+    public function test_login_locks_after_five_failures_and_returns_429(): void
+    {
+        // Dedicated identifier so the lock cannot leak into other tests
+        // (the throttle keys on email + client IP).
+        $email = 'throttled-' . uniqid() . '@example.com';
+        $hash  = password_hash(self::PASSWORD, PASSWORD_BCRYPT);
+        $stmt  = self::pdo()->prepare(
+            "INSERT INTO users (email, password_hash, role, organization_id, status, created_at, updated_at)
+             VALUES (?, ?, 'admin', ?, 'active', datetime('now'), datetime('now'))",
+        );
+        $stmt->execute([$email, $hash, self::$orgId]);
+
+        for ($i = 0; $i < 5; $i++) {
+            $resp = $this->handler()->handle(
+                $this->request('POST', '/admin/auth/login', null, ['email' => $email, 'password' => 'wrong-password']),
+            );
+            $this->assertSame(401, $resp->getStatusCode(), 'attempt ' . ($i + 1) . ' must still be 401');
+        }
+
+        // 6th attempt — even with the CORRECT password — is locked out.
+        $resp = $this->handler()->handle(
+            $this->request('POST', '/admin/auth/login', null, ['email' => $email, 'password' => self::PASSWORD]),
+        );
+        $this->assertSame(429, $resp->getStatusCode());
+        $body = json_decode((string) $resp->getBody(), true);
+        $this->assertArrayHasKey('retry_after_seconds', $body);
+        $this->assertGreaterThan(0, $body['retry_after_seconds']);
+    }
+
+    public function test_successful_login_clears_failure_counter(): void
+    {
+        $email = 'clears-' . uniqid() . '@example.com';
+        $hash  = password_hash(self::PASSWORD, PASSWORD_BCRYPT);
+        $stmt  = self::pdo()->prepare(
+            "INSERT INTO users (email, password_hash, role, organization_id, status, created_at, updated_at)
+             VALUES (?, ?, 'admin', ?, 'active', datetime('now'), datetime('now'))",
+        );
+        $stmt->execute([$email, $hash, self::$orgId]);
+
+        for ($i = 0; $i < 4; $i++) {
+            $this->handler()->handle(
+                $this->request('POST', '/admin/auth/login', null, ['email' => $email, 'password' => 'wrong-password']),
+            );
+        }
+
+        $ok = $this->handler()->handle(
+            $this->request('POST', '/admin/auth/login', null, ['email' => $email, 'password' => self::PASSWORD]),
+        );
+        $this->assertSame(200, $ok->getStatusCode());
+
+        // Counter reset: four more failures still do not lock.
+        for ($i = 0; $i < 4; $i++) {
+            $resp = $this->handler()->handle(
+                $this->request('POST', '/admin/auth/login', null, ['email' => $email, 'password' => 'wrong-password']),
+            );
+            $this->assertSame(401, $resp->getStatusCode());
+        }
+    }
+
+    public function test_login_rejects_non_active_user(): void
+    {
+        $email = 'invited-' . uniqid() . '@example.com';
+        $hash  = password_hash(self::PASSWORD, PASSWORD_BCRYPT);
+        $stmt  = self::pdo()->prepare(
+            "INSERT INTO users (email, password_hash, role, organization_id, status, created_at, updated_at)
+             VALUES (?, ?, 'member', ?, 'invited', datetime('now'), datetime('now'))",
+        );
+        $stmt->execute([$email, $hash, self::$orgId]);
+
+        $resp = $this->handler()->handle(
+            $this->request('POST', '/admin/auth/login', null, ['email' => $email, 'password' => self::PASSWORD]),
+        );
+        $this->assertSame(401, $resp->getStatusCode(), 'A non-active user must not authenticate even with the right password (#150)');
+    }
+
     public function test_issued_token_is_accepted_by_protected_route(): void
     {
         $login = $this->handler()->handle(

--- a/tests/Auth/LoginUseCaseTest.php
+++ b/tests/Auth/LoginUseCaseTest.php
@@ -76,6 +76,45 @@ final class LoginUseCaseTest extends TestCase
         $useCase->execute(new LoginInput('admin@example.com', 'wrong'));
     }
 
+    public function test_throws_when_user_is_not_active(): void
+    {
+        $user = new User(
+            id: 7,
+            email: 'invited@example.com',
+            passwordHash: password_hash('secret', PASSWORD_BCRYPT),
+            role: Role::Member->value,
+            organizationId: 1,
+            status: 'invited',
+        );
+
+        $repo = $this->createMockRepo(['invited@example.com' => $user]);
+        $useCase = new LoginUseCase($repo, new InMemoryTokenIssuer());
+
+        $this->expectException(InvalidCredentialsException::class);
+
+        $useCase->execute(new LoginInput('invited@example.com', 'secret'));
+    }
+
+    public function test_issued_token_ttl_is_one_hour(): void
+    {
+        $user = new User(
+            id: 1,
+            email: 'ttl@example.com',
+            passwordHash: password_hash('secret', PASSWORD_BCRYPT),
+            role: Role::Admin->value,
+            organizationId: 42,
+        );
+
+        $repo = $this->createMockRepo(['ttl@example.com' => $user]);
+        $useCase = new LoginUseCase($repo, new InMemoryTokenIssuer());
+
+        $output = $useCase->execute(new LoginInput('ttl@example.com', 'secret'));
+
+        $claims = json_decode((string) base64_decode($output->token, true), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(3600, (int) $claims['exp'] - (int) $claims['iat'], 'Access-token TTL must be the 1 h fleet standard (#148)');
+    }
+
     public function test_throws_on_unknown_email(): void
     {
         $repo = $this->createMockRepo([]);

--- a/tests/Auth/PdoLoginThrottleTest.php
+++ b/tests/Auth/PdoLoginThrottleTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Tests\Auth;
+
+use DateTimeImmutable;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\ClockInterface;
+use Nene2\Testing\DatabaseTestKit;
+use NeneVault\Auth\PdoLoginThrottle;
+use PHPUnit\Framework\TestCase;
+
+/** A clock the test can advance, to exercise window/lock expiry. */
+final class MutableClock implements ClockInterface
+{
+    private DateTimeImmutable $now;
+
+    public function __construct(string $start = '2026-07-11T09:00:00+00:00')
+    {
+        $this->now = new DateTimeImmutable($start);
+    }
+
+    public function now(): DateTimeImmutable
+    {
+        return $this->now;
+    }
+
+    public function advance(int $seconds): void
+    {
+        $this->now = $this->now->modify("+{$seconds} seconds");
+    }
+}
+
+final class PdoLoginThrottleTest extends TestCase
+{
+    private string $dbPath;
+    private DatabaseQueryExecutorInterface $query;
+    private MutableClock $clock;
+    private PdoLoginThrottle $throttle;
+
+    private const string ID = 'attacker@x.example|203.0.113.9';
+
+    protected function setUp(): void
+    {
+        $this->dbPath = sys_get_temp_dir() . '/' . uniqid('vault-throttle-', true) . '.sqlite';
+        $this->query = DatabaseTestKit::sqlite($this->dbPath)->queryExecutor;
+        $this->query->execute('CREATE TABLE login_attempts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            identifier_hash VARCHAR(64) NOT NULL,
+            attempt_count INTEGER NOT NULL DEFAULT 0,
+            window_started_at DATETIME NOT NULL,
+            locked_until DATETIME,
+            created_at DATETIME,
+            UNIQUE(identifier_hash)
+        )', []);
+        $this->clock = new MutableClock();
+        $this->throttle = new PdoLoginThrottle($this->query, $this->clock);
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->dbPath)) {
+            unlink($this->dbPath);
+        }
+    }
+
+    public function test_not_locked_initially(): void
+    {
+        self::assertSame(0, $this->throttle->secondsUntilUnlocked(self::ID));
+    }
+
+    public function test_locks_after_five_failures(): void
+    {
+        for ($i = 0; $i < 4; $i++) {
+            $this->throttle->recordFailure(self::ID);
+            self::assertSame(0, $this->throttle->secondsUntilUnlocked(self::ID), 'not locked after ' . ($i + 1));
+        }
+
+        $this->throttle->recordFailure(self::ID); // 5th → lock
+
+        self::assertSame(900, $this->throttle->secondsUntilUnlocked(self::ID));
+    }
+
+    public function test_success_clears_attempts(): void
+    {
+        for ($i = 0; $i < 5; $i++) {
+            $this->throttle->recordFailure(self::ID);
+        }
+
+        self::assertGreaterThan(0, $this->throttle->secondsUntilUnlocked(self::ID));
+
+        $this->throttle->clear(self::ID);
+
+        self::assertSame(0, $this->throttle->secondsUntilUnlocked(self::ID));
+    }
+
+    public function test_lock_expires_after_lock_seconds(): void
+    {
+        for ($i = 0; $i < 5; $i++) {
+            $this->throttle->recordFailure(self::ID);
+        }
+
+        $this->clock->advance(901);
+
+        self::assertSame(0, $this->throttle->secondsUntilUnlocked(self::ID));
+    }
+
+    public function test_window_expiry_resets_the_counter(): void
+    {
+        for ($i = 0; $i < 4; $i++) {
+            $this->throttle->recordFailure(self::ID);
+        }
+
+        // Window (15 min) passes → the next failure starts a fresh window.
+        $this->clock->advance(901);
+        $this->throttle->recordFailure(self::ID);
+
+        self::assertSame(0, $this->throttle->secondsUntilUnlocked(self::ID));
+    }
+
+    public function test_identifiers_are_independent(): void
+    {
+        for ($i = 0; $i < 5; $i++) {
+            $this->throttle->recordFailure(self::ID);
+        }
+
+        self::assertSame(0, $this->throttle->secondsUntilUnlocked('someone-else@x.example|198.51.100.7'));
+    }
+
+    public function test_raw_identifier_is_never_persisted(): void
+    {
+        $this->throttle->recordFailure(self::ID);
+
+        $rows = $this->query->fetchAll('SELECT identifier_hash FROM login_attempts', []);
+
+        self::assertCount(1, $rows);
+        self::assertDoesNotMatchRegularExpression('/attacker|203\.0\.113/', (string) $rows[0]['identifier_hash']);
+    }
+}

--- a/tests/Demo/DemoSessionSeaterTest.php
+++ b/tests/Demo/DemoSessionSeaterTest.php
@@ -17,7 +17,7 @@ use Psr\Http\Message\ResponseInterface;
 /**
  * The disposable-org seat page (#141): mints an admin token whose `org_id`
  * claim drives the claim-based tenant resolution, parks the SPA's
- * `AuthSession` JSON in localStorage under the exact key/shape a login
+ * `AuthSession` JSON in sessionStorage under the exact key/shape a login
  * persists, and locks the page down with a nonce'd per-response CSP.
  */
 final class DemoSessionSeaterTest extends TestCase
@@ -50,7 +50,7 @@ final class DemoSessionSeaterTest extends TestCase
 
         self::assertSame(200, $response->getStatusCode());
         $html = (string) $response->getBody();
-        self::assertStringContainsString("localStorage.setItem('nene_vault_token', JSON.stringify(", $html);
+        self::assertStringContainsString("sessionStorage.setItem('nene_vault_token', JSON.stringify(", $html);
         self::assertStringContainsString("location.replace('/')", $html);
         self::assertSame('no-store', $response->getHeaderLine('Cache-Control'));
 
@@ -66,7 +66,8 @@ final class DemoSessionSeaterTest extends TestCase
         self::assertSame(77, $claims['user_id']);
         self::assertSame(42, $claims['org_id']);
         self::assertSame('admin', $claims['role']);
-        // Token TTL matches the demo org TTL (3 h), not the 24 h login TTL.
+        // Token TTL matches the demo org TTL (3 h), not the 1 h login TTL — the
+        // disposable org lives 3 h and the seat must survive the whole session.
         self::assertSame(3 * 3600, (int) $claims['exp'] - (int) $claims['iat']);
     }
 

--- a/tests/Demo/DisposableDemoFlowTest.php
+++ b/tests/Demo/DisposableDemoFlowTest.php
@@ -28,7 +28,7 @@ final class DisposableDemoFlowTest extends ApiTestCase
 
         $this->assertSame(200, $response->getStatusCode(), (string) $response->getBody());
         $html = (string) $response->getBody();
-        $this->assertStringContainsString("localStorage.setItem('nene_vault_token', JSON.stringify(", $html);
+        $this->assertStringContainsString("sessionStorage.setItem('nene_vault_token', JSON.stringify(", $html);
         $this->assertSame('no-store', $response->getHeaderLine('Cache-Control'));
 
         $this->assertSame(1, preg_match('/JSON\.stringify\((\{.*?\})\)/s', $html, $m));

--- a/tests/Demo/SeatFixedDemoHandlerTest.php
+++ b/tests/Demo/SeatFixedDemoHandlerTest.php
@@ -148,12 +148,12 @@ final class SeatFixedDemoHandlerTest extends TestCase
         self::assertSame(200, $response->getStatusCode());
         $html = (string) $response->getBody();
 
-        self::assertStringContainsString("localStorage.setItem('nene_vault_token', JSON.stringify(", $html);
+        self::assertStringContainsString("sessionStorage.setItem('nene_vault_token', JSON.stringify(", $html);
         self::assertStringContainsString("location.replace('/')", $html);
         self::assertSame('no-store', $response->getHeaderLine('Cache-Control'));
 
         // The embedded session carries the SPA's AuthSession shape and a
-        // verifiable 24 h token with LoginUseCase-identical claims.
+        // verifiable 1 h token with LoginUseCase-identical claims.
         self::assertSame(1, preg_match('/JSON\.stringify\((\{.*?\})\)/s', $html, $m));
         $session = json_decode($m[1] ?? '', true);
         self::assertIsArray($session);
@@ -166,7 +166,7 @@ final class SeatFixedDemoHandlerTest extends TestCase
         self::assertSame(7, $claims['user_id']);
         self::assertSame(2, $claims['org_id']);
         self::assertSame('viewer', $claims['role']);
-        self::assertEqualsWithDelta(86400, (int) $claims['exp'] - (int) $claims['iat'], 5);
+        self::assertEqualsWithDelta(3600, (int) $claims['exp'] - (int) $claims['iat'], 5);
     }
 
     public function test_page_specific_csp_matches_the_script_nonce(): void

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -112,6 +112,16 @@ $pdo->exec('CREATE TABLE IF NOT EXISTS vault_documents (
     void_note TEXT
 )');
 
+$pdo->exec('CREATE TABLE IF NOT EXISTS login_attempts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    identifier_hash VARCHAR(64) NOT NULL,
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    window_started_at DATETIME NOT NULL,
+    locked_until DATETIME,
+    created_at DATETIME,
+    UNIQUE(identifier_hash)
+)');
+
 $pdo->exec('CREATE TABLE IF NOT EXISTS document_versions (
     id CHAR(26) PRIMARY KEY,
     vault_document_id CHAR(26) NOT NULL,


### PR DESCRIPTION
## Summary

Remediates the audit's highest-priority finding (#148, security) plus the `users.status` login gap from the #150 checklist.

- **TTL 24 h → 1 h** — `LoginUseCase::TOKEN_TTL_SECONDS` is now `3600` and public; `SeatFixedDemoHandler` references it instead of mirroring a literal (mirror drift is now impossible). The disposable-org seat (`/demo/standard`) keeps its deliberate org-TTL (3 h) semantics — now pinned by `DemoSessionSeaterTest` instead of a comment.
- **localStorage → sessionStorage** — SPA auth store (`frontend/src/entities/auth/model.ts`) and both PHP seat pages write `nene_vault_token` to `sessionStorage`; the token no longer survives a browser restart.
- **Login rate limit** — `PdoLoginThrottle` ported from the sibling reconciliation product: 5 failures / 15 min per SHA-256-hashed `email|IP`, 15 min lock, cleared on success. 429 Problem Details `too-many-login-attempts` with `retry_after_seconds`. New `login_attempts` table (Phinx migration + both SQLite bootstraps + installer path covered).
- **`users.status = 'active'` check + timing equalization** — non-active (`invited`) users can no longer log in; unknown emails burn the same bcrypt verify as known ones.

`docs/terms.md` (§6/§7/§17/§19 — also registers the previously unregistered `invalid-credentials` slug), OpenAPI 429, `docs/demo.md`, and `docs/todo/current.md` updated in the same PR.

Follow-up filed: #153 (in-memory + refresh session, invoice ADR 0014 shape — long-term fleet direction).

## Tests

- `composer check` all green (349 tests, incl. new `PdoLoginThrottleTest` 7 cases, HTTP-level lockout/clear/status boundary tests, TTL pinning in `LoginUseCaseTest` / `SeatFixedDemoHandlerTest`).
- `npm run check --prefix frontend` all green (196 tests; global vitest teardown now clears `sessionStorage`).

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)