### PR TITLE
feat(auth): show the login form in place on 401 via a reactive auth gate (#168)

### DIFF
--- a/frontend/src/app/auth-gate.test.tsx
+++ b/frontend/src/app/auth-gate.test.tsx
@@ -1,8 +1,17 @@
-import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { screen } from '@testing-library/react';
+import { act } from 'react';
 import { afterEach, describe, expect, it } from 'vitest';
 import { authStore } from '@/entities/auth';
+import { renderWithProviders } from '@tests/render/render-with-providers';
 import { AuthGate } from './auth-gate';
+
+const SESSION = {
+  token: 'valid-jwt',
+  userId: 1,
+  email: 'admin@example.com',
+  role: 'admin',
+  orgId: 1,
+};
 
 afterEach(() => {
   sessionStorage.clear();
@@ -10,56 +19,60 @@ afterEach(() => {
 
 describe('AuthGate', () => {
   it('renders children when a session exists', () => {
-    authStore.setSession({
-      token: 'valid-jwt',
-      userId: 1,
-      email: 'admin@example.com',
-      role: 'admin',
-      orgId: 1,
-    });
+    authStore.setSession(SESSION);
 
-    render(
-      <MemoryRouter>
-        <AuthGate>
-          <div>Protected content</div>
-        </AuthGate>
-      </MemoryRouter>,
+    renderWithProviders(
+      <AuthGate>
+        <div>Protected content</div>
+      </AuthGate>,
     );
 
     expect(screen.getByText('Protected content')).toBeInTheDocument();
   });
 
-  it('redirects to /login when no session exists', () => {
-    render(
-      <MemoryRouter initialEntries={['/dashboard']}>
-        <AuthGate>
-          <div>Protected content</div>
-        </AuthGate>
-      </MemoryRouter>,
+  it('shows the login form in place when no session exists (#168)', () => {
+    renderWithProviders(
+      <AuthGate>
+        <div>Protected content</div>
+      </AuthGate>,
     );
 
-    // Protected content should NOT be rendered
     expect(screen.queryByText('Protected content')).toBeNull();
+    // The login form renders IN PLACE — no navigation away from the route.
+    expect(screen.getByRole('button', { name: 'Log In' })).toBeInTheDocument();
   });
 
-  it('does not render children when session was cleared', () => {
-    authStore.setSession({
-      token: 'valid-jwt',
-      userId: 1,
-      email: 'a@b.com',
-      role: 'admin',
-      orgId: 1,
-    });
-    authStore.clearSession();
+  it('swaps to the login form when the session is cleared reactively', () => {
+    authStore.setSession(SESSION);
 
-    render(
-      <MemoryRouter>
-        <AuthGate>
-          <div>Protected content</div>
-        </AuthGate>
-      </MemoryRouter>,
+    renderWithProviders(
+      <AuthGate>
+        <div>Protected content</div>
+      </AuthGate>,
     );
+    expect(screen.getByText('Protected content')).toBeInTheDocument();
+
+    // A 401 in the API client clears the session; the gate must react.
+    act(() => {
+      authStore.clearSession();
+    });
 
     expect(screen.queryByText('Protected content')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Log In' })).toBeInTheDocument();
+  });
+
+  it('swaps back to children when a session appears (login in place)', () => {
+    renderWithProviders(
+      <AuthGate>
+        <div>Protected content</div>
+      </AuthGate>,
+    );
+    expect(screen.queryByText('Protected content')).toBeNull();
+
+    act(() => {
+      authStore.setSession(SESSION);
+    });
+
+    expect(screen.getByText('Protected content')).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/auth-gate.tsx
+++ b/frontend/src/app/auth-gate.tsx
@@ -1,11 +1,29 @@
-import { Navigate } from 'react-router-dom';
+import { useSyncExternalStore, type ReactNode } from 'react';
 import { authStore } from '@/entities/auth';
-import type { ReactNode } from 'react';
+import { LoginForm } from '@/features/login';
 
-/** Fail closed: render children only when a session exists, else redirect to /login. */
+const subscribe = (listener: () => void) => authStore.subscribe(listener);
+const getToken = () => authStore.getToken();
+
+/**
+ * Fail closed: render children only when a session exists; otherwise show the
+ * login form IN PLACE (#168, clear/deal shape). The store is reactive, so a
+ * 401-triggered clearSession() swaps the login form in at the current URL and
+ * a successful login swaps the protected children back — no hard navigation,
+ * no lost route.
+ */
 export function AuthGate({ children }: { children: ReactNode }) {
-  if (authStore.getToken() === null) {
-    return <Navigate to="/login" replace />;
+  const token = useSyncExternalStore(subscribe, getToken);
+
+  if (token === null) {
+    return (
+      <LoginForm
+        onLoggedIn={() => {
+          // The store notified subscribers; this gate re-renders children.
+        }}
+      />
+    );
   }
+
   return <>{children}</>;
 }

--- a/frontend/src/entities/auth/model.test.ts
+++ b/frontend/src/entities/auth/model.test.ts
@@ -57,6 +57,25 @@ describe('authStore.clearSession', () => {
   });
 });
 
+describe('authStore.subscribe', () => {
+  it('notifies on setSession and clearSession, and unsubscribes cleanly', () => {
+    let calls = 0;
+    const unsubscribe = authStore.subscribe(() => {
+      calls += 1;
+    });
+
+    authStore.setSession(SESSION);
+    expect(calls).toBe(1);
+
+    authStore.clearSession();
+    expect(calls).toBe(2);
+
+    unsubscribe();
+    authStore.setSession(SESSION);
+    expect(calls).toBe(2);
+  });
+});
+
 describe('authStore resilience', () => {
   it('returns null when sessionStorage contains malformed JSON', () => {
     sessionStorage.setItem('nene_vault_token', '{bad json');

--- a/frontend/src/entities/auth/model.ts
+++ b/frontend/src/entities/auth/model.ts
@@ -12,7 +12,26 @@ export interface AuthSession {
 
 const STORAGE_KEY = 'nene_vault_token';
 
+// Reactive layer (#168): mutations notify subscribers so the auth gate can
+// re-render via useSyncExternalStore — a 401 clears the session and the login
+// form appears IN PLACE (current URL preserved), no hard navigation.
+const listeners = new Set<() => void>();
+
+function notify(): void {
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
 export const authStore = {
+  /** Subscribe to session changes; returns the unsubscribe function. */
+  subscribe(listener: () => void): () => void {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  },
+
   getSession(): AuthSession | null {
     try {
       const raw = sessionStorage.getItem(STORAGE_KEY);
@@ -31,6 +50,7 @@ export const authStore = {
     } catch {
       // ignore persistence failure
     }
+    notify();
   },
 
   clearSession(): void {
@@ -39,6 +59,7 @@ export const authStore = {
     } catch {
       // ignore
     }
+    notify();
   },
 
   getToken(): string | null {

--- a/frontend/src/shared/api/client.ts
+++ b/frontend/src/shared/api/client.ts
@@ -12,9 +12,11 @@ interface RequestOptions {
 
 /** Fail-closed handling for auth errors, shared by all requests. */
 function handleAuthError(response: Response, path: string): void {
+  // Session expired (not a wrong-credentials 401 from the login endpoint):
+  // clear the reactive store — the auth gate shows the login form in place at
+  // the current URL (#168), instead of a hard navigation that drops SPA state.
   if (response.status === 401 && !path.includes('/auth/login')) {
     authStore.clearSession();
-    window.location.href = '/login';
   }
   if (response.status === 403) {
     window.location.href = '/forbidden';


### PR DESCRIPTION
## Summary

#150 checklist item (j): the 401 `window.location.href = '/login'` hard navigation is replaced by the clear/deal in-place shape — reactive auth store (`subscribe`/notify) + `AuthGate` on `useSyncExternalStore` rendering the login form at the current URL; re-login swaps the protected children back without losing the route.

The 403 → `/forbidden` hard redirect stays deliberately (folded into the base-path follow-up, invoice ADR 0015 reference).

## Tests

`npm run check` all green (198 tests): new gate tests cover in-place login render, reactive swap on clearSession (the 401 path), swap-back on login, and store subscribe/unsubscribe.

Closes #168. Refs #150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)