### PR TITLE
chore(standards): auth-store exemplar アンカーを植栽

### DIFF
--- a/frontend/src/entities/auth/model.ts
+++ b/frontend/src/entities/auth/model.ts
@@ -23,6 +23,7 @@ function notify(): void {
   }
 }
 
+// [nene2-exemplar:auth-store] — fleet frontend-standards AU-4 module-store exemplar (check:exemplars).
 export const authStore = {
   /** Subscribe to session changes; returns the unsubscribe function. */
   subscribe(listener: () => void): () => void {


### PR DESCRIPTION
## 目的

`nene2-fleet-tooling` の `check:exemplars`（RAT-3(a)）green 化のための **exemplar アンカー植栽**。規約文書 02-data-flow AU-4 / CS-2 / ER-5・01-architecture が指す

`[X:nene-vault/frontend/src/entities/auth/model.ts#nene2-exemplar:auth-store]`

を実ファイル側のアンカーコメントと突合させる。

## 変更

- `frontend/src/entities/auth/model.ts` の `export const authStore` 直前に `// [nene2-exemplar:auth-store] ...` の**コメント1行のみ**を追加。ロジック・型は不変。

## 検品（exemplar 実体確認）

- 規約 AU-4 は「認証状態は `useSyncExternalStore` の module store・store 本体を別ファイル（`store-instance.ts` 等）へ分離すること MUST NOT」。本ファイルは `authStore`（subscribe/notify + getSession/setSession/clearSession/getToken）を **model.ts に一体保持**（分離なし）し、`app/auth-gate.tsx` が `useSyncExternalStore(subscribe, getToken)` で消費する。規約が「vault exemplar の現物形」と明記する対象と**一致**。

## マージ方針

- **マージ禁止**（施主承認待ち）。fleet-tooling 批准 wave とあわせて扱う。

🤖 Generated with [Claude Code](https://claude.com/claude-code)