### PR TITLE
refactor(frontend): テーマ components の layer 二重指定を解消する (#213)

### DIFF
--- a/frontend/src/shared/ui/theme/index.css
+++ b/frontend/src/shared/ui/theme/index.css
@@ -1,12 +1,12 @@
 @layer theme, base, vendor, legacy, components, utilities;
 @import 'tailwindcss';
 @import './active.css';
-/* NOTE: intentionally imported WITHOUT `layer(base)`, deviating from the ST-06
-   reference form. base.css already wraps its rules in `@layer base { … }` — which
-   is what `[S:no-unlayered-css]` requires. Adding `layer(base)` on top of that
-   nests them as sub-layer `base.base`, and a sub-layer LOSES to rules sitting
-   directly in `base` — i.e. Tailwind's preflight. Measured in Chromium: with
-   `layer(base)` the preflight `h1..h6{font-weight:inherit}` beats vault's
-   `h1,h2,h3{font-weight:600}` and headings silently lose their weight.
-   See the PR body for the proposed ST-06 correction. */
+/* NOTE: imported WITHOUT `layer(base)` — this is the canonical form, not a
+   deviation. base.css already wraps its rules in `@layer base { … }`, and layer
+   membership must be declared exactly once: either on the `@import` or inside
+   the file, never both. Adding `layer(base)` on top of the file's own wrapper
+   nests the rules as sub-layer `base.base`, and a sub-layer LOSES to rules
+   sitting directly in `base` — i.e. Tailwind's preflight. Measured in Chromium:
+   with `layer(base)` the preflight `h1..h6{font-weight:inherit}` beats vault's
+   `h1,h2,h3{font-weight:600}` and headings silently lose their weight. */
 @import './base.css';

--- a/frontend/src/shared/ui/theme/themes/default.components.css
+++ b/frontend/src/shared/ui/theme/themes/default.components.css
@@ -1,6 +1,7 @@
 /* ============================================================
    NeNe Vault — "Strongbox" theme — component classes
-   Paired with `default.css`; imported from it under layer(components).
+   Paired with `default.css`, which imports this file. The `@layer components`
+   wrapper below is this file's own — the import side must not restate it.
    All raw values resolve to the theme tokens in `default.css`.
 
    Sub-layer order (`main` then `responsive`) reproduces the pre-split

--- a/frontend/src/shared/ui/theme/themes/default.css
+++ b/frontend/src/shared/ui/theme/themes/default.css
@@ -11,7 +11,12 @@
    single component.
    ============================================================ */
 
-@import './default.components.css' layer(components);
+/* NOTE: imported WITHOUT `layer(components)` — default.components.css already
+   wraps its rules in `@layer components { … }`. Adding `layer(components)` on
+   top of that nests them as sub-layer `components.components`, which loses to
+   any rule sitting directly in `components` regardless of specificity. Same
+   trap, and same reasoning, as the `layer(base)` note in `../index.css`. */
+@import './default.components.css';
 
 @theme {
   /* ---- paper / surfaces — warm, never sterile white ---- */

--- a/frontend/src/shared/ui/theme/themes/default.css
+++ b/frontend/src/shared/ui/theme/themes/default.css
@@ -12,10 +12,12 @@
    ============================================================ */
 
 /* NOTE: imported WITHOUT `layer(components)` — default.components.css already
-   wraps its rules in `@layer components { … }`. Adding `layer(components)` on
-   top of that nests them as sub-layer `components.components`, which loses to
-   any rule sitting directly in `components` regardless of specificity. Same
-   trap, and same reasoning, as the `layer(base)` note in `../index.css`. */
+   wraps its rules in `@layer components { … }`, and layer membership must be
+   declared exactly once: either on the `@import` or inside the file, never
+   both. Stating it on both nests the rules as sub-layer `components.components`,
+   which loses to any rule sitting directly in `components` regardless of
+   specificity. Same trap, same reasoning, and same fix as the `layer(base)`
+   note in `../index.css`. */
 @import './default.components.css';
 
 @theme {


### PR DESCRIPTION
Closes #213

## 変更

`frontend/src/shared/ui/theme/themes/default.css:14` の import から `layer(components)` を外す。

```diff
-@import './default.components.css' layer(components);
+@import './default.components.css';
```

`default.components.css` は**中身が自分で** `@layer components { @layer main, responsive; … }` と
ラップしている（同ファイル :14-15）ので、import 側の指定は二重。

## これは規約 03:192 の一般則そのもの（裁量ではなく準拠）

`03-styling-theming.md:192` の**一般則（2026-07-15 追加）** `[S:no-double-layer-import]`:

> レイヤ指定は「`@import` の `layer()`」か「ファイル内の `@layer`」の**どちらか一方だけ**。
> 両方書くと sub-layer に落ち、親レイヤ直下の規則に**特異度と無関係に負ける**。

同条の表は、**このファイルの形を名指しで規定している**:

| ファイル | ファイル内に `@layer` があるか | 正しい `@import` の形 |
|---|---|---|
| `base.css`（ST-08） | ある | `@import './base.css';`（**layer() なし**） |
| **`themes/*.components.css`（TH-02/TH-03）** | **ある（全ルール `@layer components` 内 — AM-9）** | **`@import './<name>.components.css';`（layer() なし）** |
| `components/<群>.css`（ST-04） | ある | `@import './components/<群>.css';`（**layer() なし**） |
| vendor CSS（ST-07(b)） | ない（第三者 CSS） | `@import url(…) layer(vendor);`（**layer() が必須**） |

この PR は表の2行目に合わせるだけ。

## 実測 1 — 直す前は本当に二重だったか

`origin/main`（`5aa5577`）の `npm run build` 出力 CSS のバイト列:

```
@layer vendor,legacy;@layer components{@layer components{@layer main{.muted{…
                     ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^
                     import 側の layer() ファイル自身のラップ
```

＝実カスケード経路は `components.components.main` / `components.components.responsive`。

## 実測 2 — 意匠が変わらないこと（「はず」で終わらせていない）

修正前後でビルド出力 CSS を取り、`{`/`}` で改行正規化して全行 diff:

```
$ diff norm-baseline.txt norm-after.txt
127d126
< @layer components{
758d756
< }
```

**差分は厳密にこの2行のみ**（余分なラッパの開きと閉じ）。**宣言は1バイトも動いていない**
（41,234 → 41,215 バイト＝差 19 バイト＝ `@layer components{` + `}` の長さと一致）。
修正後のレイヤ経路は `components.main` / `components.responsive`。

コメント修正コミット（`0e15d59`）を足した後も、ビルド出力は `3becdff` 時点と**バイト単位で同一**を確認済み。

## なぜ直すか（現状は実害ゼロなのに）

**サブレイヤはルート `components` 直下の規則に、特異度と無関係に負ける。**
現状はルート `components` 直下が空（Tailwind v4 は `components` を宣言するが中身を置かない）ため
**実害は出ていない**。だが、ルート `components` に1行でも入った瞬間、
vault のコンポーネント CSS 1,868行が**丸ごと静かに負ける**。

## 2つ目のコミット: コメントを現行条文に合わせる（`0e15d59`）

`index.css:4-11` のコメントは
「**deviating from the ST-06 reference form**」「See the PR body for the **proposed** ST-06 correction」
と書いていたが、**その correction は 2026-07-15 に規約へ着地済み**で、vault の形は
**もはや逸脱ではなく canonical そのもの**:

- `03:182`「**`base.css` の `@import` に `layer(base)` を付けてはならない**」`[C]`
- `03:189` の表には **vault の Chromium 実測がそのまま採録**され、
  「PR nene-vault#212 が先行してこの形で実装済み」と明記されている

現行コメントは未来の読み手に「vault は規約から外れている」と誤読させ、もう存在しない提案へ誘導する。
放置すると `layer(base)` へ「直し戻す」誘因になり、それは `03:182` が `[C]` で禁じ、
実測が preflight 負け（`h3` の font-weight 600 → 400）を示した形そのもの。

**コメントのみ・ビルド出力 CSS はバイト単位で不変**（実測確認済み）。
1件目と同一論点（03:192 の一般則）につき同 PR に同乗させた。**分離が望ましければ言ってください、切り出します。**

## fleet-tooling の lint との関係（対の PR・順序は2人で合意済み）

fleet-tooling の `no-double-layer-import` lint（`bcb65c3`）の検出対象がこの1行。

- **順序: vault 先（この PR）→ lint 後**で fleet-tooling リナと合意済み。
  逆だと lint が `error` で着地した瞬間 `origin/main` が red になり、この PR が入るまで main が壊れたままになる。
- この PR が先に入れば、lint を**最初から `error`** で入れられる（`warning` 先行の妥協が不要）。
  `warning` 先行は「後で error に上げ忘れる＝恒久偽 green」を生む型で、会議が KU-1 で名指しして警戒したもの。
- fleet-tooling リナの横断実測（`origin/main` 全リポ）では、**実プロダクトの違反はこの1行だけ**。
  他の1件は fleet-tooling 自身のテスト fixture で `bcb65c3` が同梱修正済み。
- lint は「import 側に `layer()` があるか」だけを見るので、`index.css` の
  layer() を付けない import 群（base.css 等）は**無傷**。
- なお `[S:no-double-layer-import]` は規約が `03:192`・`468`・`747` の**3箇所でタグとして参照済み**なのに
  配布 config にルールが無い（`check:standards-doc` が `status: "missing"` を検出）。
  `bcb65c3` がそれを解消する。

## 受け入れ条件

- [x] `npm run check --prefix frontend` green（**exit 0**: type-check / lint `--max-warnings 0` / prettier / test 221件38ファイル / knip / storybook build）— 2コミット両方で確認
- [x] 意匠が変わらないことを実測（上記「実測 2」）
- [x] `git diff origin/main` 全数目視・NUL バイト混入なしを確認
  （07-15 に NUL 混入が tsc/eslint/prettier/vitest を全通過した実例があるため）

## 出典

統合リナ指示書 `_work/handoff-vault-double-layer-2026-07-16-work-order.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## この PR の正しさを、いま機械で証明する手段は vault に存在しない

レビュアーへの申し送り。**なぜ linter を回さずビルド出力のバイト diff で検証したのか**の説明です。

- **vault には stylelint も dependency-cruiser も存在しません**（`origin/main` `5aa5577` 実測: リポ全体に stylelint 名のファイル 0件・ルート/frontend どちらの `package.json` にも依存もキーも無し）。
  つまり `[S:no-double-layer-import]` を含む `[S:…]` 系のタグは、**vault では現在そもそも実行できません**。
- `composer check` の `@conformance` は NENE2 の PHP ツール（`vendor/hideyukimori/nene2/tools/conformance.php`）で、**これとは別物**です
  （実行結果: `Conformance OK — no error findings (15 suppressed by baseline/ignore)`）。
- fleet-tooling の lint が npm パッケージへ着地しても、**それだけでは vault は守られません**。
  vault が機械で守れるようになるのは **W0b のゲート導入 PR（stylelint 導入＋config 合成＋`init --scan`）が入ってから**です。
  必要条件ではあるが十分条件ではない、という切り分けは fleet-tooling リナの指摘によります。
- したがって **本 PR の「実測 2」（ビルド出力 CSS のバイト単位 diff）は暫定の代替ではなく、現時点で唯一の証拠**です。

なお、未配線を green と偽る設計にはなっていません（fleet の conformance は未配線キーを
`unknown(not-installed)` として出す — G-6「検査が実行できない状態は green ではなく unknown」）。
「stylelint が無い＝違反 0＝green」にはなっていない、という報告を fleet-tooling リナから受けています
（※こちらは彼の実測であり、あたし自身は測っていません）。
