### PR TITLE
fix(install): 設置済み検知時に install.php＋installer.js を自己削除 (#200)

### DIFF
--- a/public_html/install.php
+++ b/public_html/install.php
@@ -17,7 +17,10 @@ declare(strict_types=1);
  * disable exec), `docker/seed-initial.php` with the admin password handed
  * over in memory only, and `ReInstallationGuard` (marker + DB probe).
  *
- * On success the installer deletes itself. CLI:
+ * The installer removes itself (install.php + installer.js) once the install is
+ * complete — both on the success path and whenever the re-installation guard
+ * fires, so a deploy/CLI-provisioned install (which never runs the web step)
+ * does not leave the installer in the docroot (#200). CLI:
  * `php public_html/install.php --export-patterns [dir]` renders every screen
  * state to static HTML (design-handoff source).
  */
@@ -57,9 +60,29 @@ function post_raw(string $key): string
     return is_string($_POST[$key] ?? null) ? (string) $_POST[$key] : '';
 }
 
+/**
+ * Remove the installer from the docroot so a completed install never leaves it
+ * reachable. Called on successful setup AND whenever the re-installation guard
+ * fires: a deploy/CLI provisions the app (writes `var/.installed`) without ever
+ * running the web step, so unlinking only on the success path would leave the
+ * files behind (#200). Best-effort — on hosting where the files are not
+ * writable they simply remain, which is no worse than before.
+ */
+function remove_installer_files(): void
+{
+    // installer.js first; install.php (this file) last — the running script
+    // keeps its already-open handle, so unlinking __FILE__ mid-request is safe.
+    @unlink(__DIR__ . '/installer.js');
+    @unlink(__FILE__);
+}
+
 /** 403 refusal shared by the entry guard and the pre-setup re-check. */
 function refuse_install(string $message): never
 {
+    // Already installed → the installer must not linger in the docroot, however
+    // the install was provisioned (web step, deploy, or CLI).
+    remove_installer_files();
+
     http_response_code(403);
     echo render_installer_page([
         'view' => 'blocked',
@@ -1117,8 +1140,9 @@ if ($method === 'POST' && $reqErrors === []) {
                     $success = true;
                     $summary = '組織「' . $orgName . '」と管理者 ' . $adminEmail . ' を作成しました。管理画面にログインして、最初の受取書類をアップロードしましょう。';
                     unset($_SESSION['db']);
-                    // Self-unlink: a completed install must not leave the installer behind.
-                    @unlink(__FILE__);
+                    // Self-unlink: a completed install must not leave the
+                    // installer (install.php + installer.js) behind.
+                    remove_installer_files();
                 }
             } catch (Throwable $e) {
                 $errors[] = 'セットアップに失敗しました: ' . $e->getMessage();


### PR DESCRIPTION
## 目的

vault 本番 docroot に `install.php`/`installer.js` が初期構築（2026-07-10）から残存していた問題
（board (B) で 2026-07-14 手動削除・報告 `_work/handoff-vault-installer-removal-2026-07-14-report.md`）の
**恒久的な再発防止**。

## 根因

自己削除が **成功パス（step=2 完了）でのみ発火し、`install.php` のみ**を消していた（`installer.js` は残る）。
本番は **deploy が rsync でファイル配置＋`var/.installed` マーカー配置**し、web インストーラの step=2 を
通っていないため自己削除が一度も走らず、両ファイルが残存した。`ReInstallationGuard::isBlocked()` で
検知はできていたが `refuse_install()` は「ブロック」ページを出すだけだった。

## 変更点

- `remove_installer_files()` を新設（`installer.js` → `install.php` の順で best-effort `@unlink`）。
- **`refuse_install()`**（設置済み検知の共通経路・呼出は entry guard と step=2 re-check の2箇所のみ・
  いずれも設置完了コンテキスト）で両ファイルを自己削除。**deploy/CLI 経由で設置され web 未通過でも、
  `install.php` に最初にアクセスした時点で消える。**
- 成功パスも `install.php` のみ → 両ファイル削除へ。
- best-effort（権限で消せないホスティングでは従来どおり残るだけ＝悪化なし）。

## 検証（書込可能な一時 docroot に `php -S` で実弾）

| ケース | HTTP | ビュー | ファイル |
|---|---|---|---|
| **設置済み**（marker あり）→ GET install.php | 403 | blocked | **install.php＋installer.js が自己削除**（BEFORE 2 → AFTER 空） |
| **未設置**（marker 無・DB 未プロビジョニング） | 200 | requirements ウィザード | 両ファイル**存置**（過剰削除なし） |

- `php -l` 構文OK・`composer check` 緑（**400 tests**・PHPStan L8 0・CS 0・OpenAPI・MCP・conformance）。

## 露出評価（誇張しない）

残存していた install.php は `ReInstallationGuard` で fail-closed（blocked ビュー・再設置不可）＝**露出は限定的**。
本 PR は衛生・多層防御と再発の恒久防止。

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)