### PR TITLE
fix(install): probe の .env 読取を phpdotenv に統一（parse_ini_file の Warning で 403 が 200 化） (#144)

### DIFF
--- a/src/Install/DatabaseProvisioningProbe.php
+++ b/src/Install/DatabaseProvisioningProbe.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneVault\Install;
 
+use Dotenv\Dotenv;
 use Nene2\Install\ProvisioningProbe;
 use PDO;
 use Throwable;
@@ -33,9 +34,27 @@ final class DatabaseProvisioningProbe implements ProvisioningProbe
 
     public static function fromEnvFile(string $envPath, string $projectRoot): self
     {
-        $env = is_file($envPath) ? (parse_ini_file($envPath) ?: []) : [];
+        // Parse with phpdotenv — the SAME dialect the runtime ConfigLoader uses.
+        // `parse_ini_file` speaks a different syntax (`#` comments and characters
+        // like `(` are errors) and emits warnings on mismatch; on a shared host
+        // with display_errors those warnings land before the guard's headers,
+        // turning the 403 blocked response into a 200 that leaks absolute paths
+        // (#144, deal #78). An unreadable `.env` degrades to an empty env — the
+        // marker layer of the guard still holds — and never produces output.
+        $env = [];
 
-        /** @var array<string, string> $env */
+        if (is_file($envPath)) {
+            try {
+                foreach (Dotenv::parse((string) @file_get_contents($envPath)) as $key => $value) {
+                    if (is_string($value)) {
+                        $env[$key] = $value;
+                    }
+                }
+            } catch (Throwable) {
+                $env = [];
+            }
+        }
+
         return new self($env, $projectRoot);
     }
 

--- a/tests/Install/DatabaseProvisioningProbeTest.php
+++ b/tests/Install/DatabaseProvisioningProbeTest.php
@@ -84,6 +84,51 @@ final class DatabaseProvisioningProbeTest extends TestCase
         self::assertFalse($probe->isProvisioned());
     }
 
+    public function test_from_env_file_reads_the_runtime_dotenv_dialect(): void
+    {
+        // The live incident shape (#144, deal #78): `#` comments containing
+        // parentheses and double-quoted values — valid for the runtime's
+        // phpdotenv loader, a syntax error (with warnings) for parse_ini_file.
+        $this->makeSqlite(withUser: true);
+        file_put_contents($this->dir . '/.env', <<<'ENV'
+            APP_ENV=production
+            DB_ADAPTER=sqlite
+            DB_NAME=var/nene_vault.sqlite
+            DB_PASSWORD="p@ss (with parens) \$ and \" quote"
+
+            # --- Demo mode (Nene2\Demo) ---
+            DEMO_MODE=1
+            ENV);
+
+        $probe = DatabaseProvisioningProbe::fromEnvFile($this->dir . '/.env', $this->dir);
+
+        self::assertTrue($probe->isProvisioned());
+    }
+
+    public function test_from_env_file_with_malformed_env_is_silent_and_not_provisioned(): void
+    {
+        // A .env even phpdotenv rejects must degrade to an EMPTY env — not a
+        // partial one — WITHOUT emitting output: warnings before headers broke
+        // the guard's 403 on the live host (#144). The provisioned sqlite here
+        // proves the whole file is discarded, not parsed up to the bad line.
+        $this->makeSqlite(withUser: true);
+        file_put_contents($this->dir . '/.env', "DB_ADAPTER=sqlite\nDB_NAME=var/nene_vault.sqlite\nFOO BAR=1\n");
+
+        ob_start();
+        $probe = DatabaseProvisioningProbe::fromEnvFile($this->dir . '/.env', $this->dir);
+        $output = ob_get_clean();
+
+        self::assertSame('', $output);
+        self::assertFalse($probe->isProvisioned());
+    }
+
+    public function test_from_env_file_without_file_is_not_provisioned(): void
+    {
+        $probe = DatabaseProvisioningProbe::fromEnvFile($this->dir . '/.env', $this->dir);
+
+        self::assertFalse($probe->isProvisioned());
+    }
+
     public function test_guard_blocks_when_marker_present(): void
     {
         $marker = $this->dir . '/var/.installed';


### PR DESCRIPTION
deal 実機で表面化したバグの横展開（deal hideyukiMORI/nene-deal#78 / 修正 PR nene-deal#79）。

## 症状
`src/Install/DatabaseProvisioningProbe.php` の `fromEnvFile()` が `parse_ini_file` で `.env` を読むが、ランタイムは phpdotenv（`Nene2\Config\ConfigLoader` → `Dotenv::createImmutable(...)->safeLoad()`）。`.env` に `#` コメントや `(` 等を含む行（vault も `DEMO_MODE` 追記等で現実に発生しうる）があると Warning → headers already sent で `refuse_install()` の 403 が 200 になり、Warning 本文にサーバー絶対パスが露出。probe 層も空配列化して DB probe が実質無効化。

vault 本番は `install.php` 削除済みで現時点の露出はないが、再 rsync で復活すると再現（deal はまさにこの経路で残存していた）＋リリースZIPに乗り self-hoster に配布されるため直す価値あり。

## 対応（deal #79 と同型）
- `fromEnvFile()` を `Dotenv::parse()`（ランタイムと同一方言）へ統一。読めない `.env` は部分パースせず無音で空 env へ fail（marker 層は引き続き有効）。**403 維持・パス非漏えい**。
- 回帰テスト 3 本追加（deal の `DatabaseProvisioningProbeTest` #78 追加分と同型・vault の `makeSqlite(bool $withUser)` 署名に適合）:
  - 実障害と同形（`#` コメント＋括弧＋quoted 値）の `.env` を provisioned と判定できる
  - phpdotenv でも読めない `.env` は provisioned な DB があっても**無音**で空 env に落ちる（`ob_start` で出力ゼロを検証）
  - `.env` 不在

## 確認
- install ガード（self-delete / marker / probe）は無改変。probe の入口方言のみ差し替え。
- `composer check` 全緑: tests 390 / PHPStan level 8 / cs / locales / openapi / mcp / conformance。
- frontend 変更なし（`npm run check` 対象外）。

Closes #144

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>