### PR TITLE
fix(ui): role-gate HomePage quick-access cards (#182, follow-up to #174)

### DIFF
--- a/frontend/src/pages/HomePage.test.tsx
+++ b/frontend/src/pages/HomePage.test.tsx
@@ -1,0 +1,46 @@
+import { screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, describe, expect, it } from 'vitest';
+import { authStore } from '@/entities/auth';
+import { renderWithProviders } from '@tests/render/render-with-providers';
+import { HomePage } from './HomePage';
+
+const baseSession = {
+  token: 'test-jwt',
+  userId: 1,
+  email: 'user@example.com',
+  orgId: 1,
+};
+
+afterEach(() => {
+  sessionStorage.clear();
+});
+
+function renderHome() {
+  return renderWithProviders(
+    <MemoryRouter initialEntries={['/']}>
+      <HomePage />
+    </MemoryRouter>,
+  );
+}
+
+describe('HomePage quick-access cards (#182 — role-gated like the rail)', () => {
+  it('shows a viewer only the documents card, not admin-only actions', () => {
+    authStore.setSession({ ...baseSession, role: 'viewer' });
+    const { container } = renderHome();
+
+    // Quick-access cards use the `.qlink` class (distinct from `.rail-link`).
+    expect(container.querySelectorAll('.qlink')).toHaveLength(1);
+    // Admin-only card labels appear nowhere on a viewer's home (rail is gated too).
+    expect(screen.queryByText('監査ログ')).toBeNull();
+    expect(screen.queryByText('保管設定')).toBeNull();
+    expect(screen.queryByText('エクスポート')).toBeNull();
+  });
+
+  it('shows an admin all four quick-access cards', () => {
+    authStore.setSession({ ...baseSession, role: 'admin' });
+    const { container } = renderHome();
+
+    expect(container.querySelectorAll('.qlink')).toHaveLength(4);
+  });
+});

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { authStore } from '@/entities/auth';
 import { useTranslation } from '@/shared/i18n/use-translation';
 import type { MessageKey } from '@/shared/i18n/catalogs';
+import { roleHasCapability, type Capability } from '@/shared/auth/capabilities';
 import { AppShell } from '@/shared/ui';
 
 interface QuickLink {
@@ -10,6 +11,13 @@ interface QuickLink {
   titleKey: MessageKey;
   subKey: MessageKey;
   icon: ReactNode;
+  /**
+   * Capability the current role must hold to reach this route (mirrors the rail
+   * gating in AppShell and the backend CapabilityResolver). Cards the role
+   * cannot use are hidden so a viewer's home never offers admin-only actions
+   * (#182, follow-up to #174).
+   */
+  requiredCapability: Capability;
 }
 
 const DocIcon = (
@@ -68,21 +76,39 @@ const LINKS: QuickLink[] = [
     titleKey: 'document.list.title',
     subKey: 'home.link_documents',
     icon: DocIcon,
+    requiredCapability: 'ViewDocuments',
   },
-  { to: '/audit', titleKey: 'navigation.audit_events', subKey: 'home.link_audit', icon: AuditIcon },
+  {
+    to: '/audit',
+    titleKey: 'navigation.audit_events',
+    subKey: 'home.link_audit',
+    icon: AuditIcon,
+    requiredCapability: 'ManageVaultSettings',
+  },
   {
     to: '/settings',
     titleKey: 'navigation.settings',
     subKey: 'home.link_settings',
     icon: SettingsIcon,
+    requiredCapability: 'ManageVaultSettings',
   },
-  { to: '/export', titleKey: 'navigation.export', subKey: 'home.link_export', icon: ExportIcon },
+  {
+    to: '/export',
+    titleKey: 'navigation.export',
+    subKey: 'home.link_export',
+    icon: ExportIcon,
+    requiredCapability: 'ExportDocuments',
+  },
 ];
 
 export function HomePage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const session = authStore.getSession();
+
+  const visibleLinks = LINKS.filter((link) =>
+    roleHasCapability(session?.role, link.requiredCapability),
+  );
 
   function handleLogout() {
     authStore.clearSession();
@@ -103,7 +129,7 @@ export function HomePage() {
           <h2 className="subtitle">{t('home.quick_access')}</h2>
         </div>
         <div className="grid-2">
-          {LINKS.map((link) => (
+          {visibleLinks.map((link) => (
             <button
               key={link.to}
               type="button"


### PR DESCRIPTION
Closes #182. Follow-up to #174.

#174 gated the rail; the HomePage quick-access cards still showed audit/settings/export to viewer/member. Apply the same `roleHasCapability` filter to `LINKS` — a viewer's home now shows only the documents card. Frontend-only, server authorization unchanged.

`npm run check` green (tsc/eslint/prettier/217 tests/knip/storybook).