### PR TITLE
chore(demo): 入場ログ(層1)を var/ file sink 化（error_log→SSH可視）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /dist/
 /var/*.sqlite
 /var/*.cache
+/var/*.log
 /var/rate-limits/
 /.env
 /.php-cs-fixer.cache

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneVault;
 
+use Closure;
 use LogicException;
 use Nene2\Auth\TokenIssuerInterface;
 use Nene2\Config\AppConfig;
@@ -18,7 +19,9 @@ use NeneVault\Auth\AuthRouteRegistrar;
 use NeneVault\Auth\InvalidCredentialsExceptionHandler;
 use NeneVault\Auth\TooManyLoginAttemptsExceptionHandler;
 use NeneVault\Auth\UserRepositoryInterface;
+use NeneVault\Demo\DemoEntryLog;
 use NeneVault\Demo\DemoServiceProvider;
+use NeneVault\Demo\FileDemoEntryLogSink;
 use NeneVault\Demo\GuidedDemoRouteRegistrar;
 use NeneVault\Demo\SeatFixedDemoHandler;
 use NeneVault\Document\DocumentRouteRegistrar;
@@ -31,6 +34,7 @@ use NeneVault\Document\MimeTypeNotAllowedExceptionHandler;
 use NeneVault\Document\VaultDocumentNotFoundExceptionHandler;
 use NeneVault\Export\ExportRouteRegistrar;
 use NeneVault\Export\ExportServiceProvider;
+use NeneVault\Http\RuntimeServiceProvider;
 use NeneVault\Ocr\OcrExceptionHandler;
 use NeneVault\Ocr\OcrRouteRegistrar;
 use NeneVault\Ocr\OcrServiceProvider;
@@ -87,6 +91,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                 $users = $c->get(UserRepositoryInterface::class);
                 $issuer = $c->get(TokenIssuerInterface::class);
                 $psr17 = $c->get(Psr17Factory::class);
+                $projectRoot = $c->get(RuntimeServiceProvider::PROJECT_ROOT);
 
                 if (!$config instanceof AppConfig) {
                     throw new LogicException('AppConfig service is invalid.');
@@ -104,7 +109,18 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     throw new LogicException('Psr17Factory service is invalid.');
                 }
 
-                return new SeatFixedDemoHandler($config->demo, $users, $issuer, $psr17, new UtcClock());
+                if (!is_string($projectRoot) || $projectRoot === '') {
+                    throw new LogicException('Project root service is invalid.');
+                }
+
+                // File sink (#192): demo-entry lines go to var/demo-entry.log
+                // (SSH-visible) instead of the default error_log (HETEML
+                // control-panel-only, invisible for UTM analysis).
+                $entryLog = new DemoEntryLog(Closure::fromCallable(
+                    new FileDemoEntryLogSink($projectRoot . '/var'),
+                ));
+
+                return new SeatFixedDemoHandler($config->demo, $users, $issuer, $psr17, new UtcClock(), $entryLog);
             },
         );
         $builder->set(

--- a/src/Demo/DemoServiceProvider.php
+++ b/src/Demo/DemoServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneVault\Demo;
 
+use Closure;
 use LogicException;
 use Nene2\Auth\TokenIssuerInterface;
 use Nene2\Config\AppConfig;
@@ -122,6 +123,7 @@ final readonly class DemoServiceProvider implements ServiceProviderInterface
                         $tokenIssuer,
                         self::psr17($c),
                         new UtcClock(),
+                        self::entryLog($c),
                     );
                 },
             )
@@ -259,5 +261,23 @@ final readonly class DemoServiceProvider implements ServiceProviderInterface
         }
 
         return $config;
+    }
+
+    /**
+     * File sink (#192): demo-entry lines go to var/demo-entry.log
+     * (SSH-visible) instead of the default error_log (HETEML
+     * control-panel-only, invisible for UTM analysis). Same var/ path
+     * resolution as {@see FileRateLimitStorage}.
+     */
+    private static function entryLog(ContainerInterface $c): DemoEntryLog
+    {
+        $projectRoot = $c->get(RuntimeServiceProvider::PROJECT_ROOT);
+        if (!is_string($projectRoot) || $projectRoot === '') {
+            throw new LogicException('Project root service is invalid.');
+        }
+
+        return new DemoEntryLog(Closure::fromCallable(
+            new FileDemoEntryLogSink($projectRoot . '/var'),
+        ));
     }
 }

--- a/src/Demo/FileDemoEntryLogSink.php
+++ b/src/Demo/FileDemoEntryLogSink.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Demo;
+
+/**
+ * File-backed sink for {@see DemoEntryLog} (#192): appends one line per demo
+ * entry to `<baseDir>/demo-entry.log` instead of the default `error_log`.
+ *
+ * Exists because on the Tier A shared-hosting target (HETEML), `error_log`
+ * output lands in the hosting control panel's log — invisible over SSH — so
+ * precise UTM/channel analysis of demo entries isn't possible there. `var/`
+ * is the writable runtime directory the deployment already relies on (same
+ * resolution as {@see FileRateLimitStorage}, #141): `RuntimeServiceProvider`'s
+ * project root plus `/var`.
+ *
+ * Best-effort like its sibling: when the file cannot be opened or the write
+ * fails, the line falls back to `error_log` so a line is never silently
+ * dropped, it just loses the SSH-visible destination for that one line.
+ */
+final readonly class FileDemoEntryLogSink
+{
+    private const string LOG_FILENAME = 'demo-entry.log';
+
+    public function __construct(
+        private string $baseDir,
+    ) {
+    }
+
+    public function __invoke(string $line): void
+    {
+        if (!is_dir($this->baseDir)) {
+            @mkdir($this->baseDir, 0o775, true);
+        }
+
+        $handle = @fopen($this->baseDir . '/' . self::LOG_FILENAME, 'ab');
+
+        if ($handle === false) {
+            error_log($line);
+
+            return;
+        }
+
+        try {
+            flock($handle, LOCK_EX);
+            $written = fwrite($handle, $line . PHP_EOL);
+            fflush($handle);
+
+            if ($written === false) {
+                error_log($line);
+            }
+        } finally {
+            flock($handle, LOCK_UN);
+            fclose($handle);
+        }
+    }
+}

--- a/tests/Demo/FileDemoEntryLogSinkTest.php
+++ b/tests/Demo/FileDemoEntryLogSinkTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Tests\Demo;
+
+use NeneVault\Demo\DemoEntryLog;
+use NeneVault\Demo\FileDemoEntryLogSink;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+
+final class FileDemoEntryLogSinkTest extends TestCase
+{
+    private string $baseDir;
+
+    protected function setUp(): void
+    {
+        $this->baseDir = sys_get_temp_dir() . '/nene-vault-entry-log-test-' . bin2hex(random_bytes(6));
+        mkdir($this->baseDir, 0o775, true);
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->baseDir . '/demo-entry.log');
+        @rmdir($this->baseDir);
+    }
+
+    public function test_appends_one_line_per_call_to_the_var_log_file(): void
+    {
+        $sink = new FileDemoEntryLogSink($this->baseDir);
+
+        $sink('NeNe Vault: demo-entry slug=demo-abc123 utm_source=newsletter utm_medium=- utm_campaign=- referer=-');
+        $sink('NeNe Vault: demo-entry slug=guided utm_source=- utm_medium=- utm_campaign=- referer=-');
+
+        $written = file_get_contents($this->baseDir . '/demo-entry.log');
+        self::assertIsString($written);
+        $lines = explode(PHP_EOL, trim($written));
+
+        self::assertCount(2, $lines);
+        self::assertSame(
+            'NeNe Vault: demo-entry slug=demo-abc123 utm_source=newsletter utm_medium=- utm_campaign=- referer=-',
+            $lines[0],
+        );
+        self::assertSame(
+            'NeNe Vault: demo-entry slug=guided utm_source=- utm_medium=- utm_campaign=- referer=-',
+            $lines[1],
+        );
+    }
+
+    public function test_creates_the_base_dir_when_missing(): void
+    {
+        $missingDir = $this->baseDir . '/nested';
+        $sink = new FileDemoEntryLogSink($missingDir);
+
+        $sink('NeNe Vault: demo-entry slug=guided utm_source=- utm_medium=- utm_campaign=- referer=-');
+
+        self::assertFileExists($missingDir . '/demo-entry.log');
+
+        // Extra teardown for the nested dir this test creates.
+        @unlink($missingDir . '/demo-entry.log');
+        @rmdir($missingDir);
+    }
+
+    public function test_falls_back_to_error_log_when_the_file_cannot_be_opened(): void
+    {
+        // A baseDir that can never become a writable directory (it's an
+        // existing regular file, so @mkdir/@fopen both fail) forces the
+        // fopen-failure fallback path without needing chmod tricks that
+        // don't reliably deny root/CI runners.
+        $unwritable = $this->baseDir . '/not-a-dir';
+        file_put_contents($unwritable, 'x');
+
+        $sink = new FileDemoEntryLogSink($unwritable);
+
+        $previous = ini_set('error_log', $this->baseDir . '/php-error.log');
+        try {
+            $sink('NeNe Vault: demo-entry slug=demo-x utm_source=- utm_medium=- utm_campaign=- referer=-');
+
+            $fallback = file_get_contents($this->baseDir . '/php-error.log');
+            self::assertIsString($fallback);
+            self::assertStringContainsString(
+                'NeNe Vault: demo-entry slug=demo-x utm_source=- utm_medium=- utm_campaign=- referer=-',
+                $fallback,
+            );
+        } finally {
+            if ($previous !== false) {
+                ini_set('error_log', $previous);
+            }
+            @unlink($unwritable);
+            @unlink($this->baseDir . '/php-error.log');
+        }
+    }
+
+    public function test_wired_through_demo_entry_log_preserves_the_line_format(): void
+    {
+        $sink = new FileDemoEntryLogSink($this->baseDir);
+        $entryLog = new DemoEntryLog(\Closure::fromCallable($sink));
+
+        $request = (new Psr17Factory())
+            ->createServerRequest('GET', 'https://vault.example.test/demo/standard')
+            ->withQueryParams(['utm_source' => 'newsletter']);
+
+        $entryLog->record($request, 'demo-abc123');
+
+        $written = file_get_contents($this->baseDir . '/demo-entry.log');
+        self::assertIsString($written);
+        self::assertSame(
+            'NeNe Vault: demo-entry slug=demo-abc123 utm_source=newsletter utm_medium=- utm_campaign=- referer=-',
+            trim($written),
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- デモ入場ログ（attribution 層1・#184）の既定 sink を `error_log`（HETEML では
  コンパネ行きで SSH 不可視）から `var/demo-entry.log`（SSH で `tail`/`grep`
  可能）へ変更する。
- 新規 `NeneVault\Demo\FileDemoEntryLogSink`: `var/` へのパス解決は
  `FileRateLimitStorage`（#141）と同じ手法（`RuntimeServiceProvider::PROJECT_ROOT`
  経由の `$projectRoot . '/var'`）を流用。新しいパス規則は作っていない。
- 書込失敗時（fopen/fwrite 失敗）は `error_log` にフォールバックし、ログ行を
  失わない。
- `ApplicationServiceProvider`（`SeatFixedDemoHandler` の合成箇所）と
  `DemoServiceProvider`（`DemoSessionSeater` の合成箇所）で、既定の
  `error_log` sink の代わりにこの file sink を配線した。
- `DemoEntryLog` 本体・行フォーマット・sink 差し替え可能な設計は不変
  （既存の `DemoEntryLogTest` / `SeatFixedDemoHandlerTest` /
  `DemoSessionSeaterTest` は無改変で緑）。
- `.gitignore` に `/var/*.log` を追加（本番生成物をコミットしない）。

Closes #192

## Test plan

- [x] `composer test` — 394 tests, 1221 assertions, green
- [x] `composer analyse`（PHPStan）— No errors
- [x] `composer cs` — no diffs
- [x] `composer check`（locales/openapi/mcp/conformance含む）— all green
- [x] 新規 `tests/Demo/FileDemoEntryLogSinkTest.php`:
      ファイルへの追記／ベースディレクトリの自動作成／fopen 失敗時の
      error_log フォールバック／`DemoEntryLog` 経由での行フォーマット不変
      をカバー

🤖 Generated with [Claude Code](https://claude.com/claude-code)