### PR TITLE
feat(auth): standardize JWT claims to the fleet schema and inject ClockInterface (#155)

### DIFF
--- a/conformance.baseline.json
+++ b/conformance.baseline.json
@@ -4,12 +4,6 @@
     "ignore": [
         {
             "rule": "D4",
-            "file": "src/Auth/LoginUseCase.php",
-            "message": "Raw current-time read time(). Inject Nene2\\Http\\ClockInterface (Nene2\\Http\\UtcClock in production) instead of reading the wall clock directly.",
-            "count": 2
-        },
-        {
-            "rule": "D4",
             "file": "src/Auth/PdoUserRepository.php",
             "message": "Raw current-time read date() with no explicit timestamp. Inject Nene2\\Http\\ClockInterface (Nene2\\Http\\UtcClock in production) instead of reading the wall clock directly.",
             "count": 5

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -44,7 +44,7 @@ slug-namespaced email) through the real create-org/create-user use cases →
 seed → seat page stores the SPA's `AuthSession` in `sessionStorage` and lands
 in the app signed in.
 
-Tenancy: the minted token carries the disposable org in its `org_id` claim,
+Tenancy: the minted token carries the disposable org in its `org` claim,
 and `OrgResolverMiddleware` resolves **verified token claims first**, host/env
 strategy second — that is what makes per-visitor orgs reachable on a
 single-domain deployment. Superadmin (`org_id: null`) and unauthenticated

--- a/src/Auth/AuthServiceProvider.php
+++ b/src/Auth/AuthServiceProvider.php
@@ -36,6 +36,7 @@ final readonly class AuthServiceProvider implements ServiceProviderInterface
                 static function (ContainerInterface $c): LoginUseCase {
                     $users = $c->get(UserRepositoryInterface::class);
                     $tokenIssuer = $c->get('nene-vault.token_issuer');
+                    $clock = $c->get(ClockInterface::class);
 
                     if (!$users instanceof UserRepositoryInterface) {
                         throw new LogicException('UserRepositoryInterface service is invalid.');
@@ -45,7 +46,11 @@ final readonly class AuthServiceProvider implements ServiceProviderInterface
                         throw new LogicException('TokenIssuerInterface service is invalid.');
                     }
 
-                    return new LoginUseCase($users, $tokenIssuer);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
+
+                    return new LoginUseCase($users, $tokenIssuer, $clock);
                 },
             )
             ->set(

--- a/src/Auth/CapabilityMiddleware.php
+++ b/src/Auth/CapabilityMiddleware.php
@@ -17,7 +17,7 @@ use Psr\Http\Server\RequestHandlerInterface;
  *
  * Organization scoping:
  *  - superadmin: no org check — operates across all organizations
- *  - admin/member/viewer: JWT org_id must match the resolved org ID (nene2.org.id attribute)
+ *  - admin/member/viewer: JWT `org` claim must match the resolved org ID (nene2.org.id attribute)
  */
 final readonly class CapabilityMiddleware implements MiddlewareInterface
 {
@@ -58,8 +58,8 @@ final readonly class CapabilityMiddleware implements MiddlewareInterface
             $resolvedOrgId = $request->getAttribute('nene2.org.id');
 
             if (is_int($resolvedOrgId)) {
-                $jwtOrgId = isset($claims['org_id']) && is_int($claims['org_id'])
-                    ? $claims['org_id']
+                $jwtOrgId = isset($claims['org']) && is_int($claims['org'])
+                    ? $claims['org']
                     : null;
 
                 if ($jwtOrgId !== $resolvedOrgId) {

--- a/src/Auth/LoginUseCase.php
+++ b/src/Auth/LoginUseCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneVault\Auth;
 
 use Nene2\Auth\TokenIssuerInterface;
+use Nene2\Http\ClockInterface;
 
 final readonly class LoginUseCase
 {
@@ -19,6 +20,7 @@ final readonly class LoginUseCase
     public function __construct(
         private UserRepositoryInterface $users,
         private TokenIssuerInterface $tokenIssuer,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -44,19 +46,20 @@ final readonly class LoginUseCase
             throw new InvalidCredentialsException();
         }
 
-        $expiresAt = time() + self::TOKEN_TTL_SECONDS;
+        $now = $this->clock->now()->getTimestamp();
+        $expiresAt = $now + self::TOKEN_TTL_SECONDS;
 
-        // superadmin は組織に属さないため org_id は null。
+        // superadmin は組織に属さないため org は null。
         // admin / member / viewer は所属組織の ID を JWT に埋め込む。
+        // Claims follow the fleet-standard schema (#150): sub = user id, org.
         $orgId = $role === Role::Superadmin ? null : $user->organizationId;
 
         $token = $this->tokenIssuer->issue([
-            'sub'     => $user->email,
-            'user_id' => $user->id,
-            'role'    => $role->value,
-            'org_id'  => $orgId,
-            'iat'     => time(),
-            'exp'     => $expiresAt,
+            'sub'  => $user->id,
+            'role' => $role->value,
+            'org'  => $orgId,
+            'iat'  => $now,
+            'exp'  => $expiresAt,
         ]);
 
         return new LoginOutput(

--- a/src/Auth/RequestContext.php
+++ b/src/Auth/RequestContext.php
@@ -19,14 +19,15 @@ final class RequestContext
     private const ORG_ATTRIBUTE = 'nene2.org.id';
 
     /**
-     * Authenticated user id from the bearer-token claims, or null when the
-     * claim is absent (e.g. service-to-service calls without a user subject).
+     * Authenticated user id from the bearer-token claims (fleet-standard
+     * `sub` = user id, #150), or null when the subject is absent or not a
+     * user id (e.g. service tokens with a string subject).
      */
     public static function actorUserId(ServerRequestInterface $request): ?int
     {
         $claims = self::claims($request);
 
-        return isset($claims['user_id']) ? (int) $claims['user_id'] : null;
+        return isset($claims['sub']) && is_int($claims['sub']) ? $claims['sub'] : null;
     }
 
     /**

--- a/src/Demo/DemoSessionSeater.php
+++ b/src/Demo/DemoSessionSeater.php
@@ -20,7 +20,7 @@ use Psr\Http\Message\ServerRequestInterface;
  *
  * Mints a normal access token for the org's throwaway ADMIN — same claims
  * shape and secret as {@see \NeneVault\Auth\LoginUseCase}; the token's
- * `org_id` claim is what {@see \NeneVault\Organization\Resolution\OrgResolverMiddleware}
+ * `org` claim is what {@see \NeneVault\Organization\Resolution\OrgResolverMiddleware}
  * resolves the tenant from — and serves a one-shot seat page whose nonce'd
  * inline script stores the SPA's `AuthSession` JSON in `sessionStorage`
  * (key `nene_vault_token`, the exact shape `frontend/src/entities/auth/model.ts`
@@ -54,10 +54,9 @@ final readonly class DemoSessionSeater implements DemoSessionSeaterInterface
         $now = $this->clock->now()->getTimestamp();
 
         $token = $this->tokenIssuer->issue([
-            'sub' => $email,
-            'user_id' => $org->adminUserId,
+            'sub' => $org->adminUserId,
             'role' => 'admin',
-            'org_id' => $org->orgId,
+            'org' => $org->orgId,
             'iat' => $now,
             'exp' => $now + $this->config->ttlHours * 3600,
         ]);

--- a/src/Demo/SeatFixedDemoHandler.php
+++ b/src/Demo/SeatFixedDemoHandler.php
@@ -25,7 +25,7 @@ use Psr\Http\Message\ServerRequestInterface;
  * ({@see DemoSessionSeater}, `/demo/standard`) is the distribution link;
  * this seat stays for guided walkthroughs and the README screenshots.
  *
- * The token's `org_id` claim resolves the tenant (claim-based resolution,
+ * The token's `org` claim resolves the tenant (claim-based resolution,
  * #141), and in `single` mode the host strategy resolves the same org for
  * unauthenticated requests — either way the seat lands scoped correctly.
  *
@@ -72,10 +72,9 @@ final readonly class SeatFixedDemoHandler
 
         $now = $this->clock->now()->getTimestamp();
         $token = $this->tokenIssuer->issue([
-            'sub' => $viewer->email,
-            'user_id' => $viewer->id,
+            'sub' => $viewer->id,
             'role' => $viewer->role,
-            'org_id' => $viewer->organizationId,
+            'org' => $viewer->organizationId,
             'iat' => $now,
             'exp' => $now + self::TOKEN_TTL_SECONDS,
         ]);

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -321,7 +321,7 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                     };
 
                     // Order matters (#141): auth verifies the bearer FIRST so the
-                    // org resolver can trust the `org_id` claim (claim-based tenant
+                    // org resolver can trust the `org` claim (claim-based tenant
                     // resolution — how a disposable demo org is reachable on a
                     // single-domain host). Neither middleware consumes the other's
                     // attributes in the opposite direction, and CapabilityMiddleware

--- a/src/Organization/Resolution/OrgResolverMiddleware.php
+++ b/src/Organization/Resolution/OrgResolverMiddleware.php
@@ -22,12 +22,12 @@ use Psr\Http\Server\RequestHandlerInterface;
  *
  * Resolution order (#141):
  *  1. Verified bearer claims (`nene2.auth.claims`, set by AdminApiAuthMiddleware,
- *     which runs before this middleware): an integer `org_id` claim resolves the
+ *     which runs before this middleware): an integer `org` claim resolves the
  *     org by ID. The claim is signed, so the authenticated user's own tenant
  *     always wins over the host — this is what lets a disposable demo org work
  *     on a single-domain deployment where the host strategy would resolve the
  *     fixed ORG_SLUG org. A claim naming a missing org (e.g. a demo org already
- *     swept) fails closed with 404. Superadmin tokens carry `org_id: null` and
+ *     swept) fails closed with 404. Superadmin tokens carry `org: null` and
  *     fall through to the strategy, preserving cross-tenant behaviour.
  *  2. strategy->resolve() → slug or custom domain identifier
  *     (env / subdomain / custom_domain — unchanged, and still the only path
@@ -121,18 +121,19 @@ final readonly class OrgResolverMiddleware implements MiddlewareInterface
     }
 
     /**
-     * Integer `org_id` claim from the verified bearer token, or null when the
-     * request is unauthenticated or the token carries no tenant (superadmin).
+     * Integer `org` claim from the verified bearer token (fleet-standard
+     * schema, #150), or null when the request is unauthenticated or the token
+     * carries no tenant (superadmin).
      */
     private function claimOrgId(ServerRequestInterface $request): ?int
     {
         $claims = $request->getAttribute('nene2.auth.claims');
 
-        if (!is_array($claims) || !isset($claims['org_id']) || !is_int($claims['org_id'])) {
+        if (!is_array($claims) || !isset($claims['org']) || !is_int($claims['org'])) {
             return null;
         }
 
-        return $claims['org_id'];
+        return $claims['org'];
     }
 
     private function continueWith(

--- a/tests/Auth/LoginUseCaseTest.php
+++ b/tests/Auth/LoginUseCaseTest.php
@@ -10,6 +10,7 @@ use NeneVault\Auth\LoginUseCase;
 use NeneVault\Auth\Role;
 use NeneVault\Auth\User;
 use NeneVault\Auth\UserRepositoryInterface;
+use NeneVault\Tests\Support\FixedClock;
 use PHPUnit\Framework\TestCase;
 
 final class LoginUseCaseTest extends TestCase
@@ -27,7 +28,7 @@ final class LoginUseCaseTest extends TestCase
 
         $repo = $this->createMockRepo(['admin@example.com' => $user]);
         $issuer = new InMemoryTokenIssuer();
-        $useCase = new LoginUseCase($repo, $issuer);
+        $useCase = new LoginUseCase($repo, $issuer, new FixedClock());
 
         $output = $useCase->execute(new LoginInput('admin@example.com', 'secret'));
 
@@ -50,7 +51,7 @@ final class LoginUseCaseTest extends TestCase
 
         $repo = $this->createMockRepo(['super@example.com' => $user]);
         $issuer = new InMemoryTokenIssuer();
-        $useCase = new LoginUseCase($repo, $issuer);
+        $useCase = new LoginUseCase($repo, $issuer, new FixedClock());
 
         $output = $useCase->execute(new LoginInput('super@example.com', 's3cr3t'));
 
@@ -69,7 +70,7 @@ final class LoginUseCaseTest extends TestCase
         );
 
         $repo = $this->createMockRepo(['admin@example.com' => $user]);
-        $useCase = new LoginUseCase($repo, new InMemoryTokenIssuer());
+        $useCase = new LoginUseCase($repo, new InMemoryTokenIssuer(), new FixedClock());
 
         $this->expectException(InvalidCredentialsException::class);
 
@@ -88,7 +89,7 @@ final class LoginUseCaseTest extends TestCase
         );
 
         $repo = $this->createMockRepo(['invited@example.com' => $user]);
-        $useCase = new LoginUseCase($repo, new InMemoryTokenIssuer());
+        $useCase = new LoginUseCase($repo, new InMemoryTokenIssuer(), new FixedClock());
 
         $this->expectException(InvalidCredentialsException::class);
 
@@ -106,7 +107,7 @@ final class LoginUseCaseTest extends TestCase
         );
 
         $repo = $this->createMockRepo(['ttl@example.com' => $user]);
-        $useCase = new LoginUseCase($repo, new InMemoryTokenIssuer());
+        $useCase = new LoginUseCase($repo, new InMemoryTokenIssuer(), new FixedClock());
 
         $output = $useCase->execute(new LoginInput('ttl@example.com', 'secret'));
 
@@ -118,7 +119,7 @@ final class LoginUseCaseTest extends TestCase
     public function test_throws_on_unknown_email(): void
     {
         $repo = $this->createMockRepo([]);
-        $useCase = new LoginUseCase($repo, new InMemoryTokenIssuer());
+        $useCase = new LoginUseCase($repo, new InMemoryTokenIssuer(), new FixedClock());
 
         $this->expectException(InvalidCredentialsException::class);
 

--- a/tests/Demo/DemoSessionSeaterTest.php
+++ b/tests/Demo/DemoSessionSeaterTest.php
@@ -63,8 +63,8 @@ final class DemoSessionSeaterTest extends TestCase
         self::assertSame(42, $session['orgId']);
 
         $claims = (new LocalBearerTokenVerifier('seat-test-secret'))->verify((string) $session['token']);
-        self::assertSame(77, $claims['user_id']);
-        self::assertSame(42, $claims['org_id']);
+        self::assertSame(77, $claims['sub']);
+        self::assertSame(42, $claims['org']);
         self::assertSame('admin', $claims['role']);
         // Token TTL matches the demo org TTL (3 h), not the 1 h login TTL — the
         // disposable org lives 3 h and the seat must survive the whole session.

--- a/tests/Demo/SeatFixedDemoHandlerTest.php
+++ b/tests/Demo/SeatFixedDemoHandlerTest.php
@@ -163,8 +163,8 @@ final class SeatFixedDemoHandlerTest extends TestCase
         self::assertSame(2, $session['orgId']);
 
         $claims = (new LocalBearerTokenVerifier('seat-test-secret'))->verify((string) $session['token']);
-        self::assertSame(7, $claims['user_id']);
-        self::assertSame(2, $claims['org_id']);
+        self::assertSame(7, $claims['sub']);
+        self::assertSame(2, $claims['org']);
         self::assertSame('viewer', $claims['role']);
         self::assertEqualsWithDelta(3600, (int) $claims['exp'] - (int) $claims['iat'], 5);
     }

--- a/tests/Document/DocumentApiTest.php
+++ b/tests/Document/DocumentApiTest.php
@@ -40,10 +40,9 @@ final class DocumentApiTest extends TestCase
         $issuer = self::$container->get(TokenIssuerInterface::class);
         assert($issuer instanceof TokenIssuerInterface);
         self::$token = $issuer->issue([
-            'sub' => 'admin@example.com',
-            'user_id' => 1,
+            'sub' => 1,
             'role' => 'admin',
-            'org_id' => self::$orgId,
+            'org' => self::$orgId,
             'iat' => time(),
             'exp' => time() + 3600,
         ]);

--- a/tests/Export/ExportApiTest.php
+++ b/tests/Export/ExportApiTest.php
@@ -36,10 +36,9 @@ final class ExportApiTest extends TestCase
         $issuer = self::$container->get(TokenIssuerInterface::class);
         assert($issuer instanceof TokenIssuerInterface);
         self::$token = $issuer->issue([
-            'sub' => 'admin@example.com',
-            'user_id' => 1,
+            'sub' => 1,
             'role' => 'admin',
-            'org_id' => $orgId,
+            'org' => $orgId,
             'iat' => time(),
             'exp' => time() + 3600,
         ]);

--- a/tests/Organization/Resolution/OrgResolverMiddlewareTest.php
+++ b/tests/Organization/Resolution/OrgResolverMiddlewareTest.php
@@ -131,7 +131,7 @@ final class OrgResolverMiddlewareTest extends TestCase
             $this->repository(orgsById: [7 => $claimOrg], orgsBySlug: ['env-org' => $envOrg]),
             $holder,
         )->process(
-            $this->request('/admin/vault/documents', ['org_id' => 7, 'role' => 'admin']),
+            $this->request('/admin/vault/documents', ['org' => 7, 'role' => 'admin']),
             $handler,
         );
 
@@ -153,7 +153,7 @@ final class OrgResolverMiddlewareTest extends TestCase
             $this->repository(orgsBySlug: ['env-org' => $envOrg]),
             $holder,
         )->process(
-            $this->request('/admin/vault/documents', ['org_id' => 424242, 'role' => 'admin']),
+            $this->request('/admin/vault/documents', ['org' => 424242, 'role' => 'admin']),
             $handler,
         );
 
@@ -172,7 +172,7 @@ final class OrgResolverMiddlewareTest extends TestCase
         $handler = $this->spyHandler();
 
         $response = $this->middleware($this->repository(orgsById: [7 => $inactive]), $holder)->process(
-            $this->request('/admin/vault/documents', ['org_id' => 7, 'role' => 'admin']),
+            $this->request('/admin/vault/documents', ['org' => 7, 'role' => 'admin']),
             $handler,
         );
 
@@ -188,7 +188,7 @@ final class OrgResolverMiddlewareTest extends TestCase
         $handler = $this->spyHandler();
 
         $response = $this->middleware($this->repository(orgsBySlug: ['env-org' => $envOrg]), $holder)->process(
-            $this->request('/admin/vault/documents', ['org_id' => null, 'role' => 'superadmin']),
+            $this->request('/admin/vault/documents', ['org' => null, 'role' => 'superadmin']),
             $handler,
         );
 

--- a/tests/Support/ApiTestCase.php
+++ b/tests/Support/ApiTestCase.php
@@ -55,10 +55,9 @@ abstract class ApiTestCase extends TestCase
         assert($issuer instanceof TokenIssuerInterface);
 
         return $issuer->issue(array_merge([
-            'sub'     => "{$role}@example.com",
-            'user_id' => $userId,
+            'sub'     => $userId,
             'role'    => $role,
-            'org_id'  => $orgId,
+            'org'     => $orgId,
             'iat'     => time(),
             'exp'     => time() + 3600,
         ], $extra));
@@ -72,10 +71,9 @@ abstract class ApiTestCase extends TestCase
         assert($issuer instanceof TokenIssuerInterface);
 
         return $issuer->issue([
-            'sub'     => 'superadmin@example.com',
-            'user_id' => $userId,
+            'sub'     => $userId,
             'role'    => 'superadmin',
-            'org_id'  => null,
+            'org'     => null,
             'iat'     => time(),
             'exp'     => time() + 3600,
         ]);

--- a/tests/User/UserApiTest.php
+++ b/tests/User/UserApiTest.php
@@ -38,10 +38,9 @@ final class UserApiTest extends TestCase
         $issuer = self::$container->get(TokenIssuerInterface::class);
         assert($issuer instanceof TokenIssuerInterface);
         self::$token = $issuer->issue([
-            'sub' => 'admin@example.com',
-            'user_id' => 1000,
+            'sub' => 1000,
             'role' => 'admin',
-            'org_id' => self::$orgId,
+            'org' => self::$orgId,
             'iat' => time(),
             'exp' => time() + 3600,
         ]);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -137,3 +137,20 @@ $pdo->exec('CREATE TABLE IF NOT EXISTS document_versions (
     uploaded_by INTEGER,
     UNIQUE(vault_document_id, version_number)
 )');
+
+// Transient state cleanup (#155): the login throttle table and the file-backed
+// demo-start rate limits persist across local runs (the SQLite file and var/
+// survive), which would make repeated suite runs trip their own locks. Both
+// hold only rate-limit counters, never business data, so a fresh suite starts
+// clean — mirroring what CI gets for free.
+$pdo->exec('DELETE FROM login_attempts');
+
+$rateLimitDir = dirname(__DIR__) . '/var/rate-limits';
+
+if (is_dir($rateLimitDir)) {
+    foreach (glob($rateLimitDir . '/*') ?: [] as $rateLimitFile) {
+        if (is_file($rateLimitFile)) {
+            @unlink($rateLimitFile);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

#150 checklist item: JWT claims schema. Issue side + read side in one PR so plan-C claim resolution never breaks:

- `sub` = user id (int), `org` = org id (int|null) — replaces `sub`=email / `user_id` / `org_id` in `LoginUseCase`, `SeatFixedDemoHandler`, `DemoSessionSeater` (fleet schema: invoice/clear/deal identical).
- Read side same PR: `OrgResolverMiddleware::claimOrgId` (claim override #141), `CapabilityMiddleware` org-scope check, `RequestContext::actorUserId` (int-guarded: string-subject service tokens → null, never 0).
- `LoginUseCase` uses injected `ClockInterface` instead of `time()`; D4 baseline entry dropped (11 → 10 files).
- `tests/bootstrap.php` clears transient throttle state so repeated local runs can't lock themselves out (CI unchanged).

Phase 0 impact check (existing tokens invalidated): demo/dev only — both seat pages mint fresh tokens on every visit, and the live demo host re-seats on link open. No production deploy in this task.

## Tests

`composer check` all green (349 tests / phpstan / cs / locales / openapi / mcp / conformance 18 suppressed).

Closes #155. Refs #150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)