### PR TITLE
feat(demo): env-gated cookieless analytics — SPA-shell beacon + server-side entry log (#184)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -104,3 +104,13 @@ DEMO_MODE=
 # DEMO_TTL_HOURS=3
 # DEMO_MAX_ORGS=200
 # DEMO_SLUG_ATTEMPTS=5
+
+# --- Demo analytics (#184, cookieless) -------------------------------------------
+# Set ONLY on the public disposable-demo host. When set to a bare origin
+# (no trailing slash, no path), index.php injects a cookieless GoatCounter beacon
+# into the SPA shell and widens the shell's CSP for that origin; the server-side
+# demo-entry attribution log records referer + utm_* regardless. Unset (the
+# default, incl. every self-hosted/OSS install) → no beacon, no analytics CSP.
+# Never commit a real origin here — it lives only in the demo host's own .env.
+# 例: DEMO_ANALYTICS_ENDPOINT=https://stats.example.test
+DEMO_ANALYTICS_ENDPOINT=

--- a/public_html/.htaccess
+++ b/public_html/.htaccess
@@ -11,10 +11,10 @@ RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 RewriteCond %{REQUEST_FILENAME} -f
 RewriteRule ^ - [L]
 
-# API, health and demo-seat routes → PHP front controller (#127)
-RewriteRule ^(admin|health|demo) index.php [QSA,L]
-
-# All other routes → SPA index.html (if present) or PHP front controller
-RewriteCond %{DOCUMENT_ROOT}/index.html -f
-RewriteRule ^ index.html [L]
+# Everything else → PHP front controller: the JSON API, the health/demo-seat
+# routes (#127), AND the SPA HTML shell. The shell is served *through* index.php
+# (it used to be the static index.html) so the disposable-demo host can inject
+# the env-gated cookieless analytics beacon (#184). index.php serves the shell
+# before the router, so with DEMO_ANALYTICS_ENDPOINT unset the shell body is
+# byte-identical and carries no CSP — exactly what the static file did.
 RewriteRule ^ index.php [QSA,L]

--- a/public_html/index.php
+++ b/public_html/index.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Nene2\Http\ResponseEmitter;
 use NeneVault\Http\AuthorizationHeaderFallback;
 use NeneVault\Http\RuntimeContainerFactory;
+use NeneVault\Http\SpaShell;
 use NeneVault\Support\EnvFileLoader;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Nyholm\Psr7Server\ServerRequestCreator;
@@ -31,9 +32,40 @@ $request = $serverRequestCreator->fromGlobals();
 // Shared-hosting front proxies (HETEML) strip the Authorization header; adopt
 // the SPA's X-Authorization mirror when the standard header is absent (#118).
 $request = AuthorizationHeaderFallback::apply($request);
-$application = $container->get(RequestHandlerInterface::class);
-assert($application instanceof RequestHandlerInterface);
-$response = $application->handle($request);
+
+// SPA shell — served *before* the router so it bypasses the security-headers
+// middleware and stays byte-identical to the static file it replaced. A non-API
+// GET/HEAD returns the built admin shell (`public_html/index.html`), which also
+// serves SPA deep-links / F5. On the disposable-demo host — and only there —
+// DEMO_ANALYTICS_ENDPOINT is set, and the shell then carries the env-gated
+// cookieless analytics beacon plus a CSP widened for the analytics origin
+// (#184). Every other install leaves the env unset, so the shell body is
+// byte-identical and no CSP header is set. The origin literal lives only in the
+// demo host's `.env` — never in `.env.example` or the committed frontend.
+$response = null;
+$method = $request->getMethod();
+$path = $request->getUri()->getPath();
+$isApiPath = $path === '/admin' || str_starts_with($path, '/admin/')
+    || $path === '/health' || str_starts_with($path, '/health/')
+    || $path === '/demo' || str_starts_with($path, '/demo/');
+
+if (($method === 'GET' || $method === 'HEAD') && !$isApiPath) {
+    $analyticsEndpointRaw = $_ENV['DEMO_ANALYTICS_ENDPOINT'] ?? getenv('DEMO_ANALYTICS_ENDPOINT');
+    $analyticsEndpoint = is_string($analyticsEndpointRaw) && $analyticsEndpointRaw !== '' ? $analyticsEndpointRaw : null;
+
+    $response = (new SpaShell(
+        dirname(__DIR__) . '/public_html/index.html',
+        $psr17Factory,
+        $psr17Factory,
+        $analyticsEndpoint,
+    ))->serve();
+}
+
+if ($response === null) {
+    $application = $container->get(RequestHandlerInterface::class);
+    assert($application instanceof RequestHandlerInterface);
+    $response = $application->handle($request);
+}
 
 $emitter = $container->get(ResponseEmitter::class);
 assert($emitter instanceof ResponseEmitter);

--- a/src/Demo/DemoEntryLog.php
+++ b/src/Demo/DemoEntryLog.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Demo;
+
+use Closure;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Attribution layer 1 (#184): records one line per demo entry with the referer
+ * and UTM tags, at the last moment they exist.
+ *
+ * Both demo entrances land the visitor on the SPA at `/` via a client-side
+ * `location.replace('/')` (see {@see DemoSessionSeater}, {@see SeatFixedDemoHandler}):
+ * the query string with the UTM tags is dropped by that navigation and the
+ * next request is same-origin (a self Referer, no UTM). So the entry handler is
+ * the only place the channel/campaign can be captured server-side — the
+ * client-side beacon (#184 ②) only sees post-landing browsing.
+ *
+ * No PII: only the Referer, the `utm_*` tags and the disposable/guided slug are
+ * logged — never the client IP or any personal field. Values are sanitised
+ * (control chars stripped, length-capped) so a crafted Referer / query cannot
+ * forge log lines, and missing tags render as `-` so a UTM-less entry still
+ * logs cleanly instead of breaking the landing.
+ */
+final readonly class DemoEntryLog
+{
+    /** @var Closure(string): void Where entry log lines go; defaults to `error_log`. */
+    private Closure $sink;
+
+    /**
+     * @param (Closure(string): void)|null $sink Sink for the demo-entry line.
+     *        Defaults to PHP's `error_log`; overridable in tests so the recorded
+     *        line can be asserted without depending on the global `error_log` ini.
+     */
+    public function __construct(?Closure $sink = null)
+    {
+        $this->sink = $sink ?? static function (string $line): void {
+            error_log($line);
+        };
+    }
+
+    /**
+     * Emits one `error_log` line for a demo entry.
+     *
+     * @param string $slug the disposable org slug (`/demo/standard`) or a fixed
+     *                     label such as `guided` (`/demo/guided`)
+     */
+    public function record(ServerRequestInterface $request, string $slug): void
+    {
+        $query = $request->getQueryParams();
+
+        $fields = [
+            'slug' => $slug,
+            'utm_source' => $query['utm_source'] ?? null,
+            'utm_medium' => $query['utm_medium'] ?? null,
+            'utm_campaign' => $query['utm_campaign'] ?? null,
+            'referer' => $request->getHeaderLine('Referer'),
+        ];
+
+        $parts = [];
+
+        foreach ($fields as $key => $value) {
+            $parts[] = $key . '=' . self::sanitise(is_string($value) ? $value : null);
+        }
+
+        ($this->sink)('NeNe Vault: demo-entry ' . implode(' ', $parts));
+    }
+
+    /**
+     * Renders a log field value: `-` when absent/empty, otherwise the value with
+     * CR/LF and other control characters removed (log-injection defence) and
+     * capped at 256 chars so a long crafted URL can't bloat the log.
+     */
+    private static function sanitise(?string $value): string
+    {
+        if ($value === null || $value === '') {
+            return '-';
+        }
+
+        $clean = trim((string) preg_replace('/[\x00-\x1F\x7F]+/', ' ', $value));
+
+        if ($clean === '') {
+            return '-';
+        }
+
+        return mb_substr($clean, 0, 256);
+    }
+}

--- a/src/Demo/DemoSessionSeater.php
+++ b/src/Demo/DemoSessionSeater.php
@@ -39,17 +39,28 @@ use Psr\Http\Message\ServerRequestInterface;
  */
 final readonly class DemoSessionSeater implements DemoSessionSeaterInterface
 {
+    private DemoEntryLog $entryLog;
+
     public function __construct(
         private DemoConfig $config,
         private DemoProvisionRegistry $registry,
         private TokenIssuerInterface $tokenIssuer,
         private Psr17Factory $psr17,
         private ClockInterface $clock,
+        ?DemoEntryLog $entryLog = null,
     ) {
+        $this->entryLog = $entryLog ?? new DemoEntryLog();
     }
 
     public function seatAndRedirect(ServerRequestInterface $request, ProvisionedDemoOrg $org): ResponseInterface
     {
+        // Attribution layer 1 (#184): record channel/campaign here — the last
+        // moment they exist — because the client-side `location.replace('/')`
+        // below drops the query and the browser's next request to `/` is
+        // same-origin (no UTM, a self Referer). No PII: only Referer + utm_* +
+        // the disposable slug are logged; never the client IP.
+        $this->entryLog->record($request, $org->slug);
+
         $email = $this->registry->adminEmail($org->orgId) ?? DemoOrgProvisioner::adminEmail($org->slug);
         $now = $this->clock->now()->getTimestamp();
 

--- a/src/Demo/SeatFixedDemoHandler.php
+++ b/src/Demo/SeatFixedDemoHandler.php
@@ -45,13 +45,17 @@ final readonly class SeatFixedDemoHandler
 
     private const int TOKEN_TTL_SECONDS = LoginUseCase::TOKEN_TTL_SECONDS; // same TTL as a normal login (#148)
 
+    private DemoEntryLog $entryLog;
+
     public function __construct(
         private DemoConfig $config,
         private UserRepositoryInterface $users,
         private TokenIssuerInterface $tokenIssuer,
         private Psr17Factory $psr17,
         private ClockInterface $clock,
+        ?DemoEntryLog $entryLog = null,
     ) {
+        $this->entryLog = $entryLog ?? new DemoEntryLog();
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
@@ -69,6 +73,13 @@ final readonly class SeatFixedDemoHandler
         if ($viewer === null || $viewer->organizationId === null || Role::tryFrom($viewer->role) !== Role::Viewer) {
             return $this->notFound();
         }
+
+        // Attribution layer 1 (#184): record channel/campaign before the seat
+        // page's `location.replace('/')` drops the query. Logged under the
+        // fixed `guided` label (no disposable slug here). No PII — Referer +
+        // utm_* only. Placed after the fail-close gates so a probe on a
+        // non-demo instance logs nothing.
+        $this->entryLog->record($request, 'guided');
 
         $now = $this->clock->now()->getTimestamp();
         $token = $this->tokenIssuer->issue([

--- a/src/Http/SpaShell.php
+++ b/src/Http/SpaShell.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Http;
+
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+/**
+ * Serves the built admin SPA shell (`public_html/index.html`) for non-API GET
+ * requests, so the disposable-demo host can inject a cookieless analytics
+ * beacon into it — env-gated and OSS-clean.
+ *
+ * Vault ships the shell as a **static file**; on OSS/self-hosted installs
+ * `.htaccess` still hands `/` to this class only so the response is
+ * byte-for-byte the static shell (no injection, no CSP header — Apache's
+ * default applies unchanged). The shell is served *before* the router runs, so
+ * it never passes through the app's security-headers middleware: with analytics
+ * off the shell carries exactly the headers the static file did (none of its
+ * own CSP), preserving the current behaviour.
+ *
+ * ## Optional demo analytics (env-gated, OSS-clean)
+ *
+ * When — and only when — `$analyticsEndpoint` is a valid origin (wired from the
+ * `DEMO_ANALYTICS_ENDPOINT` env, set on the disposable-demo host alone), a
+ * cookieless GoatCounter beacon is injected just before `</head>`
+ * (`<script data-goatcounter="…/count" async src="…/count.js">`). Because that
+ * beacon loads a cross-origin script and posts to a cross-origin collector,
+ * this response then also carries its own `Content-Security-Policy` widening
+ * `script-src` / `connect-src` / `img-src` to the analytics origin.
+ *
+ * The CSP intentionally keeps the Google Fonts origins the shell already loads
+ * (`fonts.googleapis.com` stylesheet, `fonts.gstatic.com` fonts) — dropping
+ * them would break the shell's typography (the clear #277-era CSP trap). It is
+ * emitted *only* when analytics is enabled: with the env unset no CSP is set at
+ * all, so a self-hosted install is never given a policy it did not have before.
+ *
+ * The OSS release ships **no** analytics origin anywhere: the endpoint literal
+ * lives only in the demo host's `.env`, never in `.env.example`, the committed
+ * React source/build, or `.htaccess`.
+ */
+final readonly class SpaShell
+{
+    /**
+     * The Content-Security-Policy emitted only when demo analytics is on. It
+     * keeps the shell's cross-origin Google Fonts (style/font) and adds the
+     * analytics origin to script/connect/img. `%1$s` is the validated origin.
+     */
+    private const string ANALYTICS_CSP_TEMPLATE = "default-src 'self'; script-src 'self' %1\$s; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: %1\$s; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' %1\$s; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'";
+
+    /** Normalised analytics origin (e.g. `https://stats.example.test`), or null when disabled. */
+    private ?string $analyticsEndpoint;
+
+    public function __construct(
+        private string $shellPath,
+        private ResponseFactoryInterface $responseFactory,
+        private StreamFactoryInterface $streamFactory,
+        ?string $analyticsEndpoint = null,
+    ) {
+        $this->analyticsEndpoint = self::normaliseEndpoint($analyticsEndpoint);
+    }
+
+    /**
+     * Accepts an analytics endpoint only when it is a bare `http(s)://host[:port]`
+     * origin — no path, query, fragment, whitespace or control characters. Any
+     * trailing slash is trimmed. Anything else (including empty/unset) disables
+     * analytics (fail-safe), so a fat-fingered env can never inject markup or a
+     * malformed CSP / header. The value is operator-controlled (server `.env`),
+     * but validating it keeps header/attribute construction provably safe.
+     */
+    private static function normaliseEndpoint(?string $endpoint): ?string
+    {
+        if ($endpoint === null) {
+            return null;
+        }
+
+        $endpoint = rtrim(trim($endpoint), '/');
+
+        if ($endpoint === '' || preg_match('#^https?://[A-Za-z0-9.\-]+(:\d+)?$#', $endpoint) !== 1) {
+            return null;
+        }
+
+        return $endpoint;
+    }
+
+    /**
+     * Returns the shell response, or null when the built shell is absent (e.g. a
+     * backend-only checkout, or a dev instance whose frontend runs on Vite) so
+     * the caller can fall back to the API router.
+     *
+     * With analytics disabled the body is the shell file verbatim and no CSP
+     * header is set. With analytics enabled the beacon is injected and the
+     * widened CSP is attached.
+     */
+    public function serve(): ?ResponseInterface
+    {
+        if (!is_file($this->shellPath)) {
+            return null;
+        }
+
+        $html = file_get_contents($this->shellPath);
+
+        if ($html === false) {
+            return null;
+        }
+
+        $body = $this->analyticsEndpoint === null ? $html : $this->inject($html);
+
+        $response = $this->responseFactory->createResponse(200)
+            ->withHeader('Content-Type', 'text/html; charset=UTF-8')
+            ->withBody($this->streamFactory->createStream($body));
+
+        if ($this->analyticsEndpoint !== null) {
+            $response = $response->withHeader('Content-Security-Policy', $this->analyticsCsp());
+        }
+
+        return $response;
+    }
+
+    /**
+     * Inserts the beacon immediately before the closing `</head>` so it follows
+     * the font links. If the marker is absent (unexpected), the shell is served
+     * unchanged (fail-safe — never emit a mangled document).
+     */
+    private function inject(string $html): string
+    {
+        return str_replace('</head>', $this->analyticsTag() . "\n  </head>", $html);
+    }
+
+    /**
+     * The cookieless GoatCounter beacon. Both URLs derive from the single
+     * validated origin; the origin is escaped for the HTML attribute context
+     * (belt-and-suspenders — it is already validated to a bare origin).
+     */
+    private function analyticsTag(): string
+    {
+        $dataAttr = htmlspecialchars((string) $this->analyticsEndpoint . '/count', ENT_QUOTES);
+        $src = htmlspecialchars((string) $this->analyticsEndpoint . '/count.js', ENT_QUOTES);
+
+        return "  <script data-goatcounter=\"{$dataAttr}\" async src=\"{$src}\"></script>";
+    }
+
+    private function analyticsCsp(): string
+    {
+        return sprintf(self::ANALYTICS_CSP_TEMPLATE, $this->analyticsEndpoint);
+    }
+}

--- a/tests/Demo/DemoEntryLogTest.php
+++ b/tests/Demo/DemoEntryLogTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Tests\Demo;
+
+use NeneVault\Demo\DemoEntryLog;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class DemoEntryLogTest extends TestCase
+{
+    /** @var list<string> */
+    private array $lines = [];
+
+    private function log(): DemoEntryLog
+    {
+        return new DemoEntryLog(function (string $line): void {
+            $this->lines[] = $line;
+        });
+    }
+
+    /**
+     * @param array<string, string> $query
+     */
+    private function request(array $query = [], ?string $referer = null): ServerRequestInterface
+    {
+        $request = (new Psr17Factory())
+            ->createServerRequest('GET', 'https://vault.example.test/demo/standard')
+            ->withQueryParams($query);
+
+        if ($referer !== null) {
+            $request = $request->withHeader('Referer', $referer);
+        }
+
+        return $request;
+    }
+
+    public function test_records_slug_referer_and_utm_tags(): void
+    {
+        $this->log()->record(
+            $this->request([
+                'utm_source' => 'newsletter',
+                'utm_medium' => 'email',
+                'utm_campaign' => 'launch',
+            ], 'https://ref.example.test/post'),
+            'demo-abc123',
+        );
+
+        self::assertCount(1, $this->lines);
+        $line = $this->lines[0];
+        self::assertStringStartsWith('NeNe Vault: demo-entry ', $line);
+        self::assertStringContainsString('slug=demo-abc123', $line);
+        self::assertStringContainsString('utm_source=newsletter', $line);
+        self::assertStringContainsString('utm_medium=email', $line);
+        self::assertStringContainsString('utm_campaign=launch', $line);
+        self::assertStringContainsString('referer=https://ref.example.test/post', $line);
+    }
+
+    public function test_missing_tags_render_as_dash(): void
+    {
+        $this->log()->record($this->request(), 'guided');
+
+        self::assertSame(
+            'NeNe Vault: demo-entry slug=guided utm_source=- utm_medium=- utm_campaign=- referer=-',
+            $this->lines[0],
+        );
+    }
+
+    public function test_control_characters_are_stripped_to_prevent_log_injection(): void
+    {
+        $this->log()->record(
+            $this->request(['utm_source' => "evil\r\nNeNe Vault: demo-entry slug=forged"]),
+            'demo-x',
+        );
+
+        self::assertCount(1, $this->lines);
+        // The forged newline must not create a second logical line.
+        self::assertStringNotContainsString("\n", $this->lines[0]);
+        self::assertStringContainsString('utm_source=evil NeNe Vault: demo-entry slug=forged', $this->lines[0]);
+    }
+
+    public function test_non_string_query_value_renders_as_dash(): void
+    {
+        $request = (new Psr17Factory())
+            ->createServerRequest('GET', 'https://vault.example.test/demo/standard')
+            ->withQueryParams(['utm_source' => ['array', 'value']]);
+
+        $this->log()->record($request, 'demo-x');
+
+        self::assertStringContainsString('utm_source=-', $this->lines[0]);
+    }
+
+    public function test_long_value_is_capped(): void
+    {
+        $this->log()->record($this->request(['utm_campaign' => str_repeat('a', 500)]), 'demo-x');
+
+        self::assertStringContainsString('utm_campaign=' . str_repeat('a', 256) . ' ', $this->lines[0] . ' ');
+        self::assertStringNotContainsString(str_repeat('a', 257), $this->lines[0]);
+    }
+}

--- a/tests/Demo/DemoSessionSeaterTest.php
+++ b/tests/Demo/DemoSessionSeaterTest.php
@@ -7,12 +7,14 @@ namespace NeneVault\Tests\Demo;
 use Nene2\Auth\LocalBearerTokenVerifier;
 use Nene2\Demo\DemoConfig;
 use Nene2\Demo\ProvisionedDemoOrg;
+use NeneVault\Demo\DemoEntryLog;
 use NeneVault\Demo\DemoProvisionRegistry;
 use NeneVault\Demo\DemoSessionSeater;
 use NeneVault\Tests\Support\FixedClock;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 
 /**
  * The disposable-org seat page (#141): mints an admin token whose `org_id`
@@ -22,7 +24,10 @@ use Psr\Http\Message\ResponseInterface;
  */
 final class DemoSessionSeaterTest extends TestCase
 {
-    private function seat(?DemoProvisionRegistry $registry = null): ResponseInterface
+    /** @var list<string> */
+    private array $entryLines = [];
+
+    private function seat(?DemoProvisionRegistry $registry = null, ?ServerRequestInterface $request = null): ResponseInterface
     {
         $registry ??= new DemoProvisionRegistry();
 
@@ -33,12 +38,33 @@ final class DemoSessionSeaterTest extends TestCase
             new Psr17Factory(),
             // Real "now": the verifier checks exp against wall-clock time.
             new FixedClock(gmdate('c')),
+            new DemoEntryLog(function (string $line): void {
+                $this->entryLines[] = $line;
+            }),
         );
 
         return $seater->seatAndRedirect(
-            (new Psr17Factory())->createServerRequest('GET', '/demo/standard'),
+            $request ?? (new Psr17Factory())->createServerRequest('GET', '/demo/standard'),
             new ProvisionedDemoOrg(orgId: 42, slug: 'demo-abc123', adminUserId: 77),
         );
+    }
+
+    public function test_records_a_demo_entry_attribution_line_with_utm_and_referer(): void
+    {
+        $request = (new Psr17Factory())
+            ->createServerRequest('GET', '/demo/standard')
+            ->withQueryParams(['utm_source' => 'fb', 'utm_medium' => 'social', 'utm_campaign' => 'q3'])
+            ->withHeader('Referer', 'https://facebook.example.test/');
+
+        $this->seat(null, $request);
+
+        self::assertCount(1, $this->entryLines);
+        $line = $this->entryLines[0];
+        self::assertStringContainsString('slug=demo-abc123', $line);
+        self::assertStringContainsString('utm_source=fb', $line);
+        self::assertStringContainsString('utm_medium=social', $line);
+        self::assertStringContainsString('utm_campaign=q3', $line);
+        self::assertStringContainsString('referer=https://facebook.example.test/', $line);
     }
 
     public function test_seat_page_stores_an_admin_auth_session_for_the_disposable_org(): void

--- a/tests/Demo/SeatFixedDemoHandlerTest.php
+++ b/tests/Demo/SeatFixedDemoHandlerTest.php
@@ -8,12 +8,16 @@ use Nene2\Auth\LocalBearerTokenVerifier;
 use Nene2\Demo\DemoConfig;
 use NeneVault\Auth\User;
 use NeneVault\Auth\UserRepositoryInterface;
+use NeneVault\Demo\DemoEntryLog;
 use NeneVault\Demo\SeatFixedDemoHandler;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
 
 final class SeatFixedDemoHandlerTest extends TestCase
 {
+    /** @var list<string> */
+    private array $entryLines = [];
+
     private function handler(bool $demoMode, ?User $user): SeatFixedDemoHandler
     {
         $users = new class ($user) implements UserRepositoryInterface {
@@ -99,12 +103,15 @@ final class SeatFixedDemoHandlerTest extends TestCase
             new LocalBearerTokenVerifier('seat-test-secret'),
             new Psr17Factory(),
             new \Nene2\Http\UtcClock(),
+            new DemoEntryLog(function (string $line): void {
+                $this->entryLines[] = $line;
+            }),
         );
     }
 
     private function request(): \Psr\Http\Message\ServerRequestInterface
     {
-        return (new Psr17Factory())->createServerRequest('GET', '/demo/standard');
+        return (new Psr17Factory())->createServerRequest('GET', '/demo/guided');
     }
 
     private function demoViewer(): User
@@ -179,5 +186,32 @@ final class SeatFixedDemoHandlerTest extends TestCase
         $nonce = $m[1] ?? '';
         self::assertNotSame('', $nonce);
         self::assertStringContainsString('<script nonce="' . $nonce . '">', (string) $response->getBody());
+    }
+
+    public function test_records_a_guided_demo_entry_attribution_line(): void
+    {
+        $request = (new Psr17Factory())
+            ->createServerRequest('GET', '/demo/guided')
+            ->withQueryParams(['utm_source' => 'li', 'utm_medium' => 'social', 'utm_campaign' => 'guided-tour'])
+            ->withHeader('Referer', 'https://linkedin.example.test/');
+
+        $this->handler(true, $this->demoViewer())->handle($request);
+
+        self::assertCount(1, $this->entryLines);
+        $line = $this->entryLines[0];
+        self::assertStringContainsString('slug=guided', $line);
+        self::assertStringContainsString('utm_source=li', $line);
+        self::assertStringContainsString('utm_campaign=guided-tour', $line);
+        self::assertStringContainsString('referer=https://linkedin.example.test/', $line);
+    }
+
+    public function test_fail_close_entries_record_nothing(): void
+    {
+        // A probe on a non-demo instance (or a forged viewer) must not log — the
+        // record() call sits after the fail-close gates.
+        $this->handler(false, $this->demoViewer())->handle($this->request());
+        $this->handler(true, null)->handle($this->request());
+
+        self::assertSame([], $this->entryLines);
     }
 }

--- a/tests/Http/SpaShellTest.php
+++ b/tests/Http/SpaShellTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Tests\Http;
+
+use NeneVault\Http\SpaShell;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class SpaShellTest extends TestCase
+{
+    private Psr17Factory $psr17;
+    private string $shellPath;
+    private string $shellHtml;
+
+    protected function setUp(): void
+    {
+        $this->psr17 = new Psr17Factory();
+        // A faithful slice of the real shell: cross-origin Google Fonts in <head>,
+        // absolute /assets/ references, an app root div.
+        $this->shellHtml = "<!doctype html>\n<html lang=\"ja\">\n  <head>\n"
+            . "    <meta charset=\"UTF-8\" />\n"
+            . "    <link href=\"https://fonts.googleapis.com/css2?family=Noto+Sans+JP\" rel=\"stylesheet\" />\n"
+            . "    <title>NeNe Vault</title>\n  </head>\n  <body>\n    <div id=\"root\"></div>\n  </body>\n</html>\n";
+        $this->shellPath = tempnam(sys_get_temp_dir(), 'shell') ?: '';
+        file_put_contents($this->shellPath, $this->shellHtml);
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->shellPath !== '' && is_file($this->shellPath)) {
+            unlink($this->shellPath);
+        }
+    }
+
+    private function shell(?string $analyticsEndpoint = null): SpaShell
+    {
+        return new SpaShell($this->shellPath, $this->psr17, $this->psr17, $analyticsEndpoint);
+    }
+
+    public function test_serves_the_shell_html(): void
+    {
+        $response = $this->shell()->serve();
+
+        self::assertNotNull($response);
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('text/html; charset=UTF-8', $response->getHeaderLine('Content-Type'));
+        self::assertStringContainsString('<div id="root"></div>', (string) $response->getBody());
+    }
+
+    public function test_analytics_disabled_by_default_is_byte_identical_and_sets_no_csp(): void
+    {
+        // The OSS default: env unset → the shell body is the file verbatim and
+        // no CSP header is set (the static-file behaviour it replaced).
+        $response = $this->shell()->serve();
+        self::assertNotNull($response);
+
+        $body = (string) $response->getBody();
+        self::assertSame($this->shellHtml, $body);
+        self::assertStringNotContainsString('goatcounter', $body);
+        self::assertStringNotContainsString('<script', $body);
+        self::assertFalse($response->hasHeader('Content-Security-Policy'));
+    }
+
+    public function test_analytics_endpoint_injects_beacon_before_head_close(): void
+    {
+        $response = $this->shell('https://stats.example.test')->serve();
+        self::assertNotNull($response);
+
+        $body = (string) $response->getBody();
+        self::assertStringContainsString(
+            '<script data-goatcounter="https://stats.example.test/count" async src="https://stats.example.test/count.js"></script>',
+            $body,
+        );
+        // Injected inside <head>, before the close.
+        self::assertStringContainsString('</script>' . "\n  </head>", $body);
+        // The original head content (fonts, title) is preserved.
+        self::assertStringContainsString('fonts.googleapis.com', $body);
+        self::assertStringContainsString('<title>NeNe Vault</title>', $body);
+    }
+
+    public function test_analytics_csp_widens_for_origin_and_keeps_google_fonts(): void
+    {
+        $response = $this->shell('https://stats.example.test')->serve();
+        self::assertNotNull($response);
+
+        $csp = $response->getHeaderLine('Content-Security-Policy');
+        self::assertStringContainsString("script-src 'self' https://stats.example.test", $csp);
+        self::assertStringContainsString("connect-src 'self' https://stats.example.test", $csp);
+        self::assertStringContainsString("img-src 'self' data: https://stats.example.test", $csp);
+        // The shell's cross-origin Google Fonts must survive (clear #277 CSP trap).
+        self::assertStringContainsString("style-src 'self' 'unsafe-inline' https://fonts.googleapis.com", $csp);
+        self::assertStringContainsString("font-src 'self' data: https://fonts.gstatic.com", $csp);
+        // Hardening directives intact.
+        self::assertStringContainsString("object-src 'none'", $csp);
+        self::assertStringContainsString("frame-ancestors 'self'", $csp);
+        self::assertStringContainsString("base-uri 'self'", $csp);
+    }
+
+    public function test_trailing_slash_is_trimmed_from_endpoint(): void
+    {
+        $response = $this->shell('https://stats.example.test/')->serve();
+        self::assertNotNull($response);
+
+        self::assertStringContainsString('src="https://stats.example.test/count.js"', (string) $response->getBody());
+    }
+
+    public function test_missing_shell_returns_null(): void
+    {
+        $shell = new SpaShell($this->shellPath . '.absent', $this->psr17, $this->psr17, 'https://stats.example.test');
+
+        self::assertNull($shell->serve());
+    }
+
+    /**
+     * A malformed or non-origin endpoint fails safe to disabled — no markup and
+     * no CSP header — so a fat-fingered env can never inject a tag or a broken
+     * header value.
+     *
+     * @return iterable<string, array{string}>
+     */
+    public static function invalidEndpoints(): iterable
+    {
+        yield 'empty' => [''];
+        yield 'whitespace' => ['   '];
+        yield 'no scheme' => ['stats.example.test'];
+        yield 'has path' => ['https://stats.example.test/count'];
+        yield 'has query' => ['https://stats.example.test?a=1'];
+        yield 'has space' => ['https://stats.example.test evil'];
+        yield 'javascript scheme' => ['javascript:alert(1)'];
+        yield 'quote injection' => ['https://stats.example.test"><script>'];
+    }
+
+    #[DataProvider('invalidEndpoints')]
+    public function test_invalid_endpoint_fails_safe_to_disabled(string $endpoint): void
+    {
+        $response = $this->shell($endpoint)->serve();
+        self::assertNotNull($response);
+
+        self::assertStringNotContainsString('goatcounter', (string) $response->getBody());
+        self::assertFalse($response->hasHeader('Content-Security-Policy'));
+    }
+}


### PR DESCRIPTION
Closes #184. Wires the demo fleet's shared cookieless analytics (`https://stats.ayane.co.jp`) into Vault's two demo entrances — env-driven, demo-only, OSS release un-contaminated. Follows invoice #659 (merged), adapted to Vault's different shell topology.

## Key divergence from invoice/clear — a third shell topology
invoice/clear serve the SPA shell **through PHP** (`SpaShell`) already. **Vault ships the shell as a static `index.html`** (Apache `.htaccess`), with **no CSP** on it, and it **loads cross-origin Google Fonts**. So a straight port is unsafe on two counts (no injection point; invoice's full CSP would drop the font origins → the clear font-src trap).

Adaptation:
- The shell is now served through `index.php` **before the router** (so it bypasses `SecurityHeadersMiddleware` and stays **byte-identical** when analytics is off), and `.htaccess` routes the SPA fallback to the front controller instead of the static file. **This is the reviewable structural change** — please sanity-check it against the freshly-touched #174/#182 AppShell work.
- The analytics CSP keeps `style-src … https://fonts.googleapis.com` and `font-src … https://fonts.gstatic.com`, adding the analytics origin only to script/connect/img. Emitted **only** when analytics is enabled.

## ② Beacon injection — `src/Http/SpaShell.php` + `public_html/index.php`
- `DEMO_ANALYTICS_ENDPOINT` (bare origin; malformed/empty → `null` fail-safe) gates a GoatCounter beacon injected before `</head>`.
- Env unset (every OSS/self-hosted install) → **no beacon, no CSP** — the shell body is byte-identical to the static file it replaced.

**Final CSP when analytics is ON** (verified against the real built shell):
```
default-src 'self'; script-src 'self' https://stats.ayane.co.jp; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://stats.ayane.co.jp; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://stats.ayane.co.jp; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'
```

## ③ Server-side entry log (layer 1) — `src/Demo/DemoEntryLog.php`
- **Both** `/demo/standard` (`DemoSessionSeater`) and `/demo/guided` (`SeatFixedDemoHandler`) record `Referer` + `utm_source/medium/campaign` at the last moment they exist (before the client-side `location.replace('/')` drops the query).
- No PII (referer + utm + slug only); control chars stripped + length-capped (log-injection defence); missing tags → `-`. Sink injectable (default `error_log`). Guided logs under `guided`; **fail-close paths log nothing**.

## Release cleanliness
- `.env.example` ships **no** origin (empty `DEMO_ANALYTICS_ENDPOINT=` + a documentation comment using `example.test`).
- `grep stats.ayane` over the repo = **0**; `goatcounter` appears only in `src/Http/SpaShell.php`, its test, and the `.env.example` comment — **nothing in `frontend/`** or any build.
- Tests pin env-unset → no injection + byte identity; malformed endpoint → fail-safe disabled.

## Checks
- `composer check` green — **387 tests**, PHPStan, CS, locales, OpenAPI, MCP, conformance all OK.
- `npm run check` (frontend) green — tsc / eslint / prettier / vitest / knip / storybook.
- Smoke test against the real built shell (`dist/.../public_html/index.html`): disabled → byte-identical + no CSP; enabled → beacon before `</head>`, font links preserved, CSP as above.

## Deploy note (separate GO)
Not for auto-deploy. On the demo host's `.env` only: `DEMO_ANALYTICS_ENDPOINT=https://stats.ayane.co.jp` (requires ① ConoHa GoatCounter live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)