### PR TITLE
fix(export): route export through the shared API client + ban raw fetch (#173)

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -71,6 +71,27 @@ export default tseslint.config(
           selector: 'JSXAttribute[name.name="className"] Literal[value=/\\[.*\\]/]',
           message: 'Tailwind arbitrary values are forbidden outside shared/ui/theme.',
         },
+        {
+          // All network calls must go through the shared API client, which adds
+          // the Authorization + X-Authorization mirror (#118). A raw fetch drops
+          // the mirror and 401s behind the shared-hosting proxy (see #173).
+          selector: "CallExpression[callee.name='fetch']",
+          message:
+            'Do not call fetch() directly — use the shared apiClient (shared/api/client.ts) so the Authorization/X-Authorization headers are sent.',
+        },
+      ],
+    },
+  },
+  {
+    // The shared API client is the single sanctioned place that calls fetch().
+    files: ['src/shared/api/client.ts'],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: 'JSXAttribute[name.name="className"] Literal[value=/\\[.*\\]/]',
+          message: 'Tailwind arbitrary values are forbidden outside shared/ui/theme.',
+        },
       ],
     },
   },

--- a/frontend/src/entities/document/export.test.ts
+++ b/frontend/src/entities/document/export.test.ts
@@ -1,0 +1,44 @@
+import { act, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+import { renderHookWithProviders } from '@tests/render/render-with-providers';
+import { server } from '@tests/msw/server';
+import { useExportDocuments } from './export';
+
+describe('useExportDocuments', () => {
+  it('posts the export request and returns the downloaded blob + filename', async () => {
+    let seenBody: Record<string, unknown> | null = null;
+    server.use(
+      http.post('/admin/vault/export', async ({ request }) => {
+        seenBody = (await request.json()) as Record<string, unknown>;
+        return new HttpResponse('bytes', {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/zip',
+            'Content-Disposition': 'attachment; filename="vault-export.zip"',
+          },
+        });
+      }),
+    );
+
+    const { result } = renderHookWithProviders(() => useExportDocuments());
+
+    act(() => {
+      result.current.mutate({
+        format: 'zip',
+        include_voided: true,
+        counterparty_name: 'Acme',
+        transaction_date_from: '',
+        transaction_date_to: '',
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data?.filename).toBe('vault-export.zip');
+    // Empty optional filters are omitted from the request body.
+    expect(seenBody).toEqual({ include_voided: true, format: 'zip', counterparty_name: 'Acme' });
+  });
+});

--- a/frontend/src/entities/document/export.ts
+++ b/frontend/src/entities/document/export.ts
@@ -1,0 +1,45 @@
+import { useMutation, type UseMutationResult } from '@tanstack/react-query';
+import { apiClient, type BlobDownload } from '@/shared/api/client';
+import type { AppError } from '@/shared/api/errors';
+
+export type ExportFormat = 'zip' | 'csv';
+
+export interface ExportDocumentsInput {
+  format: ExportFormat;
+  include_voided: boolean;
+  transaction_date_from?: string | undefined;
+  transaction_date_to?: string | undefined;
+  counterparty_name?: string | undefined;
+}
+
+/**
+ * Requests an archive export (ZIP + manifest CSV, or CSV only). Goes through the
+ * shared API client's postBlob so the Authorization + X-Authorization mirror
+ * (#118) is sent — a raw fetch drops the mirror and 401s behind the shared-
+ * hosting proxy that strips Authorization (#173). The page owns the browser
+ * download side-effect from the returned blob.
+ */
+export function useExportDocuments(): UseMutationResult<
+  BlobDownload,
+  AppError,
+  ExportDocumentsInput
+> {
+  return useMutation<BlobDownload, AppError, ExportDocumentsInput>({
+    mutationFn: (input) => {
+      const body: Record<string, unknown> = {
+        include_voided: input.include_voided,
+        format: input.format,
+      };
+      if (input.transaction_date_from !== undefined && input.transaction_date_from !== '') {
+        body['transaction_date_from'] = input.transaction_date_from;
+      }
+      if (input.transaction_date_to !== undefined && input.transaction_date_to !== '') {
+        body['transaction_date_to'] = input.transaction_date_to;
+      }
+      if (input.counterparty_name !== undefined && input.counterparty_name !== '') {
+        body['counterparty_name'] = input.counterparty_name;
+      }
+      return apiClient.postBlob('/admin/vault/export', body);
+    },
+  });
+}

--- a/frontend/src/entities/document/index.ts
+++ b/frontend/src/entities/document/index.ts
@@ -16,3 +16,5 @@ export {
 export type { UploadDocumentInput, UpdateMetadataInput, VoidDocumentInput } from './mutations';
 export { useOcrSuggest } from './ocr';
 export type { OcrPrefill } from './ocr';
+export { useExportDocuments } from './export';
+export type { ExportDocumentsInput, ExportFormat } from './export';

--- a/frontend/src/pages/ExportPage.tsx
+++ b/frontend/src/pages/ExportPage.tsx
@@ -1,14 +1,15 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { authStore } from '@/entities/auth';
+import { useExportDocuments } from '@/entities/document';
 import { useTranslation } from '@/shared/i18n/use-translation';
 import { AppShell, Button, Checkbox, Field, Input } from '@/shared/ui';
-import { env } from '@/shared/config/env';
 
 export function ExportPage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const session = authStore.getSession();
+  const exportMutation = useExportDocuments();
   const [dateFrom, setDateFrom] = useState('');
   const [dateTo, setDateTo] = useState('');
   const [counterparty, setCounterparty] = useState('');
@@ -29,35 +30,21 @@ export function ExportPage() {
     setExportSuccess(false);
 
     try {
-      const base = env.apiBaseUrl.replace(/\/$/, '');
-      const body: Record<string, unknown> = { include_voided: includeVoided, format };
-      if (dateFrom !== '') body['transaction_date_from'] = dateFrom;
-      if (dateTo !== '') body['transaction_date_to'] = dateTo;
-      if (counterparty !== '') body['counterparty_name'] = counterparty;
-
-      const token = authStore.getToken();
-      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-      if (token !== null) headers['Authorization'] = `Bearer ${token}`;
-
-      const response = await fetch(`${base}/admin/vault/export`, {
-        method: 'POST',
-        headers,
-        credentials: 'include',
-        body: JSON.stringify(body),
+      // Go through the shared API client (via the entity hook) so the request
+      // carries the X-Authorization mirror (#118); a raw fetch drops it and the
+      // export 401s behind the shared-hosting proxy that strips Authorization.
+      const { blob, filename } = await exportMutation.mutateAsync({
+        format,
+        include_voided: includeVoided,
+        transaction_date_from: dateFrom,
+        transaction_date_to: dateTo,
+        counterparty_name: counterparty,
       });
 
-      if (!response.ok) {
-        setExportError(t('common.status.error'));
-        return;
-      }
-
-      const blob = await response.blob();
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;
-      const cd = response.headers.get('Content-Disposition') ?? '';
-      const match = /filename="?([^"]+)"?/.exec(cd);
-      a.download = match?.[1] ?? 'export.zip';
+      a.download = filename ?? (format === 'csv' ? 'export.csv' : 'export.zip');
       document.body.appendChild(a);
       a.click();
       document.body.removeChild(a);

--- a/frontend/src/shared/api/client.test.ts
+++ b/frontend/src/shared/api/client.test.ts
@@ -1,0 +1,63 @@
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+import { server } from '@tests/msw/server';
+import { problemDetails } from '@tests/msw/fixtures';
+import { authStore } from '@/entities/auth';
+import { apiClient } from './client';
+
+function signIn(): void {
+  authStore.setSession({
+    token: 'test-jwt-token',
+    userId: 1,
+    email: 'admin@example.com',
+    role: 'admin',
+    orgId: 1,
+  });
+}
+
+describe('apiClient.postBlob', () => {
+  it('sends both Authorization and the X-Authorization mirror (#118)', async () => {
+    signIn();
+
+    let authHeader: string | null = null;
+    let mirrorHeader: string | null = null;
+    server.use(
+      http.post('/admin/vault/export', ({ request }) => {
+        authHeader = request.headers.get('Authorization');
+        mirrorHeader = request.headers.get('X-Authorization');
+        return new HttpResponse('col1,col2\n', {
+          status: 200,
+          headers: {
+            'Content-Type': 'text/csv',
+            'Content-Disposition': 'attachment; filename="vault-export.csv"',
+          },
+        });
+      }),
+    );
+
+    const { blob, filename } = await apiClient.postBlob('/admin/vault/export', { format: 'csv' });
+
+    expect(authHeader).toBe('Bearer test-jwt-token');
+    // The proxy-stripping workaround: the mirror must be present so exports keep
+    // working behind the shared-hosting front proxy that strips Authorization.
+    expect(mirrorHeader).toBe('Bearer test-jwt-token');
+    expect(filename).toBe('vault-export.csv');
+    expect(await blob.text()).toBe('col1,col2\n');
+  });
+
+  it('rejects with an AppError carrying the status on an auth failure', async () => {
+    signIn();
+    server.use(
+      http.post('/admin/vault/export', () =>
+        HttpResponse.json(problemDetails('unauthorized', 401, 'Unauthorized'), {
+          status: 401,
+          headers: { 'Content-Type': 'application/problem+json' },
+        }),
+      ),
+    );
+
+    await expect(apiClient.postBlob('/admin/vault/export', {})).rejects.toMatchObject({
+      status: 401,
+    });
+  });
+});

--- a/frontend/src/shared/api/client.ts
+++ b/frontend/src/shared/api/client.ts
@@ -65,6 +65,73 @@ async function request<T>(path: string, options: RequestOptions = {}): Promise<T
   return (await response.json()) as T;
 }
 
+export interface BlobDownload {
+  blob: Blob;
+  /** Server-suggested filename from Content-Disposition, when present. */
+  filename: string | null;
+}
+
+function parseContentDispositionFilename(header: string | null): string | null {
+  if (header === null) {
+    return null;
+  }
+  const match = /filename\*?=(?:UTF-8'')?"?([^";]+)"?/i.exec(header);
+  if (match?.[1] === undefined) {
+    return null;
+  }
+  try {
+    return decodeURIComponent(match[1]);
+  } catch {
+    return match[1];
+  }
+}
+
+/**
+ * Authenticated binary download. Goes through the same header contract as
+ * request()/uploadFormData() — crucially the X-Authorization mirror (#118) —
+ * so downloads keep working behind the shared-hosting proxy that strips the
+ * standard Authorization header. Pages must not hand-roll fetch() for this.
+ */
+async function requestBlob(path: string, options: RequestOptions = {}): Promise<BlobDownload> {
+  const base = env.apiBaseUrl.replace(/\/$/, '');
+  const url = `${base}${path}`;
+  const headers: Record<string, string> = {};
+
+  if (options.body !== undefined) {
+    headers['Content-Type'] = 'application/json';
+  }
+  const token = authStore.getToken();
+  if (token !== null) {
+    headers['Authorization'] = `Bearer ${token}`;
+    // Shared-hosting front proxies (HETEML) strip the standard Authorization
+    // header; the backend adopts this mirror when it is absent (#118).
+    headers['X-Authorization'] = `Bearer ${token}`;
+  }
+
+  const init: RequestInit = {
+    method: options.method ?? 'GET',
+    headers,
+    credentials: 'include',
+  };
+  if (options.body !== undefined) {
+    init.body = JSON.stringify(options.body);
+  }
+  if (options.signal !== undefined) {
+    init.signal = options.signal;
+  }
+
+  const response = await fetch(url, init);
+
+  if (!response.ok) {
+    handleAuthError(response, path);
+    throw await parseProblemDetails(response);
+  }
+
+  const blob = await response.blob();
+  const filename = parseContentDispositionFilename(response.headers.get('Content-Disposition'));
+  return { blob, filename };
+}
+
 async function uploadFormData<T>(path: string, formData: FormData): Promise<T> {
   const base = env.apiBaseUrl.replace(/\/$/, '');
   const url = `${base}${path}`;
@@ -108,5 +175,8 @@ export const apiClient = {
   },
   upload<T>(path: string, formData: FormData): Promise<T> {
     return uploadFormData<T>(path, formData);
+  },
+  postBlob(path: string, body?: unknown): Promise<BlobDownload> {
+    return requestBlob(path, { method: 'POST', body });
   },
 };


### PR DESCRIPTION
## What

Export (ZIP / CSV) returned `401` behind the shared-hosting front proxy. `ExportPage` hand-rolled its own `fetch()` and set only the `Authorization` header, which the proxy strips. The shared API client already mirrors the token into `X-Authorization` (#118), but Export bypassed the client entirely and never sent the mirror.

## Changes

- `shared/api/client`: add `postBlob` — an authenticated binary download that sends both `Authorization` and the `X-Authorization` mirror, matching `request()` / `uploadFormData()`, and parses the `Content-Disposition` filename.
- `entities/document/export`: `useExportDocuments` hook (the network call lives in the entity layer, per the import-zone rules); `ExportPage` now owns only the browser-download side-effect from the returned blob.
- **Permanent regression guard:** an ESLint `no-restricted-syntax` rule forbids calling `fetch()` anywhere except `shared/api/client.ts`, so no page/feature can silently bypass the shared client and drop the auth-header mirror again. This covers the whole class of bug (both the export miss here and any future one).
- Tests: `postBlob` sends both headers and raises `AppError` on 401; `useExportDocuments` posts the correct body (omitting empty filters) and returns the blob + filename.

## Verification

- `npm run check` green (type-check, lint incl. the new fetch ban, prettier, 201 tests, knip, storybook build).
- **Post-deploy re-check required:** the 401 only reproduces behind the hosting proxy that strips `Authorization`, so this must be re-verified with a real browser after deployment.

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)