### PR TITLE
fix(document): authenticated download keyed by the version ULID (#179)

### DIFF
--- a/frontend/src/entities/document/file.test.ts
+++ b/frontend/src/entities/document/file.test.ts
@@ -1,0 +1,55 @@
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+import { server } from '@tests/msw/server';
+import { authStore } from '@/entities/auth';
+import { fetchDocumentBlob } from './file';
+
+describe('fetchDocumentBlob', () => {
+  it('requests the version-ULID-keyed path with both auth headers (#179)', async () => {
+    authStore.setSession({
+      token: 'test-jwt-token',
+      userId: 1,
+      email: 'admin@example.com',
+      role: 'admin',
+      orgId: 1,
+    });
+
+    let seenVersionId: string | undefined;
+    let authHeader: string | null = null;
+    let mirrorHeader: string | null = null;
+    server.use(
+      http.get('/admin/vault/documents/:id/versions/:versionId/download', ({ params, request }) => {
+        seenVersionId = params['versionId'] as string;
+        authHeader = request.headers.get('Authorization');
+        mirrorHeader = request.headers.get('X-Authorization');
+        return new HttpResponse('pdf-bytes', {
+          status: 200,
+          headers: { 'Content-Type': 'application/pdf' },
+        });
+      }),
+    );
+
+    const blob = await fetchDocumentBlob('doc-1', 'ver-01J0000000000000000000001');
+
+    // The route is keyed by the version ULID — not the ordinal version_number.
+    expect(seenVersionId).toBe('ver-01J0000000000000000000001');
+    // A plain <a href> sends neither header; the shared client must send both
+    // (X-Authorization is the shared-hosting proxy mirror, #118).
+    expect(authHeader).toBe('Bearer test-jwt-token');
+    expect(mirrorHeader).toBe('Bearer test-jwt-token');
+    expect(await blob.text()).toBe('pdf-bytes');
+  });
+
+  it('rejects with the response status when unauthenticated', async () => {
+    server.use(
+      http.get('/admin/vault/documents/:id/versions/:versionId/download', () =>
+        HttpResponse.json(
+          { type: 'about:blank/unauthorized', title: 'Unauthorized', status: 401 },
+          { status: 401, headers: { 'Content-Type': 'application/problem+json' } },
+        ),
+      ),
+    );
+
+    await expect(fetchDocumentBlob('doc-1', 'ver-x')).rejects.toMatchObject({ status: 401 });
+  });
+});

--- a/frontend/src/entities/document/file.ts
+++ b/frontend/src/entities/document/file.ts
@@ -1,0 +1,19 @@
+import { apiClient } from '@/shared/api/client';
+
+/**
+ * The download endpoint is keyed by the version's ULID (not its ordinal
+ * version_number) and is the single authenticated path to the file bytes —
+ * the storage path is never exposed (Hard rule).
+ *
+ * A plain <a href> link cannot be used for this: it sends no Authorization
+ * header, and the backend is JWT-only (no session cookie), so the bytes must
+ * be fetched through the shared API client and saved from an object URL (#179).
+ */
+function downloadPath(documentId: string, versionId: string): string {
+  return `/admin/vault/documents/${documentId}/versions/${versionId}/download`;
+}
+
+/** Authenticated fetch of the raw file bytes (bearer token via the api client). */
+export function fetchDocumentBlob(documentId: string, versionId: string): Promise<Blob> {
+  return apiClient.getBlob(downloadPath(documentId, versionId));
+}

--- a/frontend/src/entities/document/index.ts
+++ b/frontend/src/entities/document/index.ts
@@ -18,3 +18,4 @@ export { useOcrSuggest } from './ocr';
 export type { OcrPrefill } from './ocr';
 export { useExportDocuments } from './export';
 export type { ExportDocumentsInput, ExportFormat } from './export';
+export { fetchDocumentBlob } from './file';

--- a/frontend/src/pages/DocumentDetailPage.test.tsx
+++ b/frontend/src/pages/DocumentDetailPage.test.tsx
@@ -1,0 +1,66 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '@tests/render/render-with-providers';
+import { DOCUMENT_ID } from '@tests/msw/fixtures';
+import { server } from '@tests/msw/server';
+import { authStore } from '@/entities/auth';
+import { DocumentDetailPage } from './DocumentDetailPage';
+
+// jsdom does not implement object URLs; the download handler needs them.
+// Add just the two methods — replacing the URL global would break fetch/MSW.
+URL.createObjectURL = vi.fn(() => 'blob:mock');
+URL.revokeObjectURL = vi.fn();
+
+describe('DocumentDetailPage download', () => {
+  it('downloads through the authenticated client using the version ULID (#179)', async () => {
+    authStore.setSession({
+      token: 'test-jwt-token',
+      userId: 1,
+      email: 'admin@example.com',
+      role: 'admin',
+      orgId: 1,
+    });
+
+    let seenVersionId: string | undefined;
+    let mirrorHeader: string | null = null;
+    server.use(
+      http.get('/admin/vault/documents/:id/versions/:versionId/download', ({ params, request }) => {
+        seenVersionId = params['versionId'] as string;
+        mirrorHeader = request.headers.get('X-Authorization');
+        return new HttpResponse('pdf-bytes', {
+          status: 200,
+          headers: { 'Content-Type': 'application/pdf' },
+        });
+      }),
+    );
+
+    renderWithProviders(
+      <MemoryRouter initialEntries={[`/documents/${DOCUMENT_ID}`]}>
+        <Routes>
+          <Route path="/documents/:id" element={<DocumentDetailPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    // The button stays disabled until the history response resolves the
+    // current version's ULID (the detail payload only has the ordinal number).
+    const button = await screen.findByRole('button', { name: 'Download' });
+    await waitFor(() => {
+      expect(button).toBeEnabled();
+    });
+
+    await userEvent.click(button);
+
+    await waitFor(() => {
+      // Version ULID from the history response — not the ordinal '1' the old
+      // <a href> used (which 404'd even with credentials).
+      expect(seenVersionId).toBe('ver-01J0000000000000000000001');
+    });
+    // The request went through the shared client (a plain link sends no
+    // headers): the shared-hosting proxy mirror (#118) must be present.
+    expect(mirrorHeader).toBe('Bearer test-jwt-token');
+  });
+});

--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { useDocumentById, useOcrSuggest } from '@/entities/document';
+import { useDocumentById, fetchDocumentBlob, useOcrSuggest } from '@/entities/document';
 import { useDocumentHistory } from '@/entities/audit';
 import { authStore } from '@/entities/auth';
 import {
@@ -13,7 +13,6 @@ import type { OcrPrefill } from '@/features/document-detail';
 import { useTranslation } from '@/shared/i18n/use-translation';
 import { formatJpy, formatDate, formatDateTime } from '@/shared/lib/format';
 import { AppShell, Button, Callout, EmptyState } from '@/shared/ui';
-import { env } from '@/shared/config/env';
 
 type Modal = 'void' | 'restore' | 'metadata-edit' | null;
 
@@ -30,6 +29,14 @@ export function DocumentDetailPage() {
   const { data: doc, isLoading, isError } = useDocumentById(docId);
   const { data: history } = useDocumentHistory(docId);
 
+  // The download endpoint is keyed by the version's ULID, which only the
+  // history response carries — the document detail exposes just the ordinal
+  // version_number (#179).
+  const currentVersion =
+    doc !== undefined
+      ? history?.versions.find((v) => v.version_number === doc.version_number)
+      : undefined;
+
   function handleLogout() {
     authStore.clearSession();
     void navigate('/login', { replace: true });
@@ -44,16 +51,20 @@ export function DocumentDetailPage() {
     setModal('metadata-edit');
   }
 
-  function handleDownload() {
-    if (doc === undefined) return;
-    const base = env.apiBaseUrl.replace(/\/$/, '');
-    const url = `${base}/admin/vault/documents/${doc.id}/versions/${String(doc.version_number)}/download`;
+  async function handleDownload() {
+    if (doc === undefined || currentVersion === undefined) return;
+    // Fetch through the authenticated client: a plain <a href> would drop the
+    // bearer token (the backend is JWT-only, no session cookie), and the route
+    // is keyed by the version ULID, not the ordinal version_number (#179).
+    const blob = await fetchDocumentBlob(doc.id, currentVersion.id);
+    const objectUrl = URL.createObjectURL(blob);
     const a = document.createElement('a');
-    a.href = url;
+    a.href = objectUrl;
     a.download = doc.original_filename ?? `document-${doc.id}`;
     document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);
+    URL.revokeObjectURL(objectUrl);
   }
 
   return (
@@ -102,7 +113,13 @@ export function DocumentDetailPage() {
             </div>
 
             <div className="row gap-sm wrap">
-              <Button variant="secondary" onClick={handleDownload}>
+              <Button
+                variant="secondary"
+                onClick={() => {
+                  void handleDownload();
+                }}
+                disabled={currentVersion === undefined}
+              >
                 {t('document.detail.download_button')}
               </Button>
               <Button

--- a/frontend/src/shared/api/client.ts
+++ b/frontend/src/shared/api/client.ts
@@ -179,4 +179,8 @@ export const apiClient = {
   postBlob(path: string, body?: unknown): Promise<BlobDownload> {
     return requestBlob(path, { method: 'POST', body });
   },
+  async getBlob(path: string, signal?: AbortSignal): Promise<Blob> {
+    const { blob } = await requestBlob(path, { method: 'GET', signal });
+    return blob;
+  },
 };


### PR DESCRIPTION
## What

The detail page's **Download** button failed for every role (confirmed in a real-browser walkthrough of the deployed demo, admin and viewer alike). Two defects in the same handler:

1. It built a plain `<a href>` and clicked it — no `Authorization` header, and the backend is JWT-only (no session cookie), so the request could never authenticate, on any hosting environment.
2. It keyed the URL with the ordinal `version_number`, but the route expects the **version's ULID** (`/admin/vault/documents/{id}/versions/{versionId}/download`), so even an authenticated request would 404.

## Changes

- `shared/api/client`: `getBlob` — authenticated GET returning the raw blob (delegates to the same path as `postBlob`, so it carries `Authorization` + the `X-Authorization` mirror, #118).
- `entities/document/file`: `fetchDocumentBlob(documentId, versionId)` — the sanctioned entity-layer path to the file bytes.
- `pages/DocumentDetailPage`: resolve the current version's ULID from the history response (the detail payload only carries the ordinal number), fetch through the client, save via an object URL; the button stays disabled until the version id is known.

## Provenance

This is the bug-fix subset **extracted from the pending inline-preview PR #98**, which first implemented the same fix bundled with the preview feature. Landing it separately unblocks the production bug without waiting on the feature review; #98 can rebase down to the preview-only surface.

## Tests

- Entity level: `fetchDocumentBlob` targets the ULID-keyed path and sends both auth headers; surfaces `AppError` on 401.
- Page level: clicking Download issues a request keyed by the version ULID from the history response (not the ordinal `1`) with the auth mirror present.

## Verification

- `npm run check` green (type-check, lint, prettier, 208 tests, knip, storybook build).
- Real-browser re-check on the deployed environment after the next deploy (arranged separately, together with the export re-check).

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)