### PR TITLE
feat(frontend): adopt @hideyukimori/nene2-client transport in shared/api/client.ts

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "nene-vault-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@hideyukimori/nene2-client": "^1.1.0",
         "@hookform/resolvers": "^3.10.0",
         "@tanstack/react-query": "^5.62.11",
         "react": "^19.2.6",
@@ -1133,6 +1134,16 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@hideyukimori/nene2-client": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@hideyukimori/nene2-client/-/nene2-client-1.1.0.tgz",
+      "integrity": "sha512-s625luvNkeUZnunF2o3HInpExd6sORR929PFH1kCHtGnNwvlqC6CXK4RHoWCtrcDaHe94z464Eqnd75htSWlyA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22 <25",
+        "npm": ">=10 <12"
       }
     },
     "node_modules/@hookform/resolvers": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "check": "npm run type-check && npm run lint && npm run format && npm run test && npm run knip && npm run build-storybook"
   },
   "dependencies": {
+    "@hideyukimori/nene2-client": "^1.1.0",
     "@hookform/resolvers": "^3.10.0",
     "@tanstack/react-query": "^5.62.11",
     "react": "^19.2.6",

--- a/frontend/src/shared/api/client.test.ts
+++ b/frontend/src/shared/api/client.test.ts
@@ -4,6 +4,7 @@ import { server } from '@tests/msw/server';
 import { problemDetails } from '@tests/msw/fixtures';
 import { authStore } from '@/entities/auth';
 import { apiClient } from './client';
+import { AppError } from './errors';
 
 function signIn(): void {
   authStore.setSession({
@@ -14,6 +15,100 @@ function signIn(): void {
     orgId: 1,
   });
 }
+
+describe('apiClient (nene2-client transport adapter)', () => {
+  it('mirrors the bearer token onto both Authorization and X-Authorization on GET/POST/PATCH/DELETE/upload', async () => {
+    signIn();
+
+    const seen: Record<string, { auth: string | null; xAuth: string | null }> = {};
+    function record(name: string) {
+      return ({ request }: { request: Request }) => {
+        seen[name] = {
+          auth: request.headers.get('Authorization'),
+          xAuth: request.headers.get('X-Authorization'),
+        };
+        return HttpResponse.json({ ok: true });
+      };
+    }
+
+    server.use(
+      http.get('/admin/vault/documents', record('get')),
+      http.post('/admin/vault/documents', record('post')),
+      http.patch('/admin/vault/documents/:id/metadata', record('patch')),
+      http.delete('/admin/vault/documents/:id', record('delete')),
+      http.post('/admin/vault/documents/upload', record('upload')),
+    );
+
+    await apiClient.get('/admin/vault/documents');
+    await apiClient.post('/admin/vault/documents', { name: 'x' });
+    await apiClient.patch('/admin/vault/documents/doc-1/metadata', { counterparty_name: 'y' });
+    await apiClient.delete('/admin/vault/documents/doc-1');
+    await apiClient.upload('/admin/vault/documents/upload', new FormData());
+
+    for (const method of ['get', 'post', 'patch', 'delete', 'upload']) {
+      expect(seen[method]?.auth, `${method} Authorization`).toBe('Bearer test-jwt-token');
+      // The proxy-stripping workaround (#118): the mirror must be present on
+      // every verb so requests keep working behind the shared-hosting front
+      // proxy that strips the standard Authorization header.
+      expect(seen[method]?.xAuth, `${method} X-Authorization`).toBe('Bearer test-jwt-token');
+    }
+  });
+
+  it('sends no auth headers when signed out', async () => {
+    authStore.clearSession();
+    let authorization: string | null = null;
+
+    server.use(
+      http.get('/admin/vault/documents', ({ request }) => {
+        authorization = request.headers.get('Authorization');
+        return HttpResponse.json({ items: [], limit: 20, offset: 0, total: 0 });
+      }),
+    );
+
+    await apiClient.get('/admin/vault/documents');
+
+    expect(authorization).toBeNull();
+  });
+
+  it('clears the session store on a 401 from an authenticated request (#168)', async () => {
+    signIn();
+    server.use(
+      http.get('/admin/vault/documents', () =>
+        HttpResponse.json(problemDetails('unauthorized', 401, 'Unauthorized'), {
+          status: 401,
+          headers: { 'Content-Type': 'application/problem+json' },
+        }),
+      ),
+    );
+
+    await expect(apiClient.get('/admin/vault/documents')).rejects.toBeInstanceOf(AppError);
+
+    // The reactive auth gate re-renders the login form in place once the
+    // token store reports signed-out — no hard navigation (#168).
+    expect(authStore.getToken()).toBeNull();
+  });
+
+  it('maps a Problem Details error response to AppError with the same shape as before', async () => {
+    signIn();
+    server.use(
+      http.get('/admin/vault/documents', () =>
+        HttpResponse.json(problemDetails('internal-server-error', 500, 'Server Error'), {
+          status: 500,
+          headers: { 'Content-Type': 'application/problem+json' },
+        }),
+      ),
+    );
+
+    await expect(apiClient.get('/admin/vault/documents')).rejects.toMatchObject({
+      status: 500,
+      problem: {
+        type: 'https://nene-vault.dev/problems/internal-server-error',
+        title: 'Server Error',
+      },
+    });
+    await expect(apiClient.get('/admin/vault/documents')).rejects.toBeInstanceOf(AppError);
+  });
+});
 
 describe('apiClient.postBlob', () => {
   it('sends both Authorization and the X-Authorization mirror (#118)', async () => {

--- a/frontend/src/shared/api/client.ts
+++ b/frontend/src/shared/api/client.ts
@@ -1,68 +1,87 @@
+import {
+  createNene2Transport,
+  isNene2ClientError,
+  isValidationProblemDetails,
+  type Nene2ClientError,
+  type TokenStore,
+} from '@hideyukimori/nene2-client';
 import { authStore } from '@/entities/auth';
 import { env } from '@/shared/config/env';
-import { parseProblemDetails } from '@/shared/api/errors';
+import { AppError, type ProblemDetails } from '@/shared/api/errors';
 
-type HttpMethod = 'GET' | 'POST' | 'PATCH' | 'DELETE';
-
-interface RequestOptions {
-  method?: HttpMethod | undefined;
-  body?: unknown;
-  signal?: AbortSignal | undefined;
-}
-
-/** Fail-closed handling for auth errors, shared by all requests. */
-function handleAuthError(response: Response, path: string): void {
-  // Session expired (not a wrong-credentials 401 from the login endpoint):
-  // clear the reactive store — the auth gate shows the login form in place at
-  // the current URL (#168), instead of a hard navigation that drops SPA state.
-  if (response.status === 401 && !path.includes('/auth/login')) {
+/**
+ * Adapts vault's session-object store (`entities/auth/model.ts`, #148 — the
+ * fleet exemplar for the auth module-store pattern, AU-1/AU-4) to the
+ * transport's minimal `TokenStore` contract. `authStore` itself is untouched:
+ * only its token accessors are handed to the transport.
+ */
+const tokenStore: TokenStore = {
+  getToken: () => authStore.getToken(),
+  clearToken: () => {
     authStore.clearSession();
-  }
-  if (response.status === 403) {
+  },
+};
+
+/**
+ * Fleet-standard transport (`@hideyukimori/nene2-client`, issue #102): every
+ * request mirrors the bearer token onto `Authorization` *and*
+ * `X-Authorization` (#118 — shared-hosting front proxies strip the standard
+ * header) and normalizes RFC 9457 Problem Details. `apiClient` below is a
+ * thin adapter that keeps this product's existing surface
+ * (`get/post/patch/delete/upload/postBlob/getBlob`) verbatim so call sites
+ * did not need to change.
+ */
+const transport = createNene2Transport({
+  baseUrl: env.apiBaseUrl,
+  tokenStore,
+  credentials: 'include',
+  // Look up `fetch` at call time, not bind it once at module load: tests
+  // patch `globalThis.fetch` via msw's `server.listen()`, which runs (in a
+  // `beforeAll` hook) after this module has already been imported.
+  fetch: (input, init) => globalThis.fetch(input, init),
+  onForbidden: () => {
     window.location.href = '/forbidden';
+  },
+  // 401 on an authenticated request clears `tokenStore` automatically (built
+  // into the transport); the reactive auth gate (#168, entities/auth) shows
+  // the login form in place on the next render — no separate side effect
+  // needed here. A 401 on `/auth/login` never reaches this: the request
+  // carries no token yet, so the transport does not treat it as a session
+  // failure (see `AuthFailureContext.tokenAttached`).
+});
+
+/** Maps the package's `Nene2ClientError` to this product's `AppError` (unchanged shape for callers). */
+function toAppError(error: Nene2ClientError): AppError {
+  const problem = error.problem;
+  if (problem === undefined) {
+    return new AppError(error.status, null);
   }
+  const mapped: ProblemDetails = {
+    type: problem.type,
+    title: problem.title,
+    status: problem.status,
+  };
+  if (problem.detail !== undefined) {
+    mapped.detail = problem.detail;
+  }
+  if (problem.instance !== undefined) {
+    mapped.instance = problem.instance;
+  }
+  if (isValidationProblemDetails(problem)) {
+    mapped.errors = problem.errors;
+  }
+  return new AppError(error.status, mapped);
 }
 
-async function request<T>(path: string, options: RequestOptions = {}): Promise<T> {
-  const base = env.apiBaseUrl.replace(/\/$/, '');
-  const url = `${base}${path}`;
-  const headers: Record<string, string> = {};
-
-  if (options.body !== undefined) {
-    headers['Content-Type'] = 'application/json';
+async function unwrap<T>(promise: Promise<T>): Promise<T> {
+  try {
+    return await promise;
+  } catch (error) {
+    if (isNene2ClientError(error)) {
+      throw toAppError(error);
+    }
+    throw error;
   }
-  const token = authStore.getToken();
-  if (token !== null) {
-    headers['Authorization'] = `Bearer ${token}`;
-    // Shared-hosting front proxies (HETEML) strip the standard Authorization
-    // header; the backend adopts this mirror when it is absent (#118).
-    headers['X-Authorization'] = `Bearer ${token}`;
-  }
-
-  const init: RequestInit = {
-    method: options.method ?? 'GET',
-    headers,
-    credentials: 'include',
-  };
-  if (options.body !== undefined) {
-    init.body = JSON.stringify(options.body);
-  }
-  if (options.signal !== undefined) {
-    init.signal = options.signal;
-  }
-
-  const response = await fetch(url, init);
-
-  if (!response.ok) {
-    handleAuthError(response, path);
-    throw await parseProblemDetails(response);
-  }
-
-  if (response.status === 204) {
-    return undefined as T;
-  }
-
-  return (await response.json()) as T;
 }
 
 export interface BlobDownload {
@@ -71,116 +90,27 @@ export interface BlobDownload {
   filename: string | null;
 }
 
-function parseContentDispositionFilename(header: string | null): string | null {
-  if (header === null) {
-    return null;
-  }
-  const match = /filename\*?=(?:UTF-8'')?"?([^";]+)"?/i.exec(header);
-  if (match?.[1] === undefined) {
-    return null;
-  }
-  try {
-    return decodeURIComponent(match[1]);
-  } catch {
-    return match[1];
-  }
-}
-
-/**
- * Authenticated binary download. Goes through the same header contract as
- * request()/uploadFormData() — crucially the X-Authorization mirror (#118) —
- * so downloads keep working behind the shared-hosting proxy that strips the
- * standard Authorization header. Pages must not hand-roll fetch() for this.
- */
-async function requestBlob(path: string, options: RequestOptions = {}): Promise<BlobDownload> {
-  const base = env.apiBaseUrl.replace(/\/$/, '');
-  const url = `${base}${path}`;
-  const headers: Record<string, string> = {};
-
-  if (options.body !== undefined) {
-    headers['Content-Type'] = 'application/json';
-  }
-  const token = authStore.getToken();
-  if (token !== null) {
-    headers['Authorization'] = `Bearer ${token}`;
-    // Shared-hosting front proxies (HETEML) strip the standard Authorization
-    // header; the backend adopts this mirror when it is absent (#118).
-    headers['X-Authorization'] = `Bearer ${token}`;
-  }
-
-  const init: RequestInit = {
-    method: options.method ?? 'GET',
-    headers,
-    credentials: 'include',
-  };
-  if (options.body !== undefined) {
-    init.body = JSON.stringify(options.body);
-  }
-  if (options.signal !== undefined) {
-    init.signal = options.signal;
-  }
-
-  const response = await fetch(url, init);
-
-  if (!response.ok) {
-    handleAuthError(response, path);
-    throw await parseProblemDetails(response);
-  }
-
-  const blob = await response.blob();
-  const filename = parseContentDispositionFilename(response.headers.get('Content-Disposition'));
-  return { blob, filename };
-}
-
-async function uploadFormData<T>(path: string, formData: FormData): Promise<T> {
-  const base = env.apiBaseUrl.replace(/\/$/, '');
-  const url = `${base}${path}`;
-  const headers: Record<string, string> = {};
-
-  const token = authStore.getToken();
-  if (token !== null) {
-    headers['Authorization'] = `Bearer ${token}`;
-    // Shared-hosting front proxies (HETEML) strip the standard Authorization
-    // header; the backend adopts this mirror when it is absent (#118).
-    headers['X-Authorization'] = `Bearer ${token}`;
-  }
-
-  const response = await fetch(url, {
-    method: 'POST',
-    headers,
-    credentials: 'include',
-    body: formData,
-  });
-
-  if (!response.ok) {
-    handleAuthError(response, path);
-    throw await parseProblemDetails(response);
-  }
-
-  return (await response.json()) as T;
-}
-
 export const apiClient = {
   get<T>(path: string, signal?: AbortSignal): Promise<T> {
-    return request<T>(path, { method: 'GET', signal });
+    return unwrap(transport.get<T>(path, { signal }));
   },
   post<T>(path: string, body?: unknown): Promise<T> {
-    return request<T>(path, { method: 'POST', body });
+    return unwrap(transport.post<T>(path, body));
   },
   patch<T>(path: string, body?: unknown): Promise<T> {
-    return request<T>(path, { method: 'PATCH', body });
+    return unwrap(transport.patch<T>(path, body));
   },
   delete<T>(path: string): Promise<T> {
-    return request<T>(path, { method: 'DELETE' });
+    return unwrap(transport.delete<T>(path));
   },
   upload<T>(path: string, formData: FormData): Promise<T> {
-    return uploadFormData<T>(path, formData);
+    return unwrap(transport.upload<T>(path, formData));
   },
   postBlob(path: string, body?: unknown): Promise<BlobDownload> {
-    return requestBlob(path, { method: 'POST', body });
+    return unwrap(transport.postBlob(path, body));
   },
   async getBlob(path: string, signal?: AbortSignal): Promise<Blob> {
-    const { blob } = await requestBlob(path, { method: 'GET', signal });
+    const { blob } = await unwrap(transport.getBlob(path, { signal }));
     return blob;
   },
 };


### PR DESCRIPTION
## 背景

フロント統一規約 transport 第2波（issue #204）。正本: `_work/reports/2026-07-14-frontend-standards/02-data-flow.md` §2 A-1/A-2・§3 AU-1。
参照実装: nene-payout PR #155 / `nene2-js/docs-site/howto/migrate-product-client.md`（vault は移行ガイドの4製品マッピング表に載っている当事者）。

vault の `#148`（sessionStorage トークン store）は `createSessionTokenStore` の設計原型。本 PR は参照実装自身（vault）が
パッケージ側に置換する — `shared/api/client.ts` の自前 fetch ラッパー（自前 X-Authorization ミラー・自前 Problem Details パース）を
`createNene2Transport` に一本化し、自前コードを撤去する。

## 変更（レイアウト変更なし・最小差分）

- `frontend/package.json` / `package-lock.json`: `@hideyukimori/nene2-client@^1.1.0` を追加。
- `frontend/src/shared/api/client.ts`: 全面置換。公開表面は不変
  （`apiClient.get/post/patch/delete/upload/postBlob/getBlob`・ファイル位置も不変）。
  - `createNene2Transport({ baseUrl, tokenStore, credentials: 'include', onForbidden, fetch })` に一本化。
  - **token store**: `entities/auth/model.ts` の `authStore`（#148・AU-4 の module-store exemplar）は**無改造で温存**。
    移行ガイドの vault 向けマッピング表どおり、`{ getToken: () => authStore.getToken(), clearToken: () => authStore.clearSession() }`
    で `TokenStore` インタフェースにアダプトするのみ（`createSessionTokenStore` そのものへの差し替えではない — authStore は
    `token` 以外に `userId/email/role/orgId` を保持するセッションオブジェクトであり、`createSessionTokenStore` はトークン文字列
    1本しか保持しない。移行ガイドが vault に指定しているのはこのアダプタ形）。
  - 自前 X-Authorization ミラー（3箇所で重複していた手書きヘッダ組み立て）・自前 401/403 分岐・自前 Problem Details パースは撤去し、
    transport 内蔵の機構に一本化。
  - エラー写像: `Nene2ClientError` → 既存の `AppError`（`status: number, problem: ProblemDetails | null`）へ `toAppError()` で変換。
    `problemSlug` / `isRetryable` を使う消費側（`app/providers.tsx` の retry 判定・`shared/i18n/map-problem-details.ts`）は無改造で動作。
- `frontend/src/shared/api/client.test.ts`: GET/POST/PATCH/DELETE/upload の両ヘッダミラー・401 でのセッションクリア（#168）・
  Problem Details → AppError 写像のテストを追加（既存の `postBlob` テストは維持）。

## 挙動差の開示（隠さない）

- **token store の key は不変**: `nene_vault_token`（AU-1 の命名規約と一致・既存 sessionStorage 実データ形式もそのまま
  — 中身は今までどおり `authStore` が書く JSON セッションオブジェクト）。**再ログインは発生しない**。
- **401 判定ロジックが「path が `/auth/login` を含むか」から「リクエストにトークンが付与されていたか
  （`AuthFailureContext.tokenAttached`）」へ変わる**。ログイン試行時はそもそもトークンが付いていないため、
  実質的な挙動は同じ（ログイン失敗の 401 でセッションクリアは走らない）。ただし判定軸そのものは変わっているため明記する。
- **ネットワークエラー（fetch 失敗・オフライン等）が新たに `AppError`（`status: 0`）としてスローされるようになる**。
  旧実装は `fetch()` の throw を素通しし `AppError` にラップしていなかった（`app/providers.tsx` の
  `error instanceof AppError && error.isRetryable` によるリトライ対象外だった）。新実装では `status: 0` は
  `isRetryable` が真になるため、**ネットワークエラーが TanStack Query のリトライ対象に入るようになる**
  （最大2回・既存の `retry` 設定のまま）。退行ではなく改善方向の差分だが、未計測のため PR 本文でのみ開示し
  「実測済み」とは言わない。

## 検証（実測）

すべて本 worktree で実行・実測。commit: `728336c`。

| check | 結果 |
|---|---|
| `npm run type-check`（`tsc -b`） | green |
| `npm run lint`（`eslint . --max-warnings 0`） | green |
| `npm run format`（prettier --check） | green |
| `npm run test`（vitest run） | **38 files / 221 tests green** |
| `npm run knip` | green（未使用エクスポートなし） |
| `npm run build`（tsc -b && vite build） | green |
| `npm run build-storybook` | green |

### 故意 fail 確認

`createNene2Transport` の `tokenStore` を一時的に外して同テストを再実行 → 3件が意図どおり fail
（Authorization ミラー欠落・401 でセッションが残る・postBlob のミラー欠落）。差し戻して再実行 → 6/6 green を確認。
テストが実際に配線を検査していることを実測済み。

### 未実施

- `document inline preview` の**実ブラウザ**駆動確認はしていない（`fetchDocumentBlob` 経由の `apiClient.getBlob` は
  シグネチャ・戻り値型 `Promise<Blob>` を変更していないため壊れない想定だが、UI クリックスルーは未実施 — フロントの
  自動テスト（vitest 221件、DocumentDetailPage 関連テストを含む）でカバーした範囲に留まる）。
- vault 側 `composer check`（PHP）は本 PR のスコープ外（frontend のみの変更）につき未実行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)