### PR TITLE
sec: red-team ラウンド2 — nene-records 2型の同型不在を実弾確認＋org バインディング多層化 (#198)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,9 @@ services:
       PROBLEM_DETAILS_BASE_URL: "${PROBLEM_DETAILS_BASE_URL:-https://nene-vault.dev/problems/}"
       TENANT_RESOLUTION: "${TENANT_RESOLUTION:-single}"
       ORG_SLUG: "${ORG_SLUG:-default}"
+      # Base domain for TENANT_RESOLUTION=subdomain (<slug>.<BASE_DOMAIN>).
+      # Read by RuntimeServiceProvider; default localhost for single-tenant dev.
+      BASE_DOMAIN: "${BASE_DOMAIN:-localhost}"
       ORG_NAME: "${ORG_NAME:-NeNe Vault}"
       ADMIN_EMAIL: "${ADMIN_EMAIL:-admin@example.com}"
       ADMIN_PASSWORD: "${ADMIN_PASSWORD:-changeme123}"

--- a/docs/security/2026-07-14-redteam-assessment.md
+++ b/docs/security/2026-07-14-redteam-assessment.md
@@ -1,0 +1,179 @@
+# Security Assessment — Red-team Round 2 (2026-07-14)
+
+**Type:** Authorized self / maintainer-run assessment — black-box live attack
+(ATK) + white-box review. **Not a third-party penetration test.**
+
+**App version at test:** `nene-vault` @ `cb96a7a` (branch base `origin/main`,
+round-1 #195 merged) · NENE2 v1.10.0 · PHP 8.4.22 · Apache 2.4.67.
+
+**Why this round.** Round 1 (`2026-07-13-assessment.md`, PR #195) established
+`EXPOSED 0` across a broad battery. This round is a **targeted red-team**: the
+sibling product **nene-records** completed the same assessment on 2026-07-13 and
+found two *real, exploited* vulnerability types
+(`nene-records/docs/security/2026-07-13-assessment.md`). This report verifies,
+by live fire, that **NeNe Vault does not have either type**, hardens the one
+latent-fragility that maps to the sibling's root cause, and corrects one round-1
+probe gap.
+
+**Scope / target.** Disposable local Docker stack (`docs/security/harness/`),
+project `vaultsec` / `vaultsec-tenant`, port 8600. **No production host**
+(`vault.ayane.co.jp` or any live system) was touched; no DoS/destructive payloads.
+
+## Result
+
+**0 Critical / 0 High / 0 Medium / 0 Low `EXPOSED`.**
+
+Both nene-records finding types were probed live and are **absent** in Vault:
+
+| nene-records finding | Severity there | Vault verdict | Evidence |
+|---|---|---|---|
+| **F-01** Unauthenticated read of the admin API (webhook secret / drafts) | Critical | 🚫 **NOT PRESENT** | All 11 admin GET endpoints → 401 unauthenticated (blocklist auth, fail-closed) |
+| **F-02** Cross-tenant read via JWT replay to another org's host | Medium | 🚫 **NOT PRESENT** | org-A JWT + org-B `Host` → org-A data only; claim binds tenant over host |
+| **F-03** Version-disclosure headers | Low | ✅ already fixed round 1 (PR #195) | `Server: Apache`, no `X-Powered-By` |
+
+One **defense-in-depth** hardening was applied in-branch (organization-scope
+binding made unconditional in `CapabilityMiddleware`, mirroring the sibling's
+F-02 fix) and pinned with a unit regression; it closes a *latent* fragility that
+was **not live-exploitable** in Vault (claim-based resolution already protected
+every route). Post-change: main probe `PASS=55 VULN=0 INFO=0`, tenant probe
+`4/4`, `composer check` green (400 tests).
+
+## Methodology
+
+- **Black-box live ATK.** Real app booted in a throwaway stack, seeded with two
+  orgs (`default` #1, `acme` #2) + one document each, driven over HTTP.
+  `harness/probe.sh` runs the main battery (single-tenant mode);
+  `harness/probe-tenant.sh` boots a second stack in **subdomain-resolution mode**
+  to exercise the host-vs-claim binding.
+- **White-box review.** `BearerTokenMiddleware` (blocklist), `OrgResolverMiddleware`
+  (claim-based #141), `CapabilityMiddleware` / `CapabilityResolver`, and the full
+  route registrar inventory were read to establish the root-cause difference from
+  nene-records.
+- **Regression.** The hardening is pinned by `tests/Auth/CapabilityMiddlewareTest.php`;
+  `composer check` (400 tests / 1047 assertions, PHPStan L8, CS-Fixer, OpenAPI,
+  MCP, conformance) is green.
+
+## Findings & verification
+
+### F-01 parity — Unauthenticated admin API read → NOT PRESENT
+
+**nene-records root cause.** `AdminApiAuthMiddleware` protected only *non-GET*
+methods; any admin resource whose prefix was never added to the allow-list
+leaked its GET response (webhook signing secret, drafts, full export) to anonymous
+users.
+
+**Vault design.** `BearerTokenMiddleware` uses a **blocklist** (#157): every path
+requires a bearer token **except** the four exact public paths (`/health`,
+`/admin/auth/login`, `/demo/standard`, `/demo/guided`). Adding a route makes it
+protected by default; the public surface is pinned by `PublicSurfaceBoundaryTest`.
+
+**Live result (unauthenticated, no token):**
+
+```
+GET /admin/vault/documents                         → 401
+GET /admin/vault/documents/{id}                     → 401
+GET /admin/vault/documents/{id}/history             → 401
+GET /admin/vault/documents/{id}/versions/{v}/download → 401
+GET /admin/vault/documents/{id}/ocr-suggest         → 401
+GET /admin/vault/settings                           → 401
+GET /admin/audit-events                             → 401
+GET /admin/users        /admin/users/{id}           → 401
+GET /admin/organizations /admin/organizations/{id}  → 401
+HEAD /admin/vault/documents  ·  POST /admin/vault/export → 401
+/health → 200   ·   /admin/auth/login → reachable (422 on empty body)
+```
+
+All 11 admin GET endpoints (and write/verb surfaces) require authentication; the
+public surface stays open. **No unauthenticated admin read exists.** (`probe.sh`
+section L.)
+
+### F-02 parity — Cross-tenant JWT replay to another org's host → NOT PRESENT
+
+**nene-records root cause.** `CapabilityMiddleware` ran its "JWT `org` must equal
+resolved org" check **only after** `CapabilityResolver` returned a capability;
+routes with no capability mapping skipped the check, so an org-A user replaying
+their JWT as a bearer against org-B's host read org-B's data.
+
+**Vault design.** Tenancy is resolved from the **signed `org` claim** first
+(`OrgResolverMiddleware`, #141) — the host is only a fallback for tokens without
+a tenant (superadmin). Repositories scope every query by the resolved org. So a
+non-superadmin token is bound to its own org regardless of Host.
+
+**Live result (subdomain-resolution mode, `probe-tenant.sh`):**
+
+```
+# host strategy genuinely resolves per Host (superadmin, no org claim):
+superadmin + Host acme.vault.test     → org2 (Org2 Vendor)
+superadmin + Host default.vault.test  → org1 (Org1 Vendor)
+
+# signed claim binds the token — host CANNOT override it:
+org1 JWT   + Host acme.vault.test     → org1 (Org1 Vendor)   ← no org2 leak
+org2 JWT   + Host default.vault.test  → org2 (Org2 Vendor)   ← no org1 leak
+```
+
+The superadmin rows prove the host strategy is live (not merely ignored); the
+member rows prove the claim wins. **No cross-tenant replay exists.**
+
+### Hardening (defense-in-depth) — unconditional org-scope binding
+
+Although not live-exploitable in Vault, `CapabilityMiddleware` shared the sibling's
+*structural* shape: it returned early for a route with no capability mapping,
+skipping the org-scope check. A future admin route added without a capability
+mapping would then rely solely on `OrgResolverMiddleware` + repo scoping for
+tenant safety.
+
+**Change.** The organization-scope check now runs for **every** authenticated,
+org-scoped request (non-superadmin, where `nene2.org.id` is resolved),
+*independent of* whether a capability is mapped — mirroring the nene-records F-02
+fix. Superadmin (cross-org by design) and org-agnostic bypass routes (which never
+set `nene2.org.id`) are unaffected; all capability decisions for mapped routes are
+unchanged.
+
+**Regression.** `tests/Auth/CapabilityMiddlewareTest.php` (6 tests) pins:
+unmapped route + mismatched org → **403 `org-access-denied`** (handler never
+reached); unmapped route + matching org → pass; mapped-route capability still
+enforced (viewer upload → 403); superadmin bypass; unauthenticated pass-through.
+
+### Round-1 probe gap corrected
+
+Round-1 `probe.sh` exercised CSV formula-injection via `GET /admin/vault/export`,
+but that route is **POST**-only — the GET returned no CSV, so the check passed
+vacuously. Fixed to `POST … {"format":"csv"}`. Re-run shows the real manifest
+with the user-controlled cell **neutralized**: `counterparty_name` of
+`=2+5+cmd|calc` is exported as `'=2+5+cmd|calc` (leading apostrophe, UTF-8 BOM
+present) by `Nene2\Export\CsvWriter` (ADR 0015). Now backed by real evidence.
+
+## Verified-safe (carried from round 1, re-confirmed)
+
+`PASS=55 VULN=0 INFO=0` across the extended `probe.sh`: JWT (alg:none / tamper /
+expired / wrong-secret → 401), tenant isolation incl. cross-org user
+role-escalation (→ 404), RBAC boundaries, SQL injection (parameterized), path
+traversal + storage-path non-disclosure, MIME allowlist + attachment/nosniff,
+security headers/CORS (no version banners), clean Problem Details errors,
+SHA-256 tamper detection, no hard-delete, login throttle (429).
+
+## Residual notes (non-blocking, unchanged from round 1)
+
+- **No application-layer at-rest encryption** — stored bytes are plaintext;
+  confidentiality at rest relies on host FS / S3 bucket controls. Not
+  black-box-reachable. Tracked as follow-up **#196**.
+- **`users` repository org filter** — cross-org safety is enforced in the
+  use-cases (verified live); repo-layer `organization_id` predicates would be
+  belt-and-braces. Tracked as **#197**.
+
+## Conclusion
+
+The two vulnerability types nene-records found and fixed (F-01 unauthenticated
+admin read, F-02 cross-tenant JWT replay) are **not present** in NeNe Vault
+@ `cb96a7a`, verified by live fire. Vault's blocklist authentication and
+claim-based tenant resolution are the structural reasons. A defense-in-depth
+hardening (unconditional org-scope binding) was added to remove the latent
+fragility that maps to the sibling's root cause, and a round-1 probe gap was
+corrected. `EXPOSED 0` stands.
+
+---
+
+*Methodology footer: authorized self / maintainer-run red-team round — main
+battery 55 assertions + tenant host-reuse 4 assertions against disposable local
+stacks. Reproduce with `docs/security/harness/` (`probe.sh`, `probe-tenant.sh`).
+Not a third-party pentest; no production system was targeted.*

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -8,6 +8,7 @@ penetration tests. No production host is ever targeted.
 
 | Date | Report | Scope | Result |
 |---|---|---|---|
+| 2026-07-14 | [Red-team round 2](2026-07-14-redteam-assessment.md) | nene-records parity: unauthenticated admin GET (F-01), cross-tenant JWT-vs-host replay (F-02); org-binding defense-in-depth | **0 EXPOSED** — both sibling finding types absent (main 55 + tenant 4 assertions); unconditional org-scope binding hardening + regression |
 | 2026-07-13 | [Black-box live ATK](2026-07-13-assessment.md) | Auth/JWT, tenant isolation, RBAC, upload/download, export, storage-path disclosure, headers/CORS, compliance invariants | **0 Critical / 0 High / 0 Medium / 0 Low EXPOSED** (48 assertions); 2 low info-banner INFOs fixed + re-verified |
 
 Each report documents: the tested app/framework version and scope, methodology,

--- a/docs/security/harness/README.md
+++ b/docs/security/harness/README.md
@@ -15,7 +15,8 @@ received document each, and fires a black-box live attack (ATK) battery.
 |---|---|
 | `mint.php`  | Mints fleet-standard HS256 bearer tokens (`sub`/`role`/`org`/`iat`/`exp`) with the running app's own secret, so any tenant/role can be driven directly. Also emits attack tokens (`--forge-none`, `--tamper-role`, `--exp=-60`). |
 | `seed.sh`   | Creates org 2 (`acme`) beside the default org 1 and uploads one org-tagged PDF into each — the data cross-tenant/RBAC/export attacks target. |
-| `probe.sh`  | The live ATK runner. Sections A–K; prints `[PASS]`/`[VULN]`/`[INFO]` and a `SUMMARY: PASS/VULN/INFO` line. Exit non-zero if any `VULN`. |
+| `probe.sh`  | The main live ATK runner (assumes the stack is up). Sections A–M incl. the unauthenticated admin-GET sweep (L) and verb confusion (M); prints `[PASS]`/`[VULN]`/`[INFO]` and a `SUMMARY` line. Exit non-zero if any `VULN`. |
+| `probe-tenant.sh` | Self-contained cross-tenant JWT-vs-host replay test (boots subdomain-mode stack → seeds → asserts → tears down). Verifies a signed `org` claim binds a token to its own tenant regardless of `Host`. |
 | `.gitignore`| Keeps real secrets / minted tokens / run logs out of git. |
 
 The harness reuses the repository's own `docker-compose.yml` (SQLite, port 8600)
@@ -40,7 +41,13 @@ SEC_PROJECT=vaultsec BASE=http://localhost:8600 ./docs/security/harness/seed.sh
 SEC_PROJECT=vaultsec BASE=http://localhost:8600 ./docs/security/harness/probe.sh
 ```
 
-Expected tail on a clean tree: `SUMMARY: PASS=48  VULN=0  INFO=0`.
+Expected tail on a clean tree: `SUMMARY: PASS=55  VULN=0  INFO=0`.
+
+```bash
+# 4. Cross-tenant host-reuse test (self-contained; needs port 8600 free, so run
+#    it after `down -v` of the stack above). Boots + seeds + asserts + tears down.
+./docs/security/harness/probe-tenant.sh      # → "4 passed, 0 failed"
+```
 
 ## Teardown (destroys all data + volumes)
 

--- a/docs/security/harness/probe-tenant.sh
+++ b/docs/security/harness/probe-tenant.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# =============================================================================
+# probe-tenant.sh — cross-tenant JWT-vs-host replay test (nene-records F-02
+#                   parity), self-contained: boot → seed → assert → teardown.
+#
+# Boots a DISPOSABLE stack in subdomain-resolution mode and proves that a
+# signed `org` claim binds a bearer token to its own tenant regardless of the
+# Host header — i.e. replaying org-A's JWT against org-B's host does NOT read
+# org-B (the sibling-product F-02 leak type). A superadmin token (no org claim)
+# correctly follows the host (cross-tenant by design).
+#
+# SCOPE: localhost disposable stack ONLY. Never against production. Needs host
+# port 8600 free. Requires NENE2_LOCAL_JWT_SECRET to be exported (same value
+# mint.php will sign with).
+#
+# Usage:
+#   export NENE2_LOCAL_JWT_SECRET='sec-assessment-fixed-secret-2026-07'
+#   ./docs/security/harness/probe-tenant.sh
+# =============================================================================
+set -uo pipefail
+
+PROJECT=vaultsec-tenant
+BASE="http://localhost:8600"
+DOMAIN=vault.test
+pass=0; fail=0
+check() { if [ "$2" = "$3" ]; then echo "  ✅ $1 ($3)"; pass=$((pass+1)); else echo "  ❌ $1 (expected [$2], got [$3])"; fail=$((fail+1)); fi }
+
+cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)" || exit 1
+: "${NENE2_LOCAL_JWT_SECRET:?export NENE2_LOCAL_JWT_SECRET first}"
+
+cleanup() { docker compose -p "$PROJECT" down -v >/dev/null 2>&1; }
+trap cleanup EXIT
+
+echo "== boot disposable stack (subdomain resolution, base=$DOMAIN) =="
+TENANT_RESOLUTION=subdomain BASE_DOMAIN="$DOMAIN" \
+  docker compose -p "$PROJECT" up -d app >/dev/null 2>&1
+for i in $(seq 1 40); do [ "$(curl -s -o /dev/null -w '%{http_code}' "$BASE/health")" = 200 ] && break; sleep 1; done
+
+echo "== seed org1(default) + org2(acme), one doc each =="
+SEC_PROJECT="$PROJECT" BASE="$BASE" bash docs/security/harness/seed.sh >/dev/null 2>&1
+
+MINT() { docker compose -p "$PROJECT" exec -T app php docs/security/harness/mint.php "$@" --raw; }
+SUPER=$(MINT --sub=1 --role=superadmin --org=null)
+A1=$(MINT --sub=1 --role=admin --org=1)   # org1 = default
+A2=$(MINT --sub=1 --role=admin --org=2)   # org2 = acme
+seen() { curl -s -H "Authorization: Bearer $1" ${2:+-H "Host: $2"} "$BASE/admin/vault/documents" \
+  | python3 -c 'import sys,json;d=json.load(sys.stdin);print(",".join(i["counterparty_name"] for i in d.get("items",[])) if isinstance(d,dict) and "items" in d else "ERR")' 2>/dev/null; }
+
+echo "== host strategy resolves (superadmin, no org claim) =="
+check "superadmin + Host acme.$DOMAIN sees org2"      "Org2 Vendor" "$(seen "$SUPER" "acme.$DOMAIN")"
+check "superadmin + Host default.$DOMAIN sees org1"   "Org1 Vendor" "$(seen "$SUPER" "default.$DOMAIN")"
+
+echo "== F-02 parity: signed org claim binds the token, host cannot override =="
+check "org1 JWT + Host acme.$DOMAIN stays org1 (no org2 leak)"   "Org1 Vendor" "$(seen "$A1" "acme.$DOMAIN")"
+check "org2 JWT + Host default.$DOMAIN stays org2 (no org1 leak)" "Org2 Vendor" "$(seen "$A2" "default.$DOMAIN")"
+
+echo
+echo "== RESULT: $pass passed, $fail failed =="
+[ "$fail" -eq 0 ]

--- a/docs/security/harness/probe.sh
+++ b/docs/security/harness/probe.sh
@@ -165,7 +165,8 @@ sec "I. Export CSV formula-injection neutralization"
 # upload a doc whose counterparty starts with a formula trigger
 printf '%%PDF-1.4\n%% csvinj\n%%%%EOF' > /tmp/vaultsec_csv.pdf
 code -X POST -H "Authorization: Bearer $A1" -F "file=@/tmp/vaultsec_csv.pdf;type=application/pdf" -F 'counterparty_name==2+5+cmd|calc' -F "category=other" -F "confirm_duplicate=1" "$BASE/admin/vault/documents" >/dev/null
-csv=$(body -H "Authorization: Bearer $A1" "$BASE/admin/vault/export?format=csv")
+# NB: /admin/vault/export is POST + JSON body (a GET yields no CSV — round-1 probe bug, fixed here).
+csv=$(body -X POST -H "Authorization: Bearer $A1" -H 'Content-Type: application/json' -d '{"format":"csv"}' "$BASE/admin/vault/export")
 verdict=$(printf '%s' "$csv" | python3 -c '
 import sys,csv,io
 data=sys.stdin.buffer.read().decode("utf-8-sig")
@@ -200,6 +201,37 @@ for i in 1 2 3 4 5 6 7; do
   last=$(code -X POST "$BASE/admin/auth/login" -H 'Content-Type: application/json' -d '{"email":"admin@example.com","password":"wrong"}')
 done
 [ "$last" = 429 ] && ok "brute force throttled → 429 after repeated failures" || bad "no throttle (last=$last)"
+
+# ── L. Unauthenticated admin-API sweep (nene-records F-01 Critical parity) ────
+sec "L. Unauthenticated admin-API GET sweep (every admin read must be 401)"
+UNAUTH_OK=1
+for p in \
+  "/admin/vault/documents" \
+  "/admin/vault/documents/$DOC1" \
+  "/admin/vault/documents/$DOC1/history" \
+  "/admin/vault/documents/$DOC1/versions/$VER1/download" \
+  "/admin/vault/documents/$DOC1/ocr-suggest" \
+  "/admin/vault/settings" \
+  "/admin/audit-events" \
+  "/admin/users" \
+  "/admin/users/1" \
+  "/admin/organizations" \
+  "/admin/organizations/1" ; do
+  c=$(code "$BASE$p")
+  if [ "$c" != 401 ]; then bad "UNAUTH GET $p → $c (EXPOSED: unauthenticated admin read)"; UNAUTH_OK=0; fi
+done
+[ "$UNAUTH_OK" = 1 ] && ok "all 11 admin GET endpoints require auth (401 unauthenticated)"
+# write/verb surfaces unauthenticated
+c=$(code -I "$BASE/admin/vault/documents"); [ "$c" = 401 ] && ok "unauth HEAD documents → 401" || bad "unauth HEAD → $c (EXPOSED)"
+c=$(code -X POST "$BASE/admin/vault/export" -H 'Content-Type: application/json' -d '{"format":"csv"}'); [ "$c" = 401 ] && ok "unauth POST export → 401" || bad "unauth export → $c (EXPOSED)"
+# public surface must STAY open (no over-correction)
+c=$(code "$BASE/health"); [ "$c" = 200 ] && ok "/health stays public → 200" || bad "/health → $c"
+c=$(code -X POST "$BASE/admin/auth/login" -H 'Content-Type: application/json' -d '{}'); { [ "$c" = 422 ] || [ "$c" = 400 ] || [ "$c" = 401 ]; } && ok "/admin/auth/login stays reachable (no bearer needed) → $c" || note "login → $c"
+
+# ── M. Verb/method confusion ─────────────────────────────────────────────────
+sec "M. Verb / method confusion"
+c=$(code -X GET -H "Authorization: Bearer $A1" "$BASE/admin/vault/export"); { [ "$c" = 404 ] || [ "$c" = 405 ] || [ "$c" = 403 ]; } && ok "GET on POST-only export → $c (not a data leak)" || bad "GET export → $c"
+c=$(code -X DELETE -H "Authorization: Bearer $A1" "$BASE/admin/vault/documents/$DOC1"); { [ "$c" = 404 ] || [ "$c" = 405 ]; } && ok "DELETE document (no such route) → $c" || note "DELETE document → $c"
 
 echo
 echo "================================================================"

--- a/src/Auth/CapabilityMiddleware.php
+++ b/src/Auth/CapabilityMiddleware.php
@@ -34,26 +34,16 @@ final readonly class CapabilityMiddleware implements MiddlewareInterface
             return $handler->handle($request);
         }
 
-        $path = $request->getUri()->getPath() ?: '/';
-        $required = CapabilityResolver::resolve($path, $request->getMethod());
-
-        if ($required === null) {
-            return $handler->handle($request);
-        }
-
         $role = Role::tryFrom((string) ($claims['role'] ?? ''));
 
-        if ($role === null || !$role->hasCapability($required)) {
-            return $this->problemDetails->create(
-                $request,
-                'forbidden',
-                'Forbidden',
-                403,
-                'You do not have permission to perform this action.',
-            );
-        }
-
-        // Organization scope check: superadmin bypasses, others must match resolved org.
+        // Organization scope binding runs for EVERY authenticated, org-scoped
+        // request — independent of whether the route maps to a capability.
+        // Superadmin (cross-org by design) bypasses; org-agnostic bypass routes
+        // never set `nene2.org.id` so they are unaffected. Running this before
+        // (and regardless of) the capability lookup keeps an admin route with no
+        // capability mapping org-bound instead of skipping the check — the class
+        // of gap that let a JWT be replayed cross-tenant on unmapped routes in a
+        // sibling product (security assessment 2026-07-14, defense-in-depth).
         if ($role !== Role::Superadmin) {
             $resolvedOrgId = $request->getAttribute('nene2.org.id');
 
@@ -72,6 +62,23 @@ final readonly class CapabilityMiddleware implements MiddlewareInterface
                     );
                 }
             }
+        }
+
+        $path = $request->getUri()->getPath() ?: '/';
+        $required = CapabilityResolver::resolve($path, $request->getMethod());
+
+        if ($required === null) {
+            return $handler->handle($request);
+        }
+
+        if ($role === null || !$role->hasCapability($required)) {
+            return $this->problemDetails->create(
+                $request,
+                'forbidden',
+                'Forbidden',
+                403,
+                'You do not have permission to perform this action.',
+            );
         }
 
         return $handler->handle($request);

--- a/tests/Auth/CapabilityMiddlewareTest.php
+++ b/tests/Auth/CapabilityMiddlewareTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Tests\Auth;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use NeneVault\Auth\CapabilityMiddleware;
+use NeneVault\Tests\Support\SpyRequestHandler;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Capability enforcement + organization-scope binding.
+ *
+ * The org-scope check runs for every authenticated, org-scoped request
+ * regardless of whether the route maps to a capability — so an admin route with
+ * no capability mapping stays tenant-bound rather than skipping the check
+ * (defense-in-depth, security assessment 2026-07-14; the class of gap that let a
+ * JWT be replayed cross-tenant on unmapped routes in a sibling product).
+ */
+final class CapabilityMiddlewareTest extends TestCase
+{
+    private Psr17Factory $psr17;
+
+    protected function setUp(): void
+    {
+        $this->psr17 = new Psr17Factory();
+    }
+
+    private function middleware(): CapabilityMiddleware
+    {
+        return new CapabilityMiddleware(
+            new ProblemDetailsResponseFactory($this->psr17, $this->psr17, 'https://nene-vault.dev/problems/'),
+        );
+    }
+
+    /**
+     * @param array<string, mixed>|null $claims
+     */
+    private function request(
+        string $method,
+        string $path,
+        ?array $claims = null,
+        ?int $resolvedOrgId = null,
+    ): ServerRequestInterface {
+        $request = $this->psr17->createServerRequest($method, $path);
+
+        if ($claims !== null) {
+            $request = $request->withAttribute('nene2.auth.claims', $claims);
+        }
+
+        if ($resolvedOrgId !== null) {
+            $request = $request->withAttribute('nene2.org.id', $resolvedOrgId);
+        }
+
+        return $request;
+    }
+
+    public function test_unauthenticated_request_passes_through(): void
+    {
+        $handler = new SpyRequestHandler($this->psr17);
+
+        $response = $this->middleware()->process(
+            $this->request('GET', '/admin/vault/documents'),
+            $handler,
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertNotNull($handler->captured);
+    }
+
+    public function test_capability_is_enforced_on_a_mapped_route(): void
+    {
+        $handler = new SpyRequestHandler($this->psr17);
+
+        // Viewer cannot upload (POST /admin/vault/documents → UploadDocument).
+        $response = $this->middleware()->process(
+            $this->request('POST', '/admin/vault/documents', ['role' => 'viewer', 'org' => 1], resolvedOrgId: 1),
+            $handler,
+        );
+
+        self::assertSame(403, $response->getStatusCode());
+        self::assertNull($handler->captured);
+        self::assertSame('forbidden', $this->problemType($response));
+    }
+
+    public function test_cross_org_is_denied_on_a_mapped_route(): void
+    {
+        $handler = new SpyRequestHandler($this->psr17);
+
+        $response = $this->middleware()->process(
+            $this->request('GET', '/admin/vault/documents', ['role' => 'admin', 'org' => 1], resolvedOrgId: 2),
+            $handler,
+        );
+
+        self::assertSame(403, $response->getStatusCode());
+        self::assertNull($handler->captured);
+        self::assertSame('org-access-denied', $this->problemType($response));
+    }
+
+    /**
+     * The regression that matters: a route with NO capability mapping must still
+     * be org-bound. Before the 2026-07-14 hardening the middleware returned early
+     * for unmapped routes and skipped the org-scope check entirely.
+     */
+    public function test_unmapped_route_still_denies_cross_org(): void
+    {
+        $handler = new SpyRequestHandler($this->psr17);
+
+        $response = $this->middleware()->process(
+            // `/admin/vault/reports` maps to no capability in CapabilityResolver.
+            $this->request('GET', '/admin/vault/reports', ['role' => 'admin', 'org' => 1], resolvedOrgId: 2),
+            $handler,
+        );
+
+        self::assertSame(403, $response->getStatusCode());
+        self::assertNull($handler->captured, 'cross-org request must not reach the handler on an unmapped route');
+        self::assertSame('org-access-denied', $this->problemType($response));
+    }
+
+    public function test_unmapped_route_passes_when_org_matches(): void
+    {
+        $handler = new SpyRequestHandler($this->psr17);
+
+        $response = $this->middleware()->process(
+            $this->request('GET', '/admin/vault/reports', ['role' => 'admin', 'org' => 1], resolvedOrgId: 1),
+            $handler,
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertNotNull($handler->captured);
+    }
+
+    public function test_superadmin_bypasses_org_binding(): void
+    {
+        $handler = new SpyRequestHandler($this->psr17);
+
+        // Superadmin on an unmapped route with a resolved org that is not theirs.
+        $response = $this->middleware()->process(
+            $this->request('GET', '/admin/vault/reports', ['role' => 'superadmin', 'org' => null], resolvedOrgId: 2),
+            $handler,
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertNotNull($handler->captured);
+    }
+
+    private function problemType(\Psr\Http\Message\ResponseInterface $response): string
+    {
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertIsArray($body);
+
+        return basename((string) $body['type']);
+    }
+}


### PR DESCRIPTION
## 目的

姉妹製品 **nene-records** が 2026-07-13 に実際に発見・修正した **2つの脆弱性型**を、
nene-vault に同型が無いか**名指しで実弾検証**する red-team ラウンド2。
（ラウンド1 = #194 / PR #195・merged で EXPOSED 0 は取得済み。今回はその上乗せ。）

## 結果: 両型とも同型なし・EXPOSED 0

| nene-records finding | あちらの深刻度 | vault 判定 | 実弾証拠 |
|---|---|---|---|
| **F-01** 未認証で admin API GET が読める（webhook secret/下書き漏洩） | Critical | 🚫 **不在** | 全 admin GET 11 経路 → 未認証 401（ブロックリスト認証・fail-closed・#157） |
| **F-02** org-A の JWT を org-B ホストへ使い回して越境read | Medium | 🚫 **不在** | org-A JWT + org-B `Host` → org-A データのみ（署名 claim が host に勝つ・#141） |
| **F-03** バージョン露出ヘッダ | Low | ✅ ラウンド1で修正済（PR #195） | `Server: Apache`・`X-Powered-By` 無 |

## 変更点

- **`docs/security/2026-07-14-redteam-assessment.md`** — red-team ラウンド2 レポート。
- **`docs/security/harness/probe.sh`** — 未認証 admin GET スイープ(section L)＋verb 混同(M)追加。
  ラウンド1 の CSV export 検証が GET（POST 専用）で空応答＝実質未検証だった点を **POST で是正**
  （実データで `=2+5+cmd|calc` →`'=2+5+cmd|calc` 中和を実証）。
- **`docs/security/harness/probe-tenant.sh`**（新規）— 別orgホストへの JWT 使い回しを
  **自己完結**（boot→seed→assert→teardown・subdomain モード）で検証。
- **`src/Auth/CapabilityMiddleware.php`** — org スコープバインディングを**無条件化**（防御多層）。
  従来は `\$required === null`（capability 未マップ）で早期 return し org チェックをスキップ
  （nene-records F-02 の根因と同型構造）。**live 露出ではない**（claim 解決＋repo スコープで既に保護）が、
  将来の未マップ admin ルートを org 拘束するため無条件化。superadmin と org 非設定 bypass は不変。
- **`tests/Auth/CapabilityMiddlewareTest.php`**（新規・6件）— 未マップルート越境 → 403 等を固定。
- **`docker-compose.yml`** — `BASE_DOMAIN` パススルー（subdomain 解決テスト用・既定 localhost）。

## 検証

- 主 probe **PASS=55 VULN=0 INFO=0** / tenant probe **4/4**。
- `composer check` 緑（**400 tests / 1047 assertions**・PHPStan L8 0・CS 0・locales・OpenAPI・MCP・conformance）。
- **認可された自己/maintainer-run 診断**。本番へは一切当てていない・DoS/破壊なし・第三者 pentest ではない。盛っていない。

## 残件（非ブロッキング・ラウンド1から不変）
at-rest 暗号化未実装（#196）／users リポの org フィルタ多層化（#197）。

Self-review: middleware-security
Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)