### PR TITLE
fix(org): write organizations timestamps in UTC and flip the sweep to an explicit UTC parse (#161)

### DIFF
--- a/conformance.baseline.json
+++ b/conformance.baseline.json
@@ -46,12 +46,6 @@
         },
         {
             "rule": "D4",
-            "file": "src/Organization/PdoOrganizationRepository.php",
-            "message": "Raw current-time read date() with no explicit timestamp. Inject Nene2\\Http\\ClockInterface (Nene2\\Http\\UtcClock in production) instead of reading the wall clock directly.",
-            "count": 2
-        },
-        {
-            "rule": "D4",
             "file": "src/Support/Ulid.php",
             "message": "Raw current-time read microtime(). Inject Nene2\\Http\\ClockInterface (Nene2\\Http\\UtcClock in production) instead of reading the wall clock directly.",
             "count": 1

--- a/database/migrations/20260711000002_convert_organizations_timestamps_to_utc.php
+++ b/database/migrations/20260711000002_convert_organizations_timestamps_to_utc.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * One-shot conversion for #161: `organizations.created_at` / `updated_at` were
+ * written with `date()` in the host's default timezone; from #161 on they are
+ * written in UTC and the demo sweep parses them as UTC. This migration shifts
+ * every existing row from the host default timezone (as configured at
+ * migration time — php.ini `date.timezone`, JST on the live demo host) to
+ * UTC, DST-correct via DateTime.
+ *
+ * DEPLOY ORDER MATTERS: apply this migration together with the #161 code
+ * switch, before the next hourly sweep tick. A row written in UTC by the new
+ * code and then shifted again by this migration would look older by the UTC
+ * offset (9 h on JST) and a demo org could be reaped early. On a UTC host the
+ * migration is a no-op.
+ */
+final class ConvertOrganizationsTimestampsToUtc extends AbstractMigration
+{
+    public function up(): void
+    {
+        $this->convert(date_default_timezone_get(), 'UTC');
+    }
+
+    public function down(): void
+    {
+        $this->convert('UTC', date_default_timezone_get());
+    }
+
+    private function convert(string $fromTz, string $toTz): void
+    {
+        if ($fromTz === $toTz) {
+            return;
+        }
+
+        $from = new DateTimeZone($fromTz);
+        $to = new DateTimeZone($toTz);
+
+        $rows = $this->fetchAll('SELECT id, created_at, updated_at FROM organizations');
+
+        foreach ($rows as $row) {
+            $createdAt = $this->shift((string) $row['created_at'], $from, $to);
+            $updatedAt = $this->shift((string) $row['updated_at'], $from, $to);
+
+            if ($createdAt === null || $updatedAt === null) {
+                continue; // unparseable value — leave untouched rather than corrupt
+            }
+
+            $this->execute(sprintf(
+                "UPDATE organizations SET created_at = '%s', updated_at = '%s' WHERE id = %d",
+                $createdAt,
+                $updatedAt,
+                (int) $row['id'],
+            ));
+        }
+    }
+
+    private function shift(string $value, DateTimeZone $from, DateTimeZone $to): ?string
+    {
+        $dt = DateTimeImmutable::createFromFormat('Y-m-d H:i:s', $value, $from);
+
+        if ($dt === false) {
+            return null;
+        }
+
+        return $dt->setTimezone($to)->format('Y-m-d H:i:s');
+    }
+}

--- a/src/Organization/OrganizationServiceProvider.php
+++ b/src/Organization/OrganizationServiceProvider.php
@@ -11,7 +11,9 @@ use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\UtcClock;
 use NeneVault\VaultSettings\PdoVaultSettingsRepository;
 use NeneVault\VaultSettings\VaultSettingsSeederInterface;
 use Psr\Container\ContainerInterface;
@@ -31,7 +33,13 @@ final readonly class OrganizationServiceProvider implements ServiceProviderInter
                         throw new LogicException('DatabaseQueryExecutorInterface service is invalid.');
                     }
 
-                    return new PdoOrganizationRepository($query);
+                    $clock = $c->get(ClockInterface::class);
+
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('ClockInterface service is invalid.');
+                    }
+
+                    return new PdoOrganizationRepository($query, $clock);
                 },
             )
             // ── Use cases ──
@@ -46,7 +54,7 @@ final readonly class OrganizationServiceProvider implements ServiceProviderInter
 
                     return new CreateOrganizationUseCase(
                         $tx,
-                        static fn (DatabaseQueryExecutorInterface $e): OrganizationRepositoryInterface => new PdoOrganizationRepository($e),
+                        static fn (DatabaseQueryExecutorInterface $e): OrganizationRepositoryInterface => new PdoOrganizationRepository($e, new UtcClock()),
                         static fn (DatabaseQueryExecutorInterface $e): VaultSettingsSeederInterface => new PdoVaultSettingsRepository($e),
                         self::auditFactory($c),
                     );
@@ -87,7 +95,7 @@ final readonly class OrganizationServiceProvider implements ServiceProviderInter
 
                     return new UpdateOrganizationUseCase(
                         $tx,
-                        static fn (DatabaseQueryExecutorInterface $e): OrganizationRepositoryInterface => new PdoOrganizationRepository($e),
+                        static fn (DatabaseQueryExecutorInterface $e): OrganizationRepositoryInterface => new PdoOrganizationRepository($e, new UtcClock()),
                         self::auditFactory($c),
                     );
                 },
@@ -103,7 +111,7 @@ final readonly class OrganizationServiceProvider implements ServiceProviderInter
 
                     return new DeleteOrganizationUseCase(
                         $tx,
-                        static fn (DatabaseQueryExecutorInterface $e): OrganizationRepositoryInterface => new PdoOrganizationRepository($e),
+                        static fn (DatabaseQueryExecutorInterface $e): OrganizationRepositoryInterface => new PdoOrganizationRepository($e, new UtcClock()),
                         self::auditFactory($c),
                     );
                 },

--- a/src/Organization/PdoOrganizationRepository.php
+++ b/src/Organization/PdoOrganizationRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneVault\Organization;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\ClockInterface;
 use PDOException;
 
 final readonly class PdoOrganizationRepository implements OrganizationRepositoryInterface
@@ -13,6 +14,7 @@ final readonly class PdoOrganizationRepository implements OrganizationRepository
 
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -66,7 +68,9 @@ final readonly class PdoOrganizationRepository implements OrganizationRepository
 
     public function save(Organization $organization): int
     {
-        $now = date('Y-m-d H:i:s');
+        // UTC via the injected clock (#161): the sweep parses created_at as
+        // UTC, and all fleet products write UTC (clear #280 / deal #72 shape).
+        $now = $this->clock->now()->format('Y-m-d H:i:s');
 
         try {
             $this->query->execute(
@@ -111,7 +115,7 @@ final readonly class PdoOrganizationRepository implements OrganizationRepository
                 $organization->customDomain,
                 $organization->plan,
                 $organization->isActive ? 1 : 0,
-                date('Y-m-d H:i:s'),
+                $this->clock->now()->format('Y-m-d H:i:s'),
                 $organization->id,
             ],
         );

--- a/tests/Demo/SweepDemoScriptTest.php
+++ b/tests/Demo/SweepDemoScriptTest.php
@@ -11,14 +11,14 @@ use PHPUnit\Framework\TestCase;
  * Runs the real `tools/sweep-demo.php` as a subprocess with the host timezone
  * pinned to Asia/Tokyo — the production (HETEML) configuration — and to UTC.
  *
- * Vault writes `organizations.created_at` with `date()` in the host's default
- * timezone (unlike clear/deal, which write UTC), so the sweep must parse it
- * with that same default timezone (#143): each scenario here writes
- * `created_at` in the timezone the subprocess sweeps under and expects the
- * same outcome — fresh orgs survive, genuinely expired ones are reaped, and
- * the reaped org's document storage tree goes with it. (A UTC-forced parse on
- * the JST host — the transplanted clear #280 / deal #72 shape — read every
- * org as 9 h in the future and stretched the 3 h TTL to 12 h.)
+ * Since #161 the WRITE side stamps `organizations.created_at` in UTC
+ * (PdoOrganizationRepository via the injected UtcClock) and the sweep parses
+ * it as UTC — both sides of the #143 pairing flipped together, matching
+ * clear #280 / deal #72. Each scenario writes `created_at` through the REAL
+ * repository code path in a subprocess whose default timezone is pinned (so a
+ * regression back to host-local `date()` writes shows up on the JST run), then
+ * sweeps under the same pinned timezone: fresh orgs survive, genuinely expired
+ * ones are reaped, and the reaped org's document storage tree goes with it.
  */
 final class SweepDemoScriptTest extends TestCase
 {
@@ -55,11 +55,19 @@ final class SweepDemoScriptTest extends TestCase
 
     public function test_fresh_org_survives_and_expired_org_is_reaped_on_a_jst_host(): void
     {
-        // created_at written the way the app writes it on a JST host: date()
-        // in Asia/Tokyo — the sweep subprocess below runs under the same TZ.
-        $this->insertOrg(1, 'demo-fresh', $this->localStamp('Asia/Tokyo', 60));               // 1 minute old
-        $this->insertOrg(2, 'demo-expired', $this->localStamp('Asia/Tokyo', 4 * 3600));       // past the 3h TTL
-        $this->insertOrg(3, 'ayane', $this->localStamp('Asia/Tokyo', 30 * 24 * 3600));        // fixed showcase org (no prefix)
+        // Write side runs the real PdoOrganizationRepository inside a JST
+        // subprocess (#161): the stamp must come out UTC, not Asia/Tokyo.
+        $this->writeOrgViaRepository('Asia/Tokyo', 'demo-fresh');
+        $freshStamp = $this->createdAtOf('demo-fresh');
+        self::assertEqualsWithDelta(
+            time(),
+            strtotime($freshStamp . ' UTC'),
+            60,
+            "created_at must be stamped in UTC even on a JST host (got {$freshStamp})",
+        );
+
+        $this->insertOrg(2, 'demo-expired', $this->utcStamp(4 * 3600));       // past the 3h TTL
+        $this->insertOrg(3, 'ayane', $this->utcStamp(30 * 24 * 3600));        // fixed showcase org (no prefix)
 
         // Child rows + a storage tree for the org that must be reaped.
         $this->pdo->exec('INSERT INTO users (organization_id) VALUES (2)');
@@ -78,8 +86,8 @@ final class SweepDemoScriptTest extends TestCase
 
     public function test_behaves_identically_on_a_utc_host_and_is_idempotent(): void
     {
-        $this->insertOrg(1, 'demo-fresh', $this->localStamp('UTC', 60));
-        $this->insertOrg(2, 'demo-expired', $this->localStamp('UTC', 4 * 3600));
+        $this->writeOrgViaRepository('UTC', 'demo-fresh');
+        $this->insertOrg(2, 'demo-expired', $this->utcStamp(4 * 3600));
 
         $output = $this->runSweep('UTC');
         self::assertStringContainsString('2 org(s) total, 1 expired, 0 overflow, 1 reaped', $output);
@@ -91,12 +99,53 @@ final class SweepDemoScriptTest extends TestCase
         self::assertSame(['demo-fresh'], $this->remainingSlugs());
     }
 
-    /** A created_at string as the app's date() would write it in $timezone, $secondsAgo in the past. */
-    private function localStamp(string $timezone, int $secondsAgo): string
+    /** A UTC created_at string as the app writes it since #161, $secondsAgo in the past. */
+    private function utcStamp(int $secondsAgo): string
     {
         return (new \DateTimeImmutable('@' . (time() - $secondsAgo)))
-            ->setTimezone(new \DateTimeZone($timezone))
+            ->setTimezone(new \DateTimeZone('UTC'))
             ->format('Y-m-d H:i:s');
+    }
+
+    /**
+     * Saves an org through the REAL write path (PdoOrganizationRepository) in
+     * a subprocess whose default timezone is pinned to $timezone — proving the
+     * stamp is UTC regardless of the host timezone (#161).
+     */
+    private function writeOrgViaRepository(string $timezone, string $slug): void
+    {
+        $root = dirname(__DIR__, 2);
+        $code = <<<'PHP'
+        require $argv[1] . '/vendor/autoload.php';
+        $kit = Nene2\Testing\DatabaseTestKit::sqlite($argv[2]);
+        $repo = new NeneVault\Organization\PdoOrganizationRepository($kit->queryExecutor, new Nene2\Http\UtcClock());
+        $repo->save(new NeneVault\Organization\Organization(name: 'Demo', slug: $argv[3], plan: 'free', isActive: true));
+        PHP;
+
+        $command = [
+            PHP_BINARY,
+            '-d', 'date.timezone=' . $timezone,
+            '-r', $code,
+            '--',
+            $root,
+            $this->dbPath,
+            $slug,
+        ];
+
+        $process = proc_open($command, [1 => ['pipe', 'w'], 2 => ['pipe', 'w']], $pipes, $root);
+        self::assertIsResource($process);
+        $stderr = (string) stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        self::assertSame(0, proc_close($process), 'repository write subprocess failed: ' . $stderr);
+    }
+
+    private function createdAtOf(string $slug): string
+    {
+        $stmt = $this->pdo->prepare('SELECT created_at FROM organizations WHERE slug = ?');
+        $stmt->execute([$slug]);
+
+        return (string) $stmt->fetchColumn();
     }
 
     private function insertOrg(int $id, string $slug, string $createdAt): void

--- a/tools/sweep-demo.php
+++ b/tools/sweep-demo.php
@@ -54,15 +54,15 @@ $records = [];
 foreach ($rows as $row) {
     $records[] = new DemoOrgRecord(
         orgId: (int) $row['id'],
-        // Parse created_at in the timezone it was WRITTEN in (#143). Vault's
-        // PdoOrganizationRepository stamps it with date() — the host's default
-        // timezone — unlike clear/deal, which write UTC and therefore need the
-        // UTC-explicit parse (clear #280, deal #72). Web SAPI and this CLI
-        // share php.ini date.timezone on the target host, so the bare parse
-        // is the consistent one: forcing UTC on a JST host read every org as
-        // 9 h in the future and stretched the 3 h TTL to 12 h (caught in the
-        // #141 production acceptance).
-        createdAt: new DateTimeImmutable((string) $row['created_at']),
+        // Parse created_at as UTC — the timezone it is WRITTEN in since #161
+        // (PdoOrganizationRepository stamps via the injected UtcClock, matching
+        // clear #280 / deal #72). The #143 bare parse existed to pair with the
+        // old host-local date() write; both sides flipped together, and the
+        // one-shot migration 20260711000002 converts pre-#161 rows. A legacy
+        // local-TZ row that somehow escapes migration only looks NEWER on a
+        // UTC+ host (never reaped early); the DEMO_MAX_ORGS overflow ceiling
+        // still bounds it.
+        createdAt: new DateTimeImmutable((string) $row['created_at'], new DateTimeZone('UTC')),
     );
 }
 


### PR DESCRIPTION
## Summary

#150 checklist item (`created_at` host-local writes), designed with #143's deliberate pairing in mind — **write side and parse side flip together**:

- `PdoOrganizationRepository` stamps `created_at`/`updated_at` via injected `ClockInterface` (UTC); D4 baseline entry dropped (10 → 9 files).
- `tools/sweep-demo.php` parses `created_at` explicitly as UTC.
- One-shot Phinx migration `20260711000002` converts pre-existing rows from the host default TZ to UTC (DST-correct, no-op on UTC hosts, reversible `down()`). Deploy-order note in the docblock: apply with the code switch before the next hourly sweep tick.
- Fail-safe direction: an unmigrated legacy JST row under UTC parse only looks *newer* — never premature reap; the org ceiling still bounds it.

## 2-TZ live acceptance (recorded in the handoff report)

- `SweepDemoScriptTest` now writes through the **real repository code path in TZ-pinned subprocesses** (Asia/Tokyo + UTC), asserts the stamp is UTC on the JST host, then runs the **real sweep script**: fresh org survives, 4 h-old org reaped, fixed `ayane` org untouched, idempotent second run — both TZs green.
- Migration real-run on a staged SQLite DB: JST host `17:26 JST → 08:26 UTC` (== wall-clock UTC), 4 h-old row shifted identically; UTC host verified as a byte-identical no-op.

`composer check` all green (365 tests).

Closes #161. Refs #150, #143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)