### PR TITLE
fix(document): refresh change history after edit/void/restore (#172)

### DIFF
--- a/frontend/src/entities/document/mutations.test.ts
+++ b/frontend/src/entities/document/mutations.test.ts
@@ -1,9 +1,15 @@
-import { act, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { createElement, type ReactNode } from 'react';
 import { http, HttpResponse } from 'msw';
-import { describe, expect, it } from 'vitest';
-import { renderHookWithProviders } from '@tests/render/render-with-providers';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createTestQueryClient,
+  renderHookWithProviders,
+} from '@tests/render/render-with-providers';
 import { DOCUMENT_ID, mockDocument, mockVoidedDocument, problemDetails } from '@tests/msw/fixtures';
 import { server } from '@tests/msw/server';
+import { auditQueryKeys } from '@/entities/audit';
 import { useUpdateDocumentMetadata, useVoidDocument, useRestoreDocument } from './mutations';
 
 describe('useUpdateDocumentMetadata', () => {
@@ -103,5 +109,63 @@ describe('useRestoreDocument', () => {
     await waitFor(() => {
       expect(result.current.isError).toBe(true);
     });
+  });
+});
+
+// #172: the detail page's change-history table reads the audit history query,
+// which is keyed separately from the document detail/list. Every mutation that
+// records an audit event must invalidate it so new rows appear without a reload.
+describe('change-history invalidation', () => {
+  const HISTORY_KEY = auditQueryKeys.documentHistory(DOCUMENT_ID);
+
+  function renderWithSpyClient<T>(hook: () => T) {
+    const client = createTestQueryClient();
+    const spy = vi.spyOn(client, 'invalidateQueries');
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client }, children);
+    const view = renderHook(hook, { wrapper });
+    return { ...view, spy };
+  }
+
+  it('invalidates the document history after a metadata update', async () => {
+    const { result, spy } = renderWithSpyClient(() => useUpdateDocumentMetadata());
+
+    act(() => {
+      result.current.mutate({ id: DOCUMENT_ID, counterparty_name: 'Updated Inc.' });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(spy).toHaveBeenCalledWith({ queryKey: HISTORY_KEY });
+  });
+
+  it('invalidates the document history after voiding', async () => {
+    const { result, spy } = renderWithSpyClient(() => useVoidDocument());
+
+    act(() => {
+      result.current.mutate({ id: DOCUMENT_ID, void_reason: 'Duplicate entry' });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(spy).toHaveBeenCalledWith({ queryKey: HISTORY_KEY });
+  });
+
+  it('invalidates the document history after restoring', async () => {
+    const { result, spy } = renderWithSpyClient(() => useRestoreDocument());
+
+    act(() => {
+      result.current.mutate(DOCUMENT_ID);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(spy).toHaveBeenCalledWith({ queryKey: HISTORY_KEY });
   });
 });

--- a/frontend/src/entities/document/mutations.ts
+++ b/frontend/src/entities/document/mutations.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { auditQueryKeys } from '@/entities/audit';
 import { apiClient } from '@/shared/api/client';
 import type { AppError } from '@/shared/api/errors';
 import type { DocumentCategory, VaultDocument } from './types';
@@ -58,6 +59,9 @@ export function useUpdateDocumentMetadata(onSuccess?: () => void) {
     onSuccess: (_, { id }) => {
       void queryClient.invalidateQueries({ queryKey: documentQueryKeys.detail(id) });
       void queryClient.invalidateQueries({ queryKey: documentQueryKeys.all });
+      // The detail page's change-history table reads the audit history query,
+      // which is keyed separately; refresh it so new events show without reload.
+      void queryClient.invalidateQueries({ queryKey: auditQueryKeys.documentHistory(id) });
       onSuccess?.();
     },
   });
@@ -78,6 +82,9 @@ export function useVoidDocument(onSuccess?: () => void) {
     onSuccess: (_, { id }) => {
       void queryClient.invalidateQueries({ queryKey: documentQueryKeys.detail(id) });
       void queryClient.invalidateQueries({ queryKey: documentQueryKeys.all });
+      // The detail page's change-history table reads the audit history query,
+      // which is keyed separately; refresh it so new events show without reload.
+      void queryClient.invalidateQueries({ queryKey: auditQueryKeys.documentHistory(id) });
       onSuccess?.();
     },
   });
@@ -91,6 +98,9 @@ export function useRestoreDocument(onSuccess?: () => void) {
     onSuccess: (_, id) => {
       void queryClient.invalidateQueries({ queryKey: documentQueryKeys.detail(id) });
       void queryClient.invalidateQueries({ queryKey: documentQueryKeys.all });
+      // The detail page's change-history table reads the audit history query,
+      // which is keyed separately; refresh it so new events show without reload.
+      void queryClient.invalidateQueries({ queryKey: auditQueryKeys.documentHistory(id) });
       onSuccess?.();
     },
   });


### PR DESCRIPTION
## What

The document detail page's change-history table reads the **audit history** query (`auditQueryKeys.documentHistory(id)`), which is keyed separately from the document detail/list caches. `useUpdateDocumentMetadata`, `useVoidDocument` and `useRestoreDocument` invalidated only `documentQueryKeys.detail(id)` and `documentQueryKeys.all`, so after editing, voiding or restoring a document the history table kept showing only the original `uploaded` row until a full-page reload.

## Change

- Invalidate `auditQueryKeys.documentHistory(id)` in all three mutation `onSuccess` callbacks.
- Regression tests: assert the history query key is invalidated after metadata update, void and restore.

## Verification

- `npm run check` green (type-check, lint, prettier, 201 tests, knip, storybook build).
- Underlying data was always correct (status/tags/audit-log list updated); this closes the client cache-refresh gap so the trail grows live on the detail page.

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)