### PR TITLE
feat(i18n): derive a compile-time MessageKey union from the JSON catalog (#166)

### DIFF
--- a/frontend/src/features/document-detail/ui/DocumentHistoryTable.tsx
+++ b/frontend/src/features/document-detail/ui/DocumentHistoryTable.tsx
@@ -1,3 +1,4 @@
+import { dynamicMessageKey } from '@/shared/i18n/catalogs';
 import { useTranslation } from '@/shared/i18n/use-translation';
 import { formatDateTime } from '@/shared/lib/format';
 import type { AuditEvent } from '@/entities/audit';
@@ -29,7 +30,9 @@ export function DocumentHistoryTable({ events }: DocumentHistoryTableProps) {
           {events.map((event) => (
             <tr key={event.id}>
               <td>
-                <span className="pri">{t(`audit_event.action.${event.action}`)}</span>
+                <span className="pri">
+                  {t(dynamicMessageKey(`audit_event.action.${event.action}`))}
+                </span>
               </td>
               <td className="muted mono">
                 {event.actor_user_id !== null ? String(event.actor_user_id) : '—'}

--- a/frontend/src/pages/AuditPage.tsx
+++ b/frontend/src/pages/AuditPage.tsx
@@ -1,3 +1,4 @@
+import { dynamicMessageKey } from '@/shared/i18n/catalogs';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuditEvents, diffAuditEvent, formatAuditValue } from '@/entities/audit';
@@ -150,7 +151,7 @@ function AuditDetailDrawer({ event, open, onClose }: DrawerProps) {
                 </div>
                 <h2>
                   <span className="tick" />
-                  <span>{t(`audit_event.action.${event.action}`)}</span>
+                  <span>{t(dynamicMessageKey(`audit_event.action.${event.action}`))}</span>
                 </h2>
               </div>
               <button
@@ -378,7 +379,9 @@ export function AuditPage() {
                         }
                       }}
                     >
-                      <td className="pri">{t(`audit_event.action.${event.action}`)}</td>
+                      <td className="pri">
+                        {t(dynamicMessageKey(`audit_event.action.${event.action}`))}
+                      </td>
                       <td className="muted mono label-xs">
                         {event.entity_type}/{event.entity_id}
                       </td>

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -2,12 +2,13 @@ import type { ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { authStore } from '@/entities/auth';
 import { useTranslation } from '@/shared/i18n/use-translation';
+import type { MessageKey } from '@/shared/i18n/catalogs';
 import { AppShell } from '@/shared/ui';
 
 interface QuickLink {
   to: string;
-  titleKey: string;
-  subKey: string;
+  titleKey: MessageKey;
+  subKey: MessageKey;
   icon: ReactNode;
 }
 

--- a/frontend/src/shared/i18n/catalogs.ts
+++ b/frontend/src/shared/i18n/catalogs.ts
@@ -6,6 +6,27 @@ import type { SupportedLocale } from './locales';
 
 export type LocaleCatalog = typeof ja;
 
+/** All dot-notation paths to string leaves of the catalog. */
+type DotPaths<T> = {
+  [K in keyof T & string]: T[K] extends string ? K : `${K}.${DotPaths<T[K]>}`;
+}[keyof T & string];
+
+/**
+ * Every valid message key, derived from the repo-root JSON catalog (#166).
+ * A typo'd or missing key is now a compile error (the #137 bug class), while
+ * locales/*.json stays the single source of truth (ADR 0005).
+ */
+export type MessageKey = DotPaths<LocaleCatalog>;
+
+/**
+ * Escape hatch for keys built from backend-provided values (audit actions,
+ * roles from a session blob). Compile-time checking is impossible there; the
+ * runtime key-echo fallback in lookup() still applies. Greppable on purpose.
+ */
+export function dynamicMessageKey(key: string): MessageKey {
+  return key as MessageKey;
+}
+
 export const catalogs: Record<SupportedLocale, LocaleCatalog> = {
   ja,
   en,

--- a/frontend/src/shared/i18n/context.ts
+++ b/frontend/src/shared/i18n/context.ts
@@ -1,11 +1,12 @@
 import { createContext } from 'react';
+import type { MessageKey } from './catalogs';
 import type { SupportedLocale } from './locales';
 import type { TranslateParams } from './translate';
 
 export interface I18nContextValue {
   locale: SupportedLocale;
   setLocale: (locale: SupportedLocale) => void;
-  t: (key: string, params?: TranslateParams) => string;
+  t: (key: MessageKey, params?: TranslateParams) => string;
 }
 
 export const I18nContext = createContext<I18nContextValue | null>(null);

--- a/frontend/src/shared/i18n/i18n-context.tsx
+++ b/frontend/src/shared/i18n/i18n-context.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
+import type { MessageKey } from './catalogs';
 import { persistLocale, resolveInitialLocale, type SupportedLocale } from './locales';
 import { translate, type TranslateParams } from './translate';
 import { I18nContext } from './context';
@@ -19,7 +20,7 @@ export function I18nProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const t = useCallback(
-    (key: string, params?: TranslateParams) => translate(locale, key, params),
+    (key: MessageKey, params?: TranslateParams) => translate(locale, key, params),
     [locale],
   );
 

--- a/frontend/src/shared/i18n/map-problem-details.ts
+++ b/frontend/src/shared/i18n/map-problem-details.ts
@@ -1,7 +1,8 @@
 import { AppError } from '@/shared/api/errors';
+import type { MessageKey } from './catalogs';
 
 // Map a Problem Details slug (or HTTP status fallback) to a locale key under `problem.*`.
-const SLUG_TO_KEY: Record<string, string> = {
+const SLUG_TO_KEY: Record<string, MessageKey> = {
   unauthorized: 'problem.unauthorized',
   forbidden: 'problem.forbidden',
   'org-access-denied': 'problem.org_access_denied',
@@ -23,10 +24,11 @@ const SLUG_TO_KEY: Record<string, string> = {
   'internal-server-error': 'problem.internal_server_error',
 };
 
-export function problemMessageKey(error: AppError): string {
+export function problemMessageKey(error: AppError): MessageKey {
   const slug = error.problemSlug;
-  if (slug !== null && slug in SLUG_TO_KEY) {
-    return SLUG_TO_KEY[slug] as string;
+  const mapped = slug !== null ? SLUG_TO_KEY[slug] : undefined;
+  if (mapped !== undefined) {
+    return mapped;
   }
   return error.status >= 500 ? 'problem.internal_server_error' : 'problem.validation_failed';
 }
@@ -36,6 +38,6 @@ export function problemMessageKey(error: AppError): string {
  * value is not an AppError. Lets feature hooks map errors without importing
  * shared/api directly (FSD boundary).
  */
-export function messageKeyForError(error: unknown): string | null {
+export function messageKeyForError(error: unknown): MessageKey | null {
   return error instanceof AppError ? problemMessageKey(error) : null;
 }

--- a/frontend/src/shared/i18n/translate.test.ts
+++ b/frontend/src/shared/i18n/translate.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { lookup, interpolate, translate } from './translate';
-import type { LocaleCatalog } from './catalogs';
+import { dynamicMessageKey, type LocaleCatalog } from './catalogs';
 
 const catalog = {
   common: {
@@ -22,11 +22,13 @@ describe('lookup', () => {
   });
 
   it('returns the key itself when not found', () => {
-    expect(lookup(catalog, 'no.such.key')).toBe('no.such.key');
+    expect(lookup(catalog, dynamicMessageKey('no.such.key'))).toBe('no.such.key');
   });
 
   it('returns the key when a node is not an object', () => {
-    expect(lookup(catalog, 'common.buttons.save.extra')).toBe('common.buttons.save.extra');
+    expect(lookup(catalog, dynamicMessageKey('common.buttons.save.extra'))).toBe(
+      'common.buttons.save.extra',
+    );
   });
 });
 
@@ -70,6 +72,6 @@ describe('translate', () => {
   });
 
   it('falls back to the key when the key is missing', () => {
-    expect(translate('ja', 'nonexistent.key')).toBe('nonexistent.key');
+    expect(translate('ja', dynamicMessageKey('nonexistent.key'))).toBe('nonexistent.key');
   });
 });

--- a/frontend/src/shared/i18n/translate.ts
+++ b/frontend/src/shared/i18n/translate.ts
@@ -1,10 +1,10 @@
-import { catalogs, type LocaleCatalog } from './catalogs';
+import { catalogs, type LocaleCatalog, type MessageKey } from './catalogs';
 import type { SupportedLocale } from './locales';
 
 export type TranslateParams = Record<string, string | number>;
 
 /** Look up a dot-notation key; returns the key itself when missing (visible, not blank). */
-export function lookup(catalog: LocaleCatalog, key: string): string {
+export function lookup(catalog: LocaleCatalog, key: MessageKey): string {
   const value = key.split('.').reduce<unknown>((node, part) => {
     if (node !== null && typeof node === 'object' && part in node) {
       return (node as Record<string, unknown>)[part];
@@ -24,6 +24,10 @@ export function interpolate(template: string, params?: TranslateParams): string 
   );
 }
 
-export function translate(locale: SupportedLocale, key: string, params?: TranslateParams): string {
+export function translate(
+  locale: SupportedLocale,
+  key: MessageKey,
+  params?: TranslateParams,
+): string {
   return interpolate(lookup(catalogs[locale], key), params);
 }

--- a/frontend/src/shared/ui/components/AppShell.tsx
+++ b/frontend/src/shared/ui/components/AppShell.tsx
@@ -1,3 +1,4 @@
+import { dynamicMessageKey, type MessageKey } from '@/shared/i18n/catalogs';
 import type { ReactNode } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useTranslation } from '@/shared/i18n/use-translation';
@@ -6,10 +7,10 @@ import { LanguageSwitcher } from './LanguageSwitcher';
 
 interface NavItem {
   to: string;
-  labelKey: string;
+  labelKey: MessageKey;
   icon: ReactNode;
   /** Locale key for a group heading rendered above this item (new section). */
-  groupKey?: string;
+  groupKey?: MessageKey;
 }
 
 const HomeIcon = (
@@ -145,7 +146,10 @@ export function AppShell({
   };
 
   const avatarLetter = userEmail !== undefined && userEmail !== '' ? userEmail.charAt(0) : '?';
-  const roleLabel = userRole !== undefined && userRole !== '' ? t(`user.role.${userRole}`) : null;
+  const roleLabel =
+    userRole !== undefined && userRole !== ''
+      ? t(dynamicMessageKey(`user.role.${userRole}`))
+      : null;
 
   return (
     <div className="layout">


### PR DESCRIPTION
## Summary

#150 checklist item (i18n keys are raw strings). Vault keeps `locales/*.json` as the single source of truth (ADR 0005) — unlike invoice/deal's TS message files — and gets the same compile-time safety by deriving `MessageKey` (a recursive template-literal dot-path union) from the imported JSON structure.

- `t()` and the whole translate pipeline accept `MessageKey` only; typos/missing keys are compile errors (the #137 permanent fix).
- Dynamic keys from generated literal unions type-check untouched; backend-driven strings (audit `action`, session role) use an explicit `dynamicMessageKey()` escape hatch with the existing key-echo runtime fallback.

## Tests

`npm run check` all green (type-check / eslint / prettier / vitest 196 / knip / storybook).

Closes #166. Refs #150, #137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)