### PR TITLE
fix(settings): show the retention warning live while typing (#175)

### DIFF
--- a/frontend/src/pages/SettingsPage.test.tsx
+++ b/frontend/src/pages/SettingsPage.test.tsx
@@ -1,0 +1,31 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import { renderWithProviders } from '@tests/render/render-with-providers';
+import { SettingsPage } from './SettingsPage';
+
+describe('SettingsPage retention warning', () => {
+  it('shows the under-10-years warning live while typing, before any save (#175)', async () => {
+    renderWithProviders(
+      <MemoryRouter>
+        <SettingsPage />
+      </MemoryRouter>,
+    );
+
+    // Settings load with retention_years = 10 → no warning yet.
+    const input = await screen.findByRole('spinbutton');
+    await waitFor(() => {
+      expect(input).toHaveValue(10);
+    });
+    expect(input).not.toHaveClass('input-warn');
+
+    // Typing a value below 10 must flag the field immediately — no save required.
+    await userEvent.clear(input);
+    await userEvent.type(input, '8');
+
+    await waitFor(() => {
+      expect(input).toHaveClass('input-warn');
+    });
+  });
+});

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -109,7 +109,10 @@ export function SettingsPage() {
               min={7}
               max={99}
               className={retentionWarn ? 'input-warn' : ''}
-              {...register('retention_years')}
+              // valueAsNumber so the watched value is numeric *while typing* — the
+              // under-10-years compliance warning must render live, not only after
+              // save → re-fetch coerces the value server-side.
+              {...register('retention_years', { valueAsNumber: true })}
             />
             {retentionWarn && (
               <Callout tone="warn">{t('vault_settings.fields.retention_warning')}</Callout>


### PR DESCRIPTION
## What

The retention settings **under-10-years** compliance warning appeared only after saving and re-fetching, not while the operator typed a value below 10.

## Root cause

`register('retention_years')` had no `valueAsNumber`, so while typing the watched value is a **string**; `retentionWarn = typeof retentionYears === 'number' && retentionYears < 10` is therefore always false during input. `z.coerce.number()` applies only on submit, so the numeric value (and the warning) surfaced only after save → `reset()`.

## Change

- Register the field with `{ valueAsNumber: true }` so the watched value is numeric during input and the warning renders live.
- Regression test: entering `8` flags the field (`input-warn`) without saving.

## Verification

- `npm run check` green (type-check, lint, prettier, 199 tests, knip, storybook build).

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)