### PR TITLE
[W1] vault: token vocabulary codemod (nene2-tokens VAULT_TABLE 1.0.0)

### DIFF
--- a/frontend/scripts/w1-token-vocab-codemod.mjs
+++ b/frontend/scripts/w1-token-vocab-codemod.mjs
@@ -1,0 +1,228 @@
+#!/usr/bin/env node
+/**
+ * W1 — Core Token Contract v1 color-vocabulary codemod for nene-vault.
+ *
+ * Source of truth: the frozen, hide-approved 40-row vault mapping table shipped in
+ * `@hideyukimori/nene2-tokens@1.0.0` as `CODEMOD_MAP_V1.tables.vault` (VAULT_TABLE).
+ * It is inlined below VERBATIM (snapshot) so this script is self-contained and
+ * re-runnable in CI without adding a one-shot dependency — same shape as
+ * nene-suite PR #381's `w1-stage1-token-rename.mjs`.
+ *
+ * Why a repo script instead of `npx nene2-tokens extract --map vault | generate`:
+ *   (B-1) vault's themes/default.css is NOT a token-only file — it bakes @theme +
+ *         @layer base + @layer components into one ~2000-line stylesheet, so the
+ *         token-only parser rejects it and extract/generate/validate all fail-closed.
+ *         -> hideyukiMORI/nene2-fleet-tooling (non-token-only theme unsupported).
+ *   (B-2) the shipped mapTokenName() checks isContractTokenName() BEFORE the per-repo
+ *         table, so it silently drops the table's `surface -> surface-raised` row
+ *         (vault's card-face `--color-surface` is itself a contract name) and collides
+ *         it with `bg -> surface` (extractTheme throws; a raw rename would duplicate
+ *         --color-surface with two values = visual regression).
+ *         -> hideyukiMORI/nene2-fleet-tooling (precedence/collision, family of #23/#24).
+ *   Applying VAULT_TABLE literally honors the frozen table's declared intent (40/40),
+ *   is collision-free (all 40 targets distinct), and preserves appearance.
+ *
+ * SCOPE: contract color vocabulary only (the 40-row table). Non-color tokens
+ *   (font / text / radius / spacing / rail-width / z / content / topbar-height) are
+ *   intentionally NOT x-sent this stage: vault is Tailwind v4 and fleet-tooling#17
+ *   (mechanical x- send does not preserve TW v4 namespace semantics) is unresolved.
+ *
+ * Idempotent single pass (independent matches + negative lookahead — no double-apply).
+ *
+ * Usage:
+ *   node scripts/w1-token-vocab-codemod.mjs           # apply
+ *   node scripts/w1-token-vocab-codemod.mjs --check    # verify no legacy refs remain (exit 1 if any)
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// ---- frozen VAULT_TABLE, snapshot of @hideyukimori/nene2-tokens@1.0.0 ----
+const VAULT_TABLE = {
+  bg: 'surface',
+  surface: 'surface-raised',
+  'surface-2': 'surface-overlay',
+  sunk: 'surface-sunken',
+  'sunk-2': 'x-sunk-deep',
+  text: 'text-primary',
+  'text-muted': 'text-muted',
+  'text-faint': 'text-faint',
+  ink: 'x-ink',
+  'ink-2': 'x-ink-deep',
+  line: 'border',
+  'line-2': 'x-line-mid',
+  'line-strong': 'border-strong',
+  navy: 'accent',
+  'navy-hover': 'accent-hover',
+  'navy-soft': 'accent-soft',
+  'navy-deep': 'x-navy-deep',
+  'navy-line': 'x-navy-line',
+  'on-navy': 'on-accent',
+  brass: 'x-brass',
+  'brass-deep': 'x-brass-deep',
+  'brass-soft': 'x-brass-soft',
+  'brass-line': 'x-brass-line',
+  'on-brass': 'x-on-brass',
+  seal: 'x-seal',
+  'seal-bright': 'x-seal-bright',
+  success: 'success',
+  'success-soft': 'success-soft',
+  danger: 'danger',
+  'danger-soft': 'danger-soft',
+  'danger-hover': 'x-danger-hover',
+  warning: 'warn',
+  'warning-soft': 'warn-soft',
+  'warning-ink': 'on-warn',
+  rail: 'x-rail',
+  'rail-2': 'x-rail-deep',
+  'rail-faint': 'x-rail-faint',
+  'rail-ink': 'x-rail-ink',
+  'rail-line': 'x-rail-line',
+  'rail-text': 'x-rail-text',
+};
+
+const CHECK = process.argv.includes('--check');
+const FRONTEND = path.resolve(fileURLToPath(import.meta.url), '../..');
+const SRC = path.join(FRONTEND, 'src');
+const CSS = path.join(SRC, 'shared/ui/theme/themes/default.css');
+
+// color-consuming Tailwind v4 utility namespaces
+const NS = [
+  'text',
+  'bg',
+  'border',
+  'border-t',
+  'border-r',
+  'border-b',
+  'border-l',
+  'border-x',
+  'border-y',
+  'border-s',
+  'border-e',
+  'ring',
+  'ring-offset',
+  'outline',
+  'fill',
+  'stroke',
+  'from',
+  'via',
+  'to',
+  'accent',
+  'caret',
+  'decoration',
+  'divide',
+  'placeholder',
+  'shadow',
+];
+const nsAlt = [...NS].sort((a, b) => b.length - a.length).join('|');
+const changed = Object.keys(VAULT_TABLE)
+  .filter((k) => VAULT_TABLE[k] !== k)
+  .map((k) => [k, VAULT_TABLE[k]])
+  .sort((a, b) => b[0].length - a[0].length);
+const esc = (s) => s.replace(/-/g, '\\-');
+
+function walk(dir, acc = []) {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) walk(p, acc);
+    else if (/\.(tsx|ts)$/.test(e.name)) acc.push(p);
+  }
+  return acc;
+}
+
+// ---- CSS: rename every --color-<key> (definitions + var() refs) verbatim from the table
+function renameCss(css) {
+  let counts = 0;
+  const unknown = new Set();
+  const out = css.replace(/--color-([a-zA-Z0-9-]+)/g, (whole, key) => {
+    if (!(key in VAULT_TABLE)) {
+      unknown.add(whole);
+      return whole;
+    }
+    const to = `--color-${VAULT_TABLE[key]}`;
+    if (to !== whole) counts++;
+    return to;
+  });
+  return { out, counts, unknown };
+}
+
+// ---- TSX: rename color Tailwind utilities for changed keys
+function renameTsx(src) {
+  let counts = 0;
+  for (const [oldKey, newKey] of changed) {
+    const re = new RegExp(`(^|[\\s"'\`:{(])(${nsAlt})-${esc(oldKey)}(?![a-zA-Z0-9-])`, 'g');
+    src = src.replace(re, (_m, pre, ns) => {
+      counts++;
+      return `${pre}${ns}-${newKey}`;
+    });
+  }
+  return { out: src, counts };
+}
+
+if (CHECK) {
+  // verify no legacy (pre-rename) --color name or color-utility remains
+  const oldColor = Object.keys(VAULT_TABLE).filter((k) => VAULT_TABLE[k] !== k);
+  const validTargets = new Set(Object.values(VAULT_TABLE));
+  let remaining = 0;
+  const css = fs.readFileSync(CSS, 'utf8');
+  for (const name of new Set([...css.matchAll(/--color-([a-zA-Z0-9-]+)/g)].map((m) => m[1]))) {
+    if (!validTargets.has(name)) {
+      console.log(`LEGACY css token --color-${name}`);
+      remaining++;
+    }
+  }
+  for (const f of walk(SRC)) {
+    const src = fs.readFileSync(f, 'utf8');
+    for (const oldKey of oldColor) {
+      const re = new RegExp(`(^|[\\s"'\`:{(])(${nsAlt})-${esc(oldKey)}(?![a-zA-Z0-9-])`, 'g');
+      if (re.test(src)) {
+        console.log(`LEGACY util ${oldKey} in ${path.relative(FRONTEND, f)}`);
+        remaining++;
+      }
+    }
+  }
+  console.log(`REMAINING legacy refs: ${remaining}`);
+  process.exit(remaining > 0 ? 1 : 0);
+}
+
+// apply — gated on legacy presence so it is idempotent despite the bg/surface swap
+// (post-migration `--color-surface` is ambiguous with old card-face `surface`; a fresh
+// tree is unambiguous because bg is still `--color-bg`). strictLegacy = changed keys that
+// are not themselves a valid target.
+const validTargets = new Set(Object.values(VAULT_TABLE));
+const strictLegacy = new Set(
+  Object.keys(VAULT_TABLE).filter((k) => VAULT_TABLE[k] !== k && !validTargets.has(k)),
+);
+const cssSrc0 = fs.readFileSync(CSS, 'utf8');
+const present = new Set([...cssSrc0.matchAll(/--color-([a-zA-Z0-9-]+)/g)].map((m) => m[1]));
+if (![...present].some((k) => strictLegacy.has(k))) {
+  console.log('No legacy color tokens present — already applied (idempotent no-op).');
+  process.exit(0);
+}
+const css = renameCss(cssSrc0);
+if (css.unknown.size) {
+  const truly = [...css.unknown].filter((n) => !validTargets.has(n.slice('--color-'.length)));
+  if (truly.length) {
+    console.error(
+      'FATAL: --color tokens neither in VAULT_TABLE nor a valid target (silent drop prohibited):',
+      truly,
+    );
+    process.exit(2);
+  }
+}
+fs.writeFileSync(CSS, css.out);
+let cssOcc = css.counts,
+  tsxOcc = 0,
+  tsxFiles = 0;
+for (const f of walk(SRC)) {
+  const r = renameTsx(fs.readFileSync(f, 'utf8'));
+  if (r.counts) {
+    fs.writeFileSync(f, r.out);
+    tsxOcc += r.counts;
+    tsxFiles++;
+  }
+}
+console.log(
+  `CSS --color renames: ${cssOcc} occ | TSX color-utility renames: ${tsxOcc} in ${tsxFiles} file(s)`,
+);
+console.log('Applied. Run `npm run format` (deterministic prettier) then `npm run check`.');

--- a/frontend/src/app/root-error-boundary.tsx
+++ b/frontend/src/app/root-error-boundary.tsx
@@ -21,7 +21,7 @@ export class RootErrorBoundary extends Component<{ children: ReactNode }, State>
   override render(): ReactNode {
     if (this.state.hasError) {
       return (
-        <div className="flex min-h-screen items-center justify-center bg-surface font-sans text-body text-text-primary">
+        <div className="flex min-h-screen items-center justify-center bg-surface-raised font-sans text-body text-text-primary">
           Something went wrong.
         </div>
       );

--- a/frontend/src/features/login/ui/LoginForm.tsx
+++ b/frontend/src/features/login/ui/LoginForm.tsx
@@ -21,9 +21,9 @@ export function LoginForm({ onLoggedIn }: LoginFormProps) {
       <form className="center-card" onSubmit={handleSubmit(onLoggedIn)} noValidate>
         <div className="head">
           <div className="brand-lock">
-            <BrandMark size={46} className="text-seal" title="NeNe Vault" />
+            <BrandMark size={46} className="text-x-seal" title="NeNe Vault" />
             <div className="brand-name">
-              NeNe <span className="text-brass">Vault</span>
+              NeNe <span className="text-x-brass">Vault</span>
             </div>
           </div>
         </div>

--- a/frontend/src/pages/ForbiddenPage.tsx
+++ b/frontend/src/pages/ForbiddenPage.tsx
@@ -10,7 +10,7 @@ export function ForbiddenPage() {
       <div className="center-card">
         <div className="head">
           <div className="brand-lock">
-            <BrandMark size={40} className="text-seal" title="NeNe Vault" />
+            <BrandMark size={40} className="text-x-seal" title="NeNe Vault" />
           </div>
         </div>
         <div className="body text-center stack-md">

--- a/frontend/src/shared/ui/components/AppShell.tsx
+++ b/frontend/src/shared/ui/components/AppShell.tsx
@@ -185,7 +185,7 @@ export function AppShell({
     <div className="layout">
       <aside className="rail">
         <div className="rail-brand">
-          <BrandMark size={34} className="brand-mark text-seal-bright" title="NeNe Vault" />
+          <BrandMark size={34} className="brand-mark text-x-seal-bright" title="NeNe Vault" />
           <div>
             <div className="brand-name">NeNe Vault</div>
             <div className="brand-sub">Document Archive</div>

--- a/frontend/src/shared/ui/primitives/BrandMark.stories.tsx
+++ b/frontend/src/shared/ui/primitives/BrandMark.stories.tsx
@@ -18,13 +18,13 @@ const meta: Meta<typeof BrandMark> = {
 export default meta;
 type Story = StoryObj<typeof BrandMark>;
 
-export const Default: Story = { args: { className: 'text-seal' } };
-export const Simplified: Story = { args: { simplified: true, size: 48, className: 'text-seal' } };
+export const Default: Story = { args: { className: 'text-x-seal' } };
+export const Simplified: Story = { args: { simplified: true, size: 48, className: 'text-x-seal' } };
 export const OnDark: Story = {
-  args: { className: 'text-seal-bright' },
+  args: { className: 'text-x-seal-bright' },
   decorators: [
     (Story) => (
-      <div className="bg-rail p-lg">
+      <div className="bg-x-rail p-lg">
         <Story />
       </div>
     ),

--- a/frontend/src/shared/ui/primitives/BrandMark.tsx
+++ b/frontend/src/shared/ui/primitives/BrandMark.tsx
@@ -1,8 +1,8 @@
 /**
  * BrandMark — the NeNe Vault seal (二重円の印影 × 鍵穴 / double-ring impression
  * with a keyhole). The mark inherits its color from `currentColor`, so callers
- * set the seal color with a text-color utility (`text-seal` on light surfaces,
- * `text-seal-bright` on dark). Per brand spec the mark is vermilion (朱) only.
+ * set the seal color with a text-color utility (`text-x-seal` on light surfaces,
+ * `text-x-seal-bright` on dark). Per brand spec the mark is vermilion (朱) only.
  *
  * In:  size (px), simplified (drop the inner ring for ≤20px / favicon sizes),
  *      title (accessible name; omit for decorative use), className

--- a/frontend/src/shared/ui/theme/themes/default.css
+++ b/frontend/src/shared/ui/theme/themes/default.css
@@ -11,62 +11,62 @@
 
 @theme {
   /* ---- paper / surfaces — warm, never sterile white ---- */
-  --color-bg: oklch(97.2% 0.007 83);
-  --color-surface: oklch(99.4% 0.004 83);
-  --color-surface-2: oklch(98% 0.006 83);
-  --color-sunk: oklch(95.4% 0.008 83);
-  --color-sunk-2: oklch(93.6% 0.009 80);
+  --color-surface: oklch(97.2% 0.007 83);
+  --color-surface-raised: oklch(99.4% 0.004 83);
+  --color-surface-overlay: oklch(98% 0.006 83);
+  --color-surface-sunken: oklch(95.4% 0.008 83);
+  --color-x-sunk-deep: oklch(93.6% 0.009 80);
 
   /* ---- ink — warm deep slate, never pure black ---- */
-  --color-ink: oklch(29% 0.022 256);
-  --color-ink-2: oklch(24% 0.02 256);
-  --color-text: oklch(31% 0.02 256);
+  --color-x-ink: oklch(29% 0.022 256);
+  --color-x-ink-deep: oklch(24% 0.02 256);
+  --color-text-primary: oklch(31% 0.02 256);
   --color-text-muted: oklch(49% 0.018 256);
   --color-text-faint: oklch(60% 0.015 256);
 
   /* ---- borders — confident hairlines ---- */
-  --color-line: oklch(89% 0.009 83);
-  --color-line-2: oklch(84% 0.011 80);
-  --color-line-strong: oklch(76% 0.013 78);
+  --color-border: oklch(89% 0.009 83);
+  --color-x-line-mid: oklch(84% 0.011 80);
+  --color-border-strong: oklch(76% 0.013 78);
 
   /* ---- navy — the primary "trust" color ---- */
-  --color-navy: oklch(44% 0.085 254);
-  --color-navy-deep: oklch(37% 0.085 256);
-  --color-navy-hover: oklch(39% 0.085 255);
-  --color-navy-soft: oklch(94.5% 0.025 252);
-  --color-navy-line: oklch(86% 0.04 252);
+  --color-accent: oklch(44% 0.085 254);
+  --color-x-navy-deep: oklch(37% 0.085 256);
+  --color-accent-hover: oklch(39% 0.085 255);
+  --color-accent-soft: oklch(94.5% 0.025 252);
+  --color-x-navy-line: oklch(86% 0.04 252);
 
   /* ---- brass — the one UI accent: value, security ---- */
-  --color-brass: oklch(60% 0.092 73);
-  --color-brass-deep: oklch(50% 0.09 68);
-  --color-brass-soft: oklch(93% 0.05 80);
-  --color-brass-line: oklch(82% 0.06 78);
+  --color-x-brass: oklch(60% 0.092 73);
+  --color-x-brass-deep: oklch(50% 0.09 68);
+  --color-x-brass-soft: oklch(93% 0.05 80);
+  --color-x-brass-line: oklch(82% 0.06 78);
 
   /* ---- seal / 朱 — brand mark ONLY ---- */
-  --color-seal: oklch(54% 0.142 33);
-  --color-seal-bright: oklch(67% 0.15 36);
+  --color-x-seal: oklch(54% 0.142 33);
+  --color-x-seal-bright: oklch(67% 0.15 36);
 
   /* ---- status ---- */
   --color-success: oklch(53% 0.072 156);
   --color-success-soft: oklch(94% 0.03 156);
   --color-danger: oklch(56% 0.097 33);
   --color-danger-soft: oklch(94.5% 0.035 33);
-  --color-danger-hover: oklch(49% 0.1 33);
-  --color-warning: oklch(60% 0.075 74);
-  --color-warning-soft: oklch(95% 0.045 80);
-  --color-warning-ink: oklch(40% 0.09 60);
+  --color-x-danger-hover: oklch(49% 0.1 33);
+  --color-warn: oklch(60% 0.075 74);
+  --color-warn-soft: oklch(95% 0.045 80);
+  --color-on-warn: oklch(40% 0.09 60);
 
   /* ---- dark sidebar rail ---- */
-  --color-rail: oklch(27% 0.018 258);
-  --color-rail-2: oklch(31% 0.02 258);
-  --color-rail-line: oklch(38% 0.018 258);
-  --color-rail-text: oklch(82% 0.012 258);
-  --color-rail-faint: oklch(64% 0.014 258);
-  --color-rail-ink: oklch(96% 0.01 83);
+  --color-x-rail: oklch(27% 0.018 258);
+  --color-x-rail-deep: oklch(31% 0.02 258);
+  --color-x-rail-line: oklch(38% 0.018 258);
+  --color-x-rail-text: oklch(82% 0.012 258);
+  --color-x-rail-faint: oklch(64% 0.014 258);
+  --color-x-rail-ink: oklch(96% 0.01 83);
 
   /* ---- on-dark / on-color text ---- */
-  --color-on-navy: oklch(98% 0.01 83);
-  --color-on-brass: oklch(20% 0.02 256);
+  --color-on-accent: oklch(98% 0.01 83);
+  --color-x-on-brass: oklch(20% 0.02 256);
 
   /* ---- typography ---- */
   --font-sans: 'IBM Plex Sans', 'Noto Sans JP', system-ui, sans-serif;
@@ -131,8 +131,8 @@
   }
   body {
     font-family: var(--font-sans);
-    background: var(--color-bg);
-    color: var(--color-text);
+    background: var(--color-surface);
+    color: var(--color-text-primary);
     font-size: var(--text-body);
     line-height: 1.55;
     -webkit-font-smoothing: antialiased;
@@ -141,7 +141,7 @@
   h1,
   h2,
   h3 {
-    color: var(--color-ink-2);
+    color: var(--color-x-ink-deep);
     font-weight: 600;
     line-height: 1.3;
   }
@@ -177,13 +177,13 @@
     font-size: var(--text-h1);
     font-weight: 600;
     letter-spacing: -0.01em;
-    color: var(--color-ink-2);
+    color: var(--color-x-ink-deep);
   }
   .subtitle {
     font-size: var(--text-h2);
     font-weight: 600;
     letter-spacing: -0.005em;
-    color: var(--color-ink-2);
+    color: var(--color-x-ink-deep);
     display: flex;
     align-items: center;
     gap: 9px;
@@ -192,11 +192,11 @@
     font-size: var(--text-2xs);
     letter-spacing: 0.16em;
     text-transform: uppercase;
-    color: var(--color-brass-deep);
+    color: var(--color-x-brass-deep);
     font-weight: 600;
   }
   .link {
-    color: var(--color-navy);
+    color: var(--color-accent);
     background: none;
     border: 0;
     cursor: pointer;
@@ -205,7 +205,7 @@
     text-decoration: none;
   }
   .link:hover {
-    color: var(--color-navy-deep);
+    color: var(--color-x-navy-deep);
     text-decoration: underline;
     text-underline-offset: 2px;
   }
@@ -216,7 +216,7 @@
     display: inline-block;
     width: 3px;
     height: 15px;
-    background: var(--color-brass);
+    background: var(--color-x-brass);
     border-radius: 1px;
     flex: none;
   }
@@ -232,11 +232,11 @@
     top: 0;
     align-self: start;
     height: 100vh;
-    background: var(--color-rail);
-    border-right: 1px solid var(--color-rail-line);
+    background: var(--color-x-rail);
+    border-right: 1px solid var(--color-x-rail-line);
     display: flex;
     flex-direction: column;
-    color: var(--color-rail-text);
+    color: var(--color-x-rail-text);
     z-index: var(--z-rail);
   }
   .rail-brand {
@@ -244,7 +244,7 @@
     align-items: center;
     gap: 11px;
     padding: 20px 18px 18px;
-    border-bottom: 1px solid var(--color-rail-line);
+    border-bottom: 1px solid var(--color-x-rail-line);
   }
   .brand-mark {
     width: 34px;
@@ -256,7 +256,7 @@
     font-family: var(--font-serif);
     font-size: 1.18rem;
     font-weight: 600;
-    color: var(--color-rail-ink);
+    color: var(--color-x-rail-ink);
     line-height: 1.05;
     letter-spacing: 0.01em;
     white-space: nowrap;
@@ -264,7 +264,7 @@
   .brand-sub {
     font-size: 9px;
     letter-spacing: 0.22em;
-    color: var(--color-brass);
+    color: var(--color-x-brass);
     text-transform: uppercase;
     margin-top: 2px;
     font-weight: 500;
@@ -281,7 +281,7 @@
     font-size: 9px;
     letter-spacing: 0.18em;
     text-transform: uppercase;
-    color: var(--color-rail-faint);
+    color: var(--color-x-rail-faint);
     padding: 14px 10px 6px;
     font-weight: 600;
   }
@@ -291,7 +291,7 @@
     gap: 11px;
     padding: 9px 11px;
     border-radius: var(--radius-sm);
-    color: var(--color-rail-text);
+    color: var(--color-x-rail-text);
     text-decoration: none;
     font-size: var(--text-sm);
     font-weight: 500;
@@ -309,20 +309,20 @@
     opacity: 0.78;
   }
   .rail-link:hover {
-    background: var(--color-rail-2);
-    color: var(--color-rail-ink);
+    background: var(--color-x-rail-deep);
+    color: var(--color-x-rail-ink);
   }
   .rail-link.is-active {
-    background: var(--color-brass);
-    color: var(--color-rail);
+    background: var(--color-x-brass);
+    color: var(--color-x-rail);
     font-weight: 600;
   }
   .rail-link.is-active svg {
     opacity: 1;
-    stroke: var(--color-rail);
+    stroke: var(--color-x-rail);
   }
   .rail-foot {
-    border-top: 1px solid var(--color-rail-line);
+    border-top: 1px solid var(--color-x-rail-line);
     padding: 12px 14px;
     display: flex;
     align-items: center;
@@ -333,8 +333,8 @@
     height: 30px;
     flex: none;
     border-radius: var(--radius-sm);
-    background: var(--color-brass-deep);
-    color: var(--color-on-brass);
+    background: var(--color-x-brass-deep);
+    color: var(--color-x-on-brass);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -349,7 +349,7 @@
   .rail-foot .who b {
     display: block;
     font-size: var(--text-xs);
-    color: var(--color-rail-ink);
+    color: var(--color-x-rail-ink);
     font-weight: 600;
     white-space: nowrap;
     overflow: hidden;
@@ -357,20 +357,20 @@
   }
   .rail-foot .who span {
     font-size: var(--text-2xs);
-    color: var(--color-rail-faint);
+    color: var(--color-x-rail-faint);
   }
   .rail-foot .out {
     background: none;
     border: 0;
-    color: var(--color-rail-faint);
+    color: var(--color-x-rail-faint);
     cursor: pointer;
     padding: 5px;
     border-radius: var(--radius-sm);
     display: flex;
   }
   .rail-foot .out:hover {
-    color: var(--color-rail-text);
-    background: var(--color-rail-2);
+    color: var(--color-x-rail-text);
+    background: var(--color-x-rail-deep);
   }
   .rail-foot .out svg {
     width: 16px;
@@ -395,7 +395,7 @@
     padding: 0 28px;
     background: oklch(99.4% 0.004 83 / 92%);
     backdrop-filter: saturate(1.2);
-    border-bottom: 1px solid var(--color-line);
+    border-bottom: 1px solid var(--color-border);
   }
   .crumbs {
     display: flex;
@@ -409,7 +409,7 @@
     color: var(--color-text-faint);
   }
   .crumbs b {
-    color: var(--color-ink-2);
+    color: var(--color-x-ink-deep);
     font-weight: 600;
     white-space: nowrap;
     overflow: hidden;
@@ -427,10 +427,10 @@
     gap: 6px;
     font-size: var(--text-2xs);
     color: var(--color-text-muted);
-    border: 1px solid var(--color-line-2);
+    border: 1px solid var(--color-x-line-mid);
     border-radius: var(--radius-full);
     padding: 3px 10px;
-    background: var(--color-surface);
+    background: var(--color-surface-raised);
     white-space: nowrap;
   }
   .env .dot {
@@ -449,11 +449,11 @@
   .lang select {
     font: inherit;
     font-size: var(--text-xs);
-    border: 1px solid var(--color-line-2);
-    background: var(--color-surface);
+    border: 1px solid var(--color-x-line-mid);
+    background: var(--color-surface-raised);
     border-radius: var(--radius-sm);
     padding: 5px 8px;
-    color: var(--color-text);
+    color: var(--color-text-primary);
   }
   .content {
     padding: 30px 28px 56px;
@@ -547,8 +547,8 @@
 
   /* ---- cards / panels ---- */
   .card {
-    background: var(--color-surface);
-    border: 1px solid var(--color-line);
+    background: var(--color-surface-raised);
+    border: 1px solid var(--color-border);
     border-radius: var(--radius-md);
     box-shadow: var(--shadow-sm);
   }
@@ -566,7 +566,7 @@
     align-items: center;
     gap: 10px;
     padding: 15px 18px;
-    border-bottom: 1px solid var(--color-line);
+    border-bottom: 1px solid var(--color-border);
   }
 
   /* ---- buttons ---- */
@@ -597,20 +597,20 @@
     stroke: currentColor;
   }
   .btn-primary {
-    background: var(--color-navy);
-    color: var(--color-on-navy);
+    background: var(--color-accent);
+    color: var(--color-on-accent);
     box-shadow: var(--shadow-sm);
   }
   .btn-primary:hover {
-    background: var(--color-navy-hover);
+    background: var(--color-accent-hover);
   }
   .btn-secondary {
-    background: var(--color-surface);
-    color: var(--color-ink-2);
-    border-color: var(--color-line-strong);
+    background: var(--color-surface-raised);
+    color: var(--color-x-ink-deep);
+    border-color: var(--color-border-strong);
   }
   .btn-secondary:hover {
-    background: var(--color-sunk);
+    background: var(--color-surface-sunken);
     border-color: var(--color-text-faint);
   }
   .btn-ghost {
@@ -619,15 +619,15 @@
     border-color: transparent;
   }
   .btn-ghost:hover {
-    background: var(--color-sunk);
-    color: var(--color-ink-2);
+    background: var(--color-surface-sunken);
+    color: var(--color-x-ink-deep);
   }
   .btn-danger {
     background: var(--color-danger);
-    color: var(--color-on-navy);
+    color: var(--color-on-accent);
   }
   .btn-danger:hover {
-    background: var(--color-danger-hover);
+    background: var(--color-x-danger-hover);
   }
   .btn-sm {
     padding: 5px 11px;
@@ -674,11 +674,11 @@
     font: inherit;
     font-size: var(--text-body);
     width: 100%;
-    border: 1px solid var(--color-line-2);
-    background: var(--color-surface);
+    border: 1px solid var(--color-x-line-mid);
+    background: var(--color-surface-raised);
     border-radius: var(--radius-sm);
     padding: 8px 11px;
-    color: var(--color-ink-2);
+    color: var(--color-x-ink-deep);
     transition:
       border-color 0.12s,
       box-shadow 0.12s;
@@ -691,8 +691,8 @@
   .select:focus,
   .textarea:focus {
     outline: none;
-    border-color: var(--color-navy);
-    box-shadow: 0 0 0 3px var(--color-navy-soft);
+    border-color: var(--color-accent);
+    box-shadow: 0 0 0 3px var(--color-accent-soft);
   }
   .textarea {
     min-height: 88px;
@@ -707,8 +707,8 @@
     padding-right: 30px;
   }
   .input-warn {
-    border-color: var(--color-warning);
-    box-shadow: 0 0 0 3px var(--color-warning-soft);
+    border-color: var(--color-warn);
+    box-shadow: 0 0 0 3px var(--color-warn-soft);
   }
   .checkbox,
   .radio {
@@ -717,13 +717,13 @@
     gap: 9px;
     cursor: pointer;
     font-size: var(--text-sm);
-    color: var(--color-text);
+    color: var(--color-text-primary);
   }
   .checkbox input,
   .radio input {
     width: 16px;
     height: 16px;
-    accent-color: var(--color-navy);
+    accent-color: var(--color-accent);
     flex: none;
   }
   .file-input {
@@ -739,13 +739,13 @@
     margin-right: 12px;
     border: 0;
     border-radius: var(--radius-sm);
-    background: var(--color-navy);
-    color: var(--color-on-navy);
+    background: var(--color-accent);
+    color: var(--color-on-accent);
     padding: 7px 13px;
     cursor: pointer;
   }
   .file-input::file-selector-button:hover {
-    background: var(--color-navy-hover);
+    background: var(--color-accent-hover);
   }
 
   /* ---- tables ---- */
@@ -765,8 +765,8 @@
     text-transform: uppercase;
     letter-spacing: 0.06em;
     padding: 11px 16px;
-    background: var(--color-sunk);
-    border-bottom: 1px solid var(--color-line-2);
+    background: var(--color-surface-sunken);
+    border-bottom: 1px solid var(--color-x-line-mid);
     white-space: nowrap;
   }
   table.tbl thead th.right {
@@ -774,29 +774,29 @@
   }
   table.tbl tbody td {
     padding: 13px 16px;
-    border-bottom: 1px solid var(--color-line);
+    border-bottom: 1px solid var(--color-border);
     vertical-align: top;
-    color: var(--color-text);
+    color: var(--color-text-primary);
   }
   table.tbl tbody tr:last-child td {
     border-bottom: 0;
   }
   table.tbl tbody tr:hover {
-    background: var(--color-surface-2);
+    background: var(--color-surface-overlay);
   }
   table.tbl td.right {
     text-align: right;
   }
   table.tbl td .pri {
     font-weight: 600;
-    color: var(--color-ink-2);
+    color: var(--color-x-ink-deep);
   }
   .tbl-diff {
     font-family: var(--font-mono);
     font-size: var(--text-2xs);
     color: var(--color-text-muted);
-    background: var(--color-sunk);
-    border: 1px solid var(--color-line);
+    background: var(--color-surface-sunken);
+    border: 1px solid var(--color-border);
     border-radius: var(--radius-sm);
     padding: 7px 9px;
     white-space: pre-wrap;
@@ -843,22 +843,22 @@
     color: var(--color-danger);
   }
   .badge-warning {
-    background: var(--color-warning-soft);
-    color: var(--color-warning);
+    background: var(--color-warn-soft);
+    color: var(--color-warn);
   }
   .badge-muted {
-    background: var(--color-sunk-2);
+    background: var(--color-x-sunk-deep);
     color: var(--color-text-muted);
   }
   .badge-brass {
-    background: var(--color-brass-soft);
-    color: var(--color-brass-deep);
+    background: var(--color-x-brass-soft);
+    color: var(--color-x-brass-deep);
   }
   .tag {
     display: inline-flex;
     border-radius: var(--radius-sm);
-    background: var(--color-surface-2);
-    border: 1px solid var(--color-line-2);
+    background: var(--color-surface-overlay);
+    border: 1px solid var(--color-x-line-mid);
     padding: 3px 9px;
     font-size: var(--text-2xs);
     color: var(--color-text-muted);
@@ -884,7 +884,7 @@
   }
   .dl dd {
     font-size: var(--text-sm);
-    color: var(--color-ink-2);
+    color: var(--color-x-ink-deep);
   }
   .dl .col2 {
     grid-column: span 2;
@@ -908,19 +908,19 @@
     stroke: currentColor;
   }
   .callout-warn {
-    background: var(--color-warning-soft);
-    border-color: var(--color-warning);
-    color: var(--color-warning-ink);
+    background: var(--color-warn-soft);
+    border-color: var(--color-warn);
+    color: var(--color-on-warn);
   }
   .callout-info {
-    background: var(--color-navy-soft);
-    border-color: var(--color-navy-line);
-    color: var(--color-navy-deep);
+    background: var(--color-accent-soft);
+    border-color: var(--color-x-navy-line);
+    color: var(--color-x-navy-deep);
   }
   .callout-danger {
     background: var(--color-danger-soft);
     border-color: var(--color-danger);
-    color: var(--color-danger-hover);
+    color: var(--color-x-danger-hover);
   }
 
   /* ---- pagination ---- */
@@ -929,15 +929,15 @@
     align-items: center;
     justify-content: space-between;
     padding: 12px 16px;
-    border-top: 1px solid var(--color-line);
+    border-top: 1px solid var(--color-border);
     font-size: var(--text-xs);
     color: var(--color-text-muted);
   }
 
   /* ---- stat tiles (home) ---- */
   .stat {
-    background: var(--color-surface);
-    border: 1px solid var(--color-line);
+    background: var(--color-surface-raised);
+    border: 1px solid var(--color-border);
     border-radius: var(--radius-md);
     padding: 18px 18px 16px;
     box-shadow: var(--shadow-sm);
@@ -951,7 +951,7 @@
     left: 0;
     width: 100%;
     height: 2px;
-    background: var(--color-brass);
+    background: var(--color-x-brass);
   }
   .stat .k {
     font-size: var(--text-2xs);
@@ -964,7 +964,7 @@
     font-family: var(--font-serif);
     font-size: 1.85rem;
     font-weight: 600;
-    color: var(--color-ink-2);
+    color: var(--color-x-ink-deep);
     margin-top: 8px;
     line-height: 1;
     font-variant-numeric: tabular-nums;
@@ -988,8 +988,8 @@
     align-items: center;
     gap: 14px;
     padding: 16px 18px;
-    background: var(--color-surface);
-    border: 1px solid var(--color-line);
+    background: var(--color-surface-raised);
+    border: 1px solid var(--color-border);
     border-radius: var(--radius-md);
     text-decoration: none;
     color: inherit;
@@ -1002,16 +1002,16 @@
     width: 100%;
   }
   .qlink:hover {
-    border-color: var(--color-line-strong);
-    background: var(--color-surface-2);
+    border-color: var(--color-border-strong);
+    background: var(--color-surface-overlay);
   }
   .qlink .ic {
     width: 38px;
     height: 38px;
     flex: none;
     border-radius: var(--radius-sm);
-    background: var(--color-navy-soft);
-    color: var(--color-navy);
+    background: var(--color-accent-soft);
+    color: var(--color-accent);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -1023,7 +1023,7 @@
   }
   .qlink b {
     display: block;
-    color: var(--color-ink-2);
+    color: var(--color-x-ink-deep);
     font-size: var(--text-body);
     font-weight: 600;
   }
@@ -1041,7 +1041,11 @@
     min-height: 100vh;
     display: flex;
     flex-direction: column;
-    background: radial-gradient(120% 80% at 50% -10%, oklch(95% 0.012 83) 0%, var(--color-bg) 60%);
+    background: radial-gradient(
+      120% 80% at 50% -10%,
+      oklch(95% 0.012 83) 0%,
+      var(--color-surface) 60%
+    );
   }
   .center-top {
     display: flex;
@@ -1052,8 +1056,8 @@
     margin: auto;
     width: 100%;
     max-width: 392px;
-    background: var(--color-surface);
-    border: 1px solid var(--color-line-2);
+    background: var(--color-surface-raised);
+    border: 1px solid var(--color-x-line-mid);
     border-radius: var(--radius-lg);
     box-shadow: var(--shadow-lg);
     overflow: hidden;
@@ -1063,7 +1067,7 @@
     text-align: center;
   }
   .center-card .head .brand-name {
-    color: var(--color-ink-2);
+    color: var(--color-x-ink-deep);
     font-size: 1.5rem;
   }
   .center-card .body {
@@ -1088,8 +1092,8 @@
     z-index: var(--z-modal);
   }
   .modal {
-    background: var(--color-surface);
-    border: 1px solid var(--color-line-2);
+    background: var(--color-surface-raised);
+    border: 1px solid var(--color-x-line-mid);
     border-radius: var(--radius-lg);
     box-shadow: var(--shadow-lg);
     width: 100%;
@@ -1106,7 +1110,7 @@
     gap: 10px;
     justify-content: space-between;
     padding: 17px 22px;
-    border-bottom: 1px solid var(--color-line);
+    border-bottom: 1px solid var(--color-border);
   }
   .modal-header h2 {
     font-size: var(--text-h2);
@@ -1126,8 +1130,8 @@
     border-radius: var(--radius-sm);
   }
   .modal-close:hover {
-    color: var(--color-ink-2);
-    background: var(--color-sunk);
+    color: var(--color-x-ink-deep);
+    background: var(--color-surface-sunken);
   }
   .modal-body {
     padding: 22px;
@@ -1137,8 +1141,8 @@
     justify-content: flex-end;
     gap: 10px;
     padding: 16px 22px;
-    border-top: 1px solid var(--color-line);
-    background: var(--color-surface-2);
+    border-top: 1px solid var(--color-border);
+    background: var(--color-surface-overlay);
   }
 
   /* ---- audit log: clickable rows + change summary ---- */
@@ -1146,7 +1150,7 @@
     cursor: pointer;
   }
   .audit-row:hover .row-chev {
-    color: var(--color-navy);
+    color: var(--color-accent);
     transform: translateX(2px);
   }
   .chg-sum {
@@ -1171,16 +1175,16 @@
   }
   .chg-kv .b {
     color: var(--color-text-faint);
-    background: var(--color-sunk);
-    border: 1px solid var(--color-line);
+    background: var(--color-surface-sunken);
+    border: 1px solid var(--color-border);
     border-radius: 3px;
     padding: 1px 6px;
     overflow-wrap: anywhere;
   }
   .chg-kv .a {
-    color: var(--color-brass-deep);
-    background: var(--color-brass-soft);
-    border: 1px solid var(--color-brass-line);
+    color: var(--color-x-brass-deep);
+    background: var(--color-x-brass-soft);
+    border: 1px solid var(--color-x-brass-line);
     border-radius: 3px;
     padding: 1px 6px;
     overflow-wrap: anywhere;
@@ -1263,8 +1267,8 @@
     right: 0;
     height: 100vh;
     width: min(540px, 94vw);
-    background: var(--color-surface);
-    border-left: 1px solid var(--color-line-2);
+    background: var(--color-surface-raised);
+    border-left: 1px solid var(--color-x-line-mid);
     box-shadow: var(--shadow-lg);
     z-index: 91;
     display: flex;
@@ -1281,7 +1285,7 @@
     gap: 12px;
     justify-content: space-between;
     padding: 18px 22px 16px;
-    border-bottom: 1px solid var(--color-line);
+    border-bottom: 1px solid var(--color-border);
   }
   .drawer-head .eyebrow {
     margin-bottom: 5px;
@@ -1305,8 +1309,8 @@
     flex: none;
   }
   .drawer-close:hover {
-    color: var(--color-ink-2);
-    background: var(--color-sunk);
+    color: var(--color-x-ink-deep);
+    background: var(--color-surface-sunken);
   }
   .drawer-body {
     overflow: auto;
@@ -1318,7 +1322,7 @@
     grid-template-columns: 1fr 1fr;
     gap: 13px 22px;
     padding-bottom: 18px;
-    border-bottom: 1px solid var(--color-line);
+    border-bottom: 1px solid var(--color-border);
     margin-bottom: 18px;
   }
   .drawer-meta .col2 {
@@ -1334,7 +1338,7 @@
   }
   .drawer-meta dd {
     font-size: var(--text-sm);
-    color: var(--color-ink-2);
+    color: var(--color-x-ink-deep);
   }
   .params-head {
     display: flex;
@@ -1352,10 +1356,10 @@
   }
   .seg {
     display: inline-flex;
-    border: 1px solid var(--color-line-2);
+    border: 1px solid var(--color-x-line-mid);
     border-radius: var(--radius-sm);
     overflow: hidden;
-    background: var(--color-surface);
+    background: var(--color-surface-raised);
   }
   .seg button {
     font: inherit;
@@ -1368,11 +1372,11 @@
     cursor: pointer;
   }
   .seg button + button {
-    border-left: 1px solid var(--color-line-2);
+    border-left: 1px solid var(--color-x-line-mid);
   }
   .seg button.is-on {
-    background: var(--color-navy);
-    color: var(--color-on-navy);
+    background: var(--color-accent);
+    color: var(--color-on-accent);
   }
   .diff-field + .diff-field {
     margin-top: 13px;
@@ -1380,7 +1384,7 @@
   .diff-key {
     font-family: var(--font-mono);
     font-size: var(--text-xs);
-    color: var(--color-ink-2);
+    color: var(--color-x-ink-deep);
     font-weight: 500;
     margin-bottom: 7px;
     display: flex;
@@ -1401,8 +1405,8 @@
     color: var(--color-success);
   }
   .tag-chg.mod {
-    background: var(--color-brass-soft);
-    color: var(--color-brass-deep);
+    background: var(--color-x-brass-soft);
+    color: var(--color-x-brass-deep);
   }
   .diff-pair {
     display: grid;
@@ -1420,14 +1424,14 @@
     white-space: pre-wrap;
   }
   .diff-before {
-    background: var(--color-sunk);
-    border: 1px solid var(--color-line);
+    background: var(--color-surface-sunken);
+    border: 1px solid var(--color-border);
     color: var(--color-text-muted);
   }
   .diff-after {
-    background: var(--color-brass-soft);
-    border: 1px solid var(--color-brass-line);
-    color: var(--color-brass-deep);
+    background: var(--color-x-brass-soft);
+    border: 1px solid var(--color-x-brass-line);
+    color: var(--color-x-brass-deep);
   }
   .diff-arrow {
     display: flex;
@@ -1446,8 +1450,8 @@
   .diff-empty {
     font-size: var(--text-sm);
     color: var(--color-text-muted);
-    background: var(--color-surface-2);
-    border: 1px dashed var(--color-line-2);
+    background: var(--color-surface-overlay);
+    border: 1px dashed var(--color-x-line-mid);
     border-radius: var(--radius-md);
     padding: 16px;
     text-align: center;
@@ -1467,13 +1471,13 @@
     font-family: var(--font-mono);
     font-size: var(--text-2xs);
     line-height: 1.6;
-    background: var(--color-sunk);
-    border: 1px solid var(--color-line);
+    background: var(--color-surface-sunken);
+    border: 1px solid var(--color-border);
     border-radius: var(--radius-sm);
     padding: 12px 13px;
     white-space: pre;
     overflow-x: auto;
-    color: var(--color-text);
+    color: var(--color-text-primary);
   }
 }
 
@@ -1516,7 +1520,7 @@
   .rail-group::before {
     content: '·';
     font-size: 11px;
-    color: var(--color-rail-faint);
+    color: var(--color-x-rail-faint);
     letter-spacing: 0;
   }
   .rail-link {
@@ -1589,7 +1593,7 @@
     flex-direction: row;
     align-items: stretch;
     border-right: 0;
-    border-top: 1px solid var(--color-rail-line);
+    border-top: 1px solid var(--color-x-rail-line);
     box-shadow: 0 -6px 20px oklch(25% 0.02 256 / 16%);
     z-index: 60;
     padding-bottom: env(safe-area-inset-bottom, 0);
@@ -1621,13 +1625,13 @@
     align-items: center;
     justify-content: center;
     color: var(--color-text-muted);
-    background: var(--color-surface);
-    border: 1px solid var(--color-line-2);
+    background: var(--color-surface-raised);
+    border: 1px solid var(--color-x-line-mid);
     border-radius: var(--radius-sm);
   }
   .rail-foot .out:hover {
-    background: var(--color-sunk);
-    color: var(--color-ink-2);
+    background: var(--color-surface-sunken);
+    color: var(--color-x-ink-deep);
   }
   .rail-foot .out svg {
     width: 17px;
@@ -1656,7 +1660,7 @@
     line-height: 1;
     white-space: nowrap;
     text-align: center;
-    color: var(--color-rail-faint);
+    color: var(--color-x-rail-faint);
     overflow: hidden;
   }
   .rail-link svg {
@@ -1666,7 +1670,7 @@
   }
   .rail-link:hover {
     background: transparent;
-    color: var(--color-rail-text);
+    color: var(--color-x-rail-text);
   }
   .rail-link.is-active {
     background: transparent;
@@ -1814,7 +1818,7 @@
   .tbl.tbl-cards tr {
     display: block;
     padding: 14px 16px;
-    border-bottom: 1px solid var(--color-line);
+    border-bottom: 1px solid var(--color-border);
   }
   .tbl.tbl-cards tr:last-child {
     border-bottom: 0;
@@ -1847,10 +1851,10 @@
     text-align: left;
     font-size: var(--text-body);
     font-weight: 600;
-    color: var(--color-ink-2);
+    color: var(--color-x-ink-deep);
     padding: 0 0 8px;
     margin-bottom: 6px;
-    border-bottom: 1px solid var(--color-line);
+    border-bottom: 1px solid var(--color-border);
   }
   .tbl.tbl-cards td.cell-title::before {
     display: none;
@@ -1869,7 +1873,7 @@
     height: auto;
     max-height: 90vh;
     border-left: 0;
-    border-top: 1px solid var(--color-line-2);
+    border-top: 1px solid var(--color-x-line-mid);
     border-radius: 14px 14px 0 0;
     transform: translateY(100%);
   }
@@ -1889,7 +1893,7 @@
     width: 38px;
     height: 4px;
     border-radius: 999px;
-    background: var(--color-line-2);
+    background: var(--color-x-line-mid);
   }
   .drawer-close {
     width: 40px;
@@ -1936,13 +1940,13 @@
     flex-direction: column;
     position: relative;
     padding: 15px 44px 15px 16px;
-    border-bottom: 1px solid var(--color-line);
+    border-bottom: 1px solid var(--color-border);
   }
   .audit-row:hover {
     background: transparent;
   }
   .audit-row:active {
-    background: var(--color-surface-2);
+    background: var(--color-surface-overlay);
   }
   .audit-row td {
     display: block;


### PR DESCRIPTION
Closes #206

## 目的

フロント統一規約 **W1**（05 §9.2）。nene-vault の手書き色語彙を **Core Token Contract v1** の語彙へ rename する。**名前の付け替えのみ**（値・レイアウト・FSD 構造は不変）。payout #159 / suite #381 と同型。

## codemod 名と version（M-1）

- 写像の正本: **`@hideyukimori/nene2-tokens@1.0.0`** 同梱の凍結・hide 承認済み **`VAULT_TABLE`（40 行）**（`CODEMOD_MAP_V1.tables.vault`・`CODEMOD_MAP_VERSION = 1.0.0`）。
- 適用: **表を literal 適用**する PR 同梱スクリプト `frontend/scripts/w1-token-vocab-codemod.mjs`（表を verbatim スナップショット・`--check` 検証モード・単一パス＋負の先読みで冪等）。**手動編集は非混載**（唯一の非トークン変更は prettier が長い契約名で `radial-gradient(...)` 1 箇所を再折返した決定的整形のみ＝suite #381 と同型）。

### なぜ CLI（extract→generate）ではなくスクリプトか（正直な開示）

1. **(B-1) vault の `themes/default.css` は token-only ではない** — `@theme` + `@layer base` + `@layer components`（DS クラス群）を同居させた ~2000 行の完全スタイルシート。`nene2-tokens` の parser は token-only 文法専用のため extract/generate/validate が **全 fail-closed**（`unexpected block '@layer base'`）。→ **hideyukiMORI/nene2-fleet-tooling#26**
2. **(B-2) `mapTokenName` の contract 短絡が表の `surface→surface-raised` を握り潰す** — vault の `--color-surface`（カード面）自体が契約名なので短絡し、`bg→surface` と **同一 `--color-surface` へ衝突**（`extractTheme` は fail-closed で throw／raw rename では page 地の見た目が変わる回帰）。→ **hideyukiMORI/nene2-fleet-tooling#25**（suite#23 / origin#24 と同族）

**VAULT_TABLE を literal 適用**すると表の宣言意図どおり `surface→surface-raised`（40/40 忠実）・**全 40 target が distinct** なので衝突せず・見た目不変。これが本 PR の方式。修正版 nene2-tokens（#25 の precedence 修正）が出たらスクリプトからそちらへ寄せる。

## スコープ（本 stage）

**契約色語彙（40 行表）のみ**。非色トークン（typography / radius / spacing / rail-width / z / content / topbar-height）の x- 送りは **本 stage 対象外**: vault は Tailwind v4 で、機械的 x- 送りが TW v4 namespace 意味論を保存しない **fleet-tooling#17 が未解決**のため（PR-C 相当の known-utility 配線を #21/#22 待ちで見送るのと同じ規律）。非色トークンは現状維持。

## 置換実測（契約名 / x- 別）

- **CSS（`themes/default.css`）: 189 occurrence / 34 token 名**
  - **契約名 rename: 14 名 / 93 occ** — 例 `--color-bg→surface`・`--color-surface→surface-raised`・`--color-sunk→surface-sunken`・`--color-line→border`・`--color-line-strong→border-strong`・`--color-navy→accent`(+hover/soft)・`--color-on-navy→on-accent`・`--color-text→text-primary`・`--color-warning→warn`(+soft)・`--color-warning-ink→on-warn`
  - **x- 送り: 20 名 / 96 occ** — `brass*→x-brass*`・`seal*→x-seal*`・`rail*→x-rail*`・`ink/ink-2→x-ink/x-ink-deep`・`line-2→x-line-mid`・`navy-deep/navy-line→x-navy-*`・`sunk-2→x-sunk-deep`・`danger-hover→x-danger-hover`・`on-brass→x-on-brass`
  - 恒等（不変）6 名: `text-muted`・`text-faint`・`success`・`success-soft`・`danger`・`danger-soft`
- **TSX 色ユーティリティ: 11 / 6 ファイル** — `text-seal→text-x-seal`×5・`text-seal-bright→text-x-seal-bright`×3・`text-brass→text-x-brass`×1・`bg-rail→bg-x-rail`×1・`bg-surface→bg-surface-raised`×1
- **取り残し 0**: `node scripts/w1-token-vocab-codemod.mjs --check` → `REMAINING legacy refs: 0`（exit 0）。全 `--color-*` が有効 target であることも機械確認（distinct 40）。

## 見た目の不変（emit 差分の根拠）

`vite build` の生成 CSS を before/after 突合（payout #159 と同手法）:

- **値不変**: 出力の `--color-*` 定義 **39 件すべて、rename 後キーの下で before と同値**（value mismatch **0**）。色の出所である @theme トークン表が名前だけ変わり値は同一。
- **セレクタ 1:1 rename**: 生成ユーティリティのセレクタ集合に **newly-dead 0**。**newly-live は `.text-text-primary` の 1 件のみ** — これは `root-error-boundary.tsx` に元々あった**契約名先取りの dead class**（旧テーマに `--color-text-primary` が無く silent no-op だった）。codemod で `--color-text→text-primary` が定義されて live 化するが、当該要素は `body { color: var(--color-text) }`（= 同 31% 値）を継承していたため **描画色は同一**（見た目不変）。同ファイルの `bg-surface→bg-surface-raised` も同値（99.4%）に追従。
- 面の swap（`bg→surface` / `surface→surface-raised`）は @theme 定義で `--color-surface: 97.2%`（旧 bg）・`--color-surface-raised: 99.4%`（旧 card）と**値保存**を実測確認。

## 受け入れゲート実測

- `npm run check`（type-check / eslint `--max-warnings 0` / prettier `--check` / vitest / knip / build-storybook）: **緑**（**Test Files 38 / Tests 221 passed**・storybook build OK・vite build OK）。
- **故意 fail 確認**: 適用済みツリーに legacy `var(--color-navy)` を再注入 → `--check` 相当の leftover-scan が `["navy"]` を検出し **exit 1**、revert で **exit 0**。検証は空虚合格ではない。
- **冪等性**: 適用済みツリーで `apply` を再実行 → `already applied (idempotent no-op)` exit 0（bg/surface swap の二重適用を legacy 検出ゲートで回避）。

## validate:themes について（未実施・正直な開示）

W1 の受け入れゲート「`validate:themes` 緑」は **vault では到達不能**（B-1 — 単一ファイル・テーマを validate が構造 error で全 fail-closed）。よって本ゲートは**未実施**として明記し、代替に上記 emit 差分＋`npm run check`＋`--check` leftover-scan で健全性を担保した。恒久解は fleet-tooling#26。

## 是正（PR-B）

`REMEDIATION_V1`（`@hideyukimori/nene2-tokens@1.0.0`）に **nene-vault 分は 0 件**（grep 確認済み・payout/records のみ）。よって **PR-B はなし**。

## known-utility 配線（PR-C 相当）

**今回やらない**。standards 1.0.1 の publish 待ち（fleet #21/#22 の entryPoint 修正が未配布）— payout #161 と同じ轍を避ける。

## 実弾テストで見つけた道具の穴（fleet-tooling へ起票）

- **hideyukiMORI/nene2-fleet-tooling#25** — `mapTokenName` の contract 短絡が個別表 `surface→surface-raised` を握り潰し `bg→surface` と衝突（suite#23 / origin#24 と同族の vault 実例・`surface→surface-raised` は未テストの盲点）。
- **hideyukiMORI/nene2-fleet-tooling#26** — 単一ファイル・テーマ（`@theme` + `@layer base/components` 同居）を extract/generate/validate が扱えず全 fail-closed（W1 の validate:themes ゲートが vault で到達不能）。
- 既知の関連: #15（jscodeshift ランナー未同梱・M-1 純度が構造的に満たせない）・#17（機械 x- 送りが TW v4 namespace を保存しない＝本 PR で非色 x- 送りを見送った根拠）。

## M-1 純度の注記

CSS/TSX の rename は「versioned codemod（CLI）の出力」ではなく「（B-1/B-2 により CLI 経路が不成立につき）**凍結 VAULT_TABLE を verbatim 適用する PR 同梱スクリプトの出力**」。手動編集は非混載（全 hunk が機械置換＋prettier 決定的整形）。字面を厳格に取るなら nene2-tokens 側の #25/#26 修正を待つ判断もあり得る — 施主判断に委ねる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
