### PR TITLE
fix(ui): gate rail nav by role capability + Forbidden escape hatch (#174)

### DIFF
--- a/frontend/src/pages/ForbiddenPage.test.tsx
+++ b/frontend/src/pages/ForbiddenPage.test.tsx
@@ -1,13 +1,35 @@
 import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import { describe, expect, it } from 'vitest';
 import { renderWithProviders } from '@tests/render/render-with-providers';
 import { ForbiddenPage } from './ForbiddenPage';
 
 describe('ForbiddenPage', () => {
   it('renders a forbidden message', () => {
-    renderWithProviders(<ForbiddenPage />);
+    renderWithProviders(
+      <MemoryRouter initialEntries={['/forbidden']}>
+        <ForbiddenPage />
+      </MemoryRouter>,
+    );
     // The page renders the problem.forbidden locale key text
     const el = screen.getByText(/permission/i);
     expect(el).toBeInTheDocument();
+  });
+
+  it('offers a way home so the page is not a dead-end (#174)', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <MemoryRouter initialEntries={['/forbidden']}>
+        <Routes>
+          <Route path="/forbidden" element={<ForbiddenPage />} />
+          <Route path="/" element={<div>home-landing</div>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await user.click(screen.getByRole('button', { name: /home/i }));
+
+    expect(screen.getByText('home-landing')).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/ForbiddenPage.tsx
+++ b/frontend/src/pages/ForbiddenPage.tsx
@@ -1,8 +1,10 @@
+import { useNavigate } from 'react-router-dom';
 import { useTranslation } from '@/shared/i18n/use-translation';
-import { BrandMark } from '@/shared/ui';
+import { BrandMark, Button } from '@/shared/ui';
 
 export function ForbiddenPage() {
   const { t } = useTranslation();
+  const navigate = useNavigate();
   return (
     <div className="center">
       <div className="center-card">
@@ -11,8 +13,17 @@ export function ForbiddenPage() {
             <BrandMark size={40} className="text-seal" title="NeNe Vault" />
           </div>
         </div>
-        <div className="body text-center">
+        <div className="body text-center stack-md">
           <p className="danger">{t('problem.forbidden')}</p>
+          {/* Escape hatch so a forbidden route is never a dead-end (#174). */}
+          <Button
+            variant="secondary"
+            onClick={() => {
+              void navigate('/');
+            }}
+          >
+            {t('navigation.back_home')}
+          </Button>
         </div>
       </div>
     </div>

--- a/frontend/src/shared/auth/capabilities.test.ts
+++ b/frontend/src/shared/auth/capabilities.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { roleHasCapability, type Capability } from './capabilities';
+
+// This table MUST match backend `NeneVault\Auth\Role::hasCapability`
+// (src/Auth/Role.php). If the backend changes, update both together.
+const ALL: Capability[] = [
+  'ManageOrganizations',
+  'ManageUsers',
+  'ManageVaultSettings',
+  'UploadDocument',
+  'EditMetadata',
+  'VoidDocument',
+  'ViewDocuments',
+  'ExportDocuments',
+];
+
+describe('roleHasCapability (mirror of backend Role::hasCapability)', () => {
+  it('superadmin has every capability', () => {
+    for (const cap of ALL) {
+      expect(roleHasCapability('superadmin', cap)).toBe(true);
+    }
+  });
+
+  it('admin has everything except ManageOrganizations', () => {
+    for (const cap of ALL) {
+      expect(roleHasCapability('admin', cap)).toBe(cap !== 'ManageOrganizations');
+    }
+  });
+
+  it('member may upload / edit / view only', () => {
+    const allowed = new Set<Capability>(['UploadDocument', 'EditMetadata', 'ViewDocuments']);
+    for (const cap of ALL) {
+      expect(roleHasCapability('member', cap)).toBe(allowed.has(cap));
+    }
+  });
+
+  it('viewer may view documents only', () => {
+    for (const cap of ALL) {
+      expect(roleHasCapability('viewer', cap)).toBe(cap === 'ViewDocuments');
+    }
+  });
+
+  it('fails closed for an unknown or missing role', () => {
+    for (const cap of ALL) {
+      expect(roleHasCapability(undefined, cap)).toBe(false);
+      expect(roleHasCapability('', cap)).toBe(false);
+      expect(roleHasCapability('robot', cap)).toBe(false);
+    }
+  });
+
+  it('viewer and member cannot reach the admin-only rail routes (#174)', () => {
+    // Rail gating: audit + settings require ManageVaultSettings, users require
+    // ManageUsers, export requires ExportDocuments.
+    for (const role of ['viewer', 'member'] as const) {
+      expect(roleHasCapability(role, 'ManageVaultSettings')).toBe(false);
+      expect(roleHasCapability(role, 'ManageUsers')).toBe(false);
+      expect(roleHasCapability(role, 'ExportDocuments')).toBe(false);
+    }
+    // ...but admin sees all of them.
+    expect(roleHasCapability('admin', 'ManageVaultSettings')).toBe(true);
+    expect(roleHasCapability('admin', 'ManageUsers')).toBe(true);
+    expect(roleHasCapability('admin', 'ExportDocuments')).toBe(true);
+  });
+});

--- a/frontend/src/shared/auth/capabilities.ts
+++ b/frontend/src/shared/auth/capabilities.ts
@@ -1,0 +1,42 @@
+/**
+ * Capabilities, mirroring the backend `NeneVault\Auth\Capability` enum.
+ * Keep in sync with `src/Auth/Capability.php`.
+ */
+export type Capability =
+  | 'ManageOrganizations'
+  | 'ManageUsers'
+  | 'ManageVaultSettings'
+  | 'UploadDocument'
+  | 'EditMetadata'
+  | 'VoidDocument'
+  | 'ViewDocuments'
+  | 'ExportDocuments';
+
+/**
+ * Frontend mirror of `NeneVault\Auth\Role::hasCapability` (`src/Auth/Role.php`).
+ * This is a UX convenience only — the server remains the authority (a viewer who
+ * hand-types an admin URL still gets a correct 403). Keeping the table identical
+ * to the backend is what lets the rail hide exactly the routes a role cannot use
+ * (#174), so admin-only links never dead-end a viewer on the Forbidden page.
+ *
+ * Takes the raw role string from the session claim; an unknown/missing role is
+ * treated as having no capabilities (fail-closed).
+ */
+export function roleHasCapability(role: string | undefined, capability: Capability): boolean {
+  switch (role) {
+    case 'superadmin':
+      return true;
+    case 'admin':
+      return capability !== 'ManageOrganizations';
+    case 'member':
+      return (
+        capability === 'UploadDocument' ||
+        capability === 'EditMetadata' ||
+        capability === 'ViewDocuments'
+      );
+    case 'viewer':
+      return capability === 'ViewDocuments';
+    default:
+      return false;
+  }
+}

--- a/frontend/src/shared/ui/components/AppShell.tsx
+++ b/frontend/src/shared/ui/components/AppShell.tsx
@@ -2,6 +2,7 @@ import { dynamicMessageKey, type MessageKey } from '@/shared/i18n/catalogs';
 import type { ReactNode } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useTranslation } from '@/shared/i18n/use-translation';
+import { roleHasCapability, type Capability } from '@/shared/auth/capabilities';
 import { BrandMark } from '@/shared/ui/primitives/BrandMark';
 import { LanguageSwitcher } from './LanguageSwitcher';
 
@@ -11,6 +12,13 @@ interface NavItem {
   icon: ReactNode;
   /** Locale key for a group heading rendered above this item (new section). */
   groupKey?: MessageKey;
+  /**
+   * Capability the current role must hold for this route (mirrors the backend
+   * CapabilityResolver). Omitted for routes open to every authenticated role
+   * (e.g. Home). Items the role cannot use are hidden so they never dead-end a
+   * viewer on the Forbidden page (#174).
+   */
+  requiredCapability?: Capability;
 }
 
 const HomeIcon = (
@@ -123,17 +131,39 @@ export function AppShell({
       labelKey: 'document.list.title',
       icon: DocIcon,
       groupKey: 'navigation.documents',
+      requiredCapability: 'ViewDocuments',
     },
     {
       to: '/audit',
       labelKey: 'navigation.audit_events',
       icon: AuditIcon,
       groupKey: 'navigation.group_admin',
+      requiredCapability: 'ManageVaultSettings',
     },
-    { to: '/settings', labelKey: 'navigation.settings', icon: SettingsIcon },
-    { to: '/users', labelKey: 'navigation.users', icon: UsersIcon },
-    { to: '/export', labelKey: 'navigation.export', icon: ExportIcon },
+    {
+      to: '/settings',
+      labelKey: 'navigation.settings',
+      icon: SettingsIcon,
+      requiredCapability: 'ManageVaultSettings',
+    },
+    {
+      to: '/users',
+      labelKey: 'navigation.users',
+      icon: UsersIcon,
+      requiredCapability: 'ManageUsers',
+    },
+    {
+      to: '/export',
+      labelKey: 'navigation.export',
+      icon: ExportIcon,
+      requiredCapability: 'ExportDocuments',
+    },
   ];
+
+  const visibleNav = nav.filter(
+    (item) =>
+      item.requiredCapability === undefined || roleHasCapability(userRole, item.requiredCapability),
+  );
 
   const isActive = (to: string): boolean =>
     to === '/' ? pathname === '/' : pathname.startsWith(to);
@@ -163,7 +193,7 @@ export function AppShell({
         </div>
 
         <nav className="rail-nav" aria-label={t('navigation.menu')}>
-          {nav.map((item) => (
+          {visibleNav.map((item) => (
             <div key={item.to} className="contents">
               {item.groupKey !== undefined && <div className="rail-group">{t(item.groupKey)}</div>}
               <button

--- a/locales/en.json
+++ b/locales/en.json
@@ -98,7 +98,8 @@
     "language": "Language",
     "group_admin": "Administration",
     "menu": "Menu",
-    "breadcrumb": "Breadcrumb"
+    "breadcrumb": "Breadcrumb",
+    "back_home": "Back to Home"
   },
   "home": {
     "eyebrow": "Overview",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -101,7 +101,8 @@
     "language": "言語切替",
     "group_admin": "管理・運用",
     "menu": "メニュー",
-    "breadcrumb": "パンくずリスト"
+    "breadcrumb": "パンくずリスト",
+    "back_home": "ホームに戻る"
   },
 
   "home": {


### PR DESCRIPTION
Closes #174.

A viewer/member saw admin-only rail items (audit log, users, settings, export). Clicking one returned a correct server 403 but hard-navigated to a standalone `ForbiddenPage` with **no way back** — a dead end.

**Fix (frontend only; server authorization unchanged — still the authority):**
- `shared/auth/capabilities.ts` — frontend mirror of backend `Role::hasCapability` (`src/Auth/Role.php`) + matrix test. In `shared` so `AppShell` uses it without crossing FSD layers.
- `AppShell` hides rail items the role lacks capability for (matches backend `CapabilityResolver`): viewer/member now see **Home + Received Documents** only; audit/settings/users/export are admin+.
- `ForbiddenPage` gains a **back-home** button (+`navigation.back_home` ja/en) so a 403 is never a dead end — defense in depth for direct-URL hits.

Chose 施主 option **C (both)**: gate the nav *and* make Forbidden recoverable.

Surfaced by the 2026-07-11 vault demo browser walkthrough (guided/viewer seat).
`npm run check` green (tsc/eslint/prettier/215 tests/knip/storybook); `composer locales` consistent.