### PR TITLE
docs(readme): 静的 status/phase バッジ2枚を撤去（成熟度はStatus表で語る）

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](./LICENSE)
 [![PHP 8.4](https://img.shields.io/badge/PHP-8.4-777BB4?logo=php)](https://www.php.net/)
-[![Public](https://img.shields.io/badge/status-public-blue)]()
-[![Status: Phase 4 complete](https://img.shields.io/badge/status-Phase%204%20complete-brightgreen)]()
 
 **Received-document archive — self-hosted for Japan SMB.**
 


### PR DESCRIPTION
Closes #188

## Summary
- README.md 5・6行目の静的 status バッジ（`status-public` / `Status: Phase 4 complete`）を撤去
- 特に phase バッジは腐る典型（フェーズ進行に追従しない）でテンプレ規約に抵触
- 成熟度情報は既存の Status phase 表（149行目付近、`docs/todo/current.md` 同期）でカバー済みのため情報欠落なし
- License / PHP バッジは維持

## Test plan
- [x] README.md 以外の変更なし（docs-only）
- [x] 差分は該当2行の削除のみ、空行の重複なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)