### PR TITLE
chore(deps): move NENE2 to Packagist ^1.10 and add SHA-256 sidecar to the release build (#159)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -34,12 +34,6 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
           restore-keys: ${{ runner.os }}-composer-
 
-      # NENE2 is a Composer path repository (../NENE2, @dev) — see composer.json.
-      # Clone the framework next to this checkout so `composer install` can
-      # resolve it (same pattern as nene-records).
-      - name: Clone NENE2 (local path dependency)
-        run: git clone --depth=1 https://github.com/hideyukiMORI/NENE2.git ../NENE2
-
       - name: Install dependencies
         run: composer install --no-interaction --prefer-dist --optimize-autoloader
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,22 +50,19 @@ ENV APACHE_RUN_USER=www-data \
 ENTRYPOINT ["/usr/local/bin/init.sh"]
 
 # ── Production target ─────────────────────────────────────────────────────────
-# Expects the entire monorepo context (../) including ../NENE2 so composer can
-# resolve the path dependency. Run:
-#   docker build --target prod -f nene-vault/Dockerfile ..
+# NENE2 is installed from Packagist (#159), so the build context is just this
+# repository. Run:
+#   docker build --target prod .
 FROM base AS prod
 
 WORKDIR /var/www/html
 
-# Copy the nene-vault project and NENE2 sibling (required by composer path repo)
-COPY nene-vault/ /var/www/html/
-COPY NENE2/ /NENE2/
+COPY . /var/www/html/
 
 RUN composer install --no-dev --optimize-autoloader --no-interaction \
-    && chown -R www-data:www-data /var/www/html \
-    && rm -rf /NENE2
+    && chown -R www-data:www-data /var/www/html
 
-COPY nene-vault/docker/init.sh /usr/local/bin/init.sh
+COPY docker/init.sh /usr/local/bin/init.sh
 RUN chmod +x /usr/local/bin/init.sh
 
 ENV APACHE_RUN_USER=www-data \

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Japanese UI shown — the admin UI is bilingual (ja/en, one-click switch).
 > [`docs/operator/installation.md`](./docs/operator/installation.md).
 
 ```sh
-composer install            # once, on the host — resolves the ../NENE2 path dependency
+composer install            # once, on the host — installs NENE2 ^1.10 from Packagist
 cp .env.example .env        # customise ADMIN_EMAIL / ADMIN_PASSWORD if desired
 docker compose up           # SQLite (default) + Vite dev server
 ```

--- a/composer.json
+++ b/composer.json
@@ -5,15 +5,9 @@
     "license": "MIT",
     "require": {
         "php": ">=8.4.1 <9.0",
-        "hideyukimori/nene2": "@dev",
+        "hideyukimori/nene2": "^1.10",
         "robmorgan/phinx": "^0.16.11"
     },
-    "repositories": [
-        {
-            "type": "path",
-            "url": "../NENE2"
-        }
-    ],
     "autoload": {
         "psr-4": {
             "NeneVault\\": "src/"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "596ac73b4e5a84fe838f52aae7c74c69",
+    "content-hash": "0819fdd39da9da7bf87ebaf0ea6ea412",
     "packages": [
         {
             "name": "cakephp/chronos",
@@ -394,11 +394,17 @@
         },
         {
             "name": "hideyukimori/nene2",
-            "version": "dev-main",
+            "version": "v1.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hideyukiMORI/NENE2.git",
+                "reference": "c5c1bb67819145099155bd969f3319294bca49d4"
+            },
             "dist": {
-                "type": "path",
-                "url": "../NENE2",
-                "reference": "1baf2096dd07e296417b7ec88b4176a83c992bb7"
+                "type": "zip",
+                "url": "https://api.github.com/repos/hideyukiMORI/NENE2/zipball/c5c1bb67819145099155bd969f3319294bca49d4",
+                "reference": "c5c1bb67819145099155bd969f3319294bca49d4",
+                "shasum": ""
             },
             "require": {
                 "monolog/monolog": "^3.0",
@@ -428,76 +434,16 @@
                     "Nene2\\": "src/"
                 }
             },
-            "autoload-dev": {
-                "psr-4": {
-                    "Nene2\\Tests\\": "tests/"
-                }
-            },
-            "scripts": {
-                "test": [
-                    "phpunit --testsuite NENE2,Database"
-                ],
-                "test:database": [
-                    "phpunit --testsuite Database"
-                ],
-                "test:database:mysql": [
-                    "phpunit --testsuite DatabaseMySQL"
-                ],
-                "analyse": [
-                    "phpstan analyse --memory-limit 512M"
-                ],
-                "cs": [
-                    "php-cs-fixer fix --dry-run --diff --config=.php-cs-fixer.php"
-                ],
-                "cs:fix": [
-                    "php-cs-fixer fix --config=.php-cs-fixer.php"
-                ],
-                "openapi": [
-                    "php tools/validate-openapi.php"
-                ],
-                "openapi:docs": [
-                    "php tools/openapi-to-md.php"
-                ],
-                "howto:index": [
-                    "php tools/build-howto-index.php"
-                ],
-                "howto:frontmatter": [
-                    "php tools/validate-howto-frontmatter.php"
-                ],
-                "mcp": [
-                    "php tools/validate-mcp-tools.php"
-                ],
-                "version:check": [
-                    "php tools/validate-version.php"
-                ],
-                "migrations:status": [
-                    "phinx status -c phinx.php"
-                ],
-                "migrations:migrate": [
-                    "phinx migrate -c phinx.php"
-                ],
-                "migrations:rollback": [
-                    "phinx rollback -c phinx.php"
-                ],
-                "migrations:seed": [
-                    "phinx seed:run -c phinx.php"
-                ],
-                "check": [
-                    "@test",
-                    "@analyse",
-                    "@cs",
-                    "@openapi",
-                    "@mcp",
-                    "@version:check"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
             "description": "PHP micro-framework: JSON APIs first, minimal server HTML, easy React/SPA integration, structure friendly to AI tooling.",
-            "transport-options": {
-                "relative": true
-            }
+            "support": {
+                "issues": "https://github.com/hideyukiMORI/NENE2/issues",
+                "source": "https://github.com/hideyukiMORI/NENE2/tree/v1.10.0"
+            },
+            "time": "2026-07-10T07:35:29+00:00"
         },
         {
             "name": "league/container",
@@ -6230,9 +6176,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "hideyukimori/nene2": 20
-    },
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 ## NeNe Vault — development stack
 ##
 ## Prerequisites:
-##   composer install     (once, on the host — resolves ../NENE2 path dependency)
+##   composer install     (once, on the host — installs NENE2 from Packagist)
 ##   cp .env.example .env (and customise as needed)
 ##
 ## Usage:
@@ -28,11 +28,9 @@ services:
     ports:
       - "${NENE_VAULT_PORT:-8600}:8080"
     volumes:
-      # Source + vendor (read-only); vendor resolved by host composer install
+      # Source + vendor (read-only); vendor resolved by host composer install.
+      # NENE2 comes from Packagist (#159) — real files in vendor/, no sibling mount.
       - .:/var/www/html:ro
-      # vendor/hideyukimori/nene2 is a symlink pointing 3 levels up to NENE2/.
-      # Mount the sibling NENE2 directory at the resolved path inside the container.
-      - ../NENE2:/var/www/NENE2:ro
       # SQLite database and uploaded files need to be writable
       - sqlite_data:/var/www/html/var
       - vault_storage:/var/www/html/storage/vault

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -145,6 +145,23 @@ $pdo->exec('CREATE TABLE IF NOT EXISTS document_versions (
 // clean — mirroring what CI gets for free.
 $pdo->exec('DELETE FROM login_attempts');
 
+// Disposable demo orgs from previous local runs (slug prefix `demo-`) count
+// against the DEMO_MAX_ORGS ceiling and would eventually 503 the disposable
+// demo tests. Sweep them and their tenant rows before the suite starts.
+$demoOrgIds = $pdo->query(
+    "SELECT id FROM organizations WHERE slug LIKE 'demo-%'",
+)->fetchAll(PDO::FETCH_COLUMN);
+
+if ($demoOrgIds !== []) {
+    $in = implode(',', array_map('intval', $demoOrgIds));
+    $pdo->exec("DELETE FROM vault_documents WHERE organization_id IN ({$in})");
+    $pdo->exec("DELETE FROM document_versions WHERE organization_id IN ({$in})");
+    $pdo->exec("DELETE FROM audit_events WHERE organization_id IN ({$in})");
+    $pdo->exec("DELETE FROM vault_settings WHERE organization_id IN ({$in})");
+    $pdo->exec("DELETE FROM users WHERE organization_id IN ({$in})");
+    $pdo->exec("DELETE FROM organizations WHERE id IN ({$in})");
+}
+
 $rateLimitDir = dirname(__DIR__) . '/var/rate-limits';
 
 if (is_dir($rateLimitDir)) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -148,9 +148,8 @@ $pdo->exec('DELETE FROM login_attempts');
 // Disposable demo orgs from previous local runs (slug prefix `demo-`) count
 // against the DEMO_MAX_ORGS ceiling and would eventually 503 the disposable
 // demo tests. Sweep them and their tenant rows before the suite starts.
-$demoOrgIds = $pdo->query(
-    "SELECT id FROM organizations WHERE slug LIKE 'demo-%'",
-)->fetchAll(PDO::FETCH_COLUMN);
+$demoOrgStmt = $pdo->query("SELECT id FROM organizations WHERE slug LIKE 'demo-%'");
+$demoOrgIds = $demoOrgStmt !== false ? $demoOrgStmt->fetchAll(PDO::FETCH_COLUMN) : [];
 
 if ($demoOrgIds !== []) {
     $in = implode(',', array_map('intval', $demoOrgIds));

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -7,6 +7,7 @@
 #
 # Output:
 #   dist/nene-vault-{version}.zip
+#   dist/nene-vault-{version}.zip.sha256   (integrity sidecar, #159)
 #
 # Requirements:
 #   - Composer installed globally
@@ -24,7 +25,7 @@ ZIP_FILE="$DIST/nene-vault-$VERSION.zip"
 echo "==> Building NeNe Vault $VERSION"
 
 # ── Cleanup ───────────────────────────────────────────────────────────────────
-rm -rf "$STAGING" "$ZIP_FILE"
+rm -rf "$STAGING" "$ZIP_FILE" "$ZIP_FILE.sha256"
 mkdir -p "$STAGING"
 
 # ── Frontend build ────────────────────────────────────────────────────────────
@@ -49,9 +50,10 @@ rsync -a --exclude='*.test.*' \
 rsync -a \
     "$ROOT/vendor/"    "$STAGING/vendor/"
 
-# Path-repository packages (hideyukimori/nene2) are SYMLINKS in vendor/;
-# rsync -a keeps them as links and zip silently drops them — the shipped zip
-# then contains no framework at all (#122). Dereference into real files.
+# Guard against symlinked vendor packages (the historic #122 trap): NENE2 now
+# comes from Packagist as real files (#159), so this loop is normally a no-op,
+# but a local path-repository override would reintroduce the empty-framework
+# zip without it. Dereference any remaining links into real files.
 find "$STAGING/vendor" -maxdepth 3 -type l | while read -r link; do
     # Relative link targets only resolve from the ORIGINAL vendor tree.
     src="$ROOT/vendor/${link#"$STAGING/vendor/"}"
@@ -102,8 +104,15 @@ cd "$DIST"
 # Tier A zip (#118) — without .htaccess Apache serves no routes at all.
 zip -r "nene-vault-$VERSION.zip" "nene-vault-$VERSION/" -x "*/.git/*" -x "*/.gitkeep" -q
 
+# ── SHA-256 sidecar (#159, invoice shape) ─────────────────────────────────────
+echo "--> Writing SHA-256 sidecar..."
+sha256sum "nene-vault-$VERSION.zip" > "nene-vault-$VERSION.zip.sha256"
+SHA256="$(cut -d' ' -f1 "nene-vault-$VERSION.zip.sha256")"
+
 echo ""
 echo "==> Release ZIP: $ZIP_FILE"
+echo "    sha256:  ${SHA256}"
+echo "    sidecar: $ZIP_FILE.sha256"
 echo "    Contents: $(du -sh "$STAGING" | cut -f1) uncompressed"
 echo ""
 echo "Tier A installation:"


### PR DESCRIPTION
## Summary

#150 checklist items: NENE2 path repo `@dev` → **Packagist `^1.10`** (lock pins v1.10.0 dist zip — reproducible builds, no silent tracking of local NENE2 HEAD), and `tools/build-release.sh` now writes a **SHA-256 sidecar** next to the zip (invoice shape).

- CI no longer clones NENE2; docker-compose drops the `../NENE2` mount; Dockerfile prod stage builds from this repo alone.
- `vendor/hideyukimori/nene2` is now real files (the #122 symlink-drop trap can't recur); the dereference loop in the build script stays as a guard.
- Test bootstrap sweeps stale `demo-*` orgs from previous local runs (they accumulated toward the DEMO_MAX_ORGS ceiling in the persistent SQLite test DB and started 503ing the demo tests locally; CI is always fresh).

## Tests

`composer check` all green (365 tests) with the Packagist-installed framework. `bash -n tools/build-release.sh` passes.

Closes #159. Refs #150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)