### PR TITLE
fix(openapi): レスポンス契約の required を実装の実態に合わせる (#215)

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -889,7 +889,7 @@ components:
 
     LoginResponse:
       type: object
-      required: [token, expires_at, user_id, email, role]
+      required: [token, expires_at, user_id, email, role, org_id]
       properties:
         token:
           type: string
@@ -991,7 +991,7 @@ components:
 
     UserResponse:
       type: object
-      required: [id, email, role, status]
+      required: [id, email, role, organization_id, status, created_at, updated_at]
       properties:
         id:
           type: integer
@@ -1054,7 +1054,7 @@ components:
 
     VaultSettingsResponse:
       type: object
-      required: [organization_id, retention_years]
+      required: [organization_id, retention_years, storage_path_override, invoice_api_base_url, clear_api_base_url, updated_at]
       properties:
         organization_id:
           type: integer
@@ -1105,12 +1105,26 @@ components:
         - id
         - organization_id
         - status
+        - transaction_date
+        - amount_cents
         - counterparty_name
         - category
+        - tags
         - file_sha256
+        - mime_type
+        - original_filename
+        - file_size_bytes
         - version_number
         - source
         - uploaded_at
+        - uploaded_by
+        - voided_at
+        - voided_by
+        - void_reason
+        - date_uncertain
+        - is_metadata_confirmed
+        - retention_years
+        - retention_expires_at
       properties:
         id:
           type: string
@@ -1243,7 +1257,7 @@ components:
 
     DocumentVersionResponse:
       type: object
-      required: [id, version_number, file_sha256, mime_type, original_filename, source, uploaded_at]
+      required: [id, version_number, file_sha256, mime_type, original_filename, file_size_bytes, source, uploaded_at, uploaded_by]
       properties:
         id:
           type: string
@@ -1281,7 +1295,7 @@ components:
 
     AuditEventResponse:
       type: object
-      required: [id, action, entity_type, entity_id, created_at]
+      required: [id, action, entity_type, entity_id, actor_user_id, organization_id, before_json, after_json, source, metadata_json, created_at]
       properties:
         id:
           type: integer

--- a/frontend/src/shared/api/generated/schema.gen.ts
+++ b/frontend/src/shared/api/generated/schema.gen.ts
@@ -362,13 +362,70 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/admin/vault/documents/{id}/ocr-suggest": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Resource ID. */
+                id: components["parameters"]["IdPath"];
+            };
+            cookie?: never;
+        };
+        /**
+         * OCR metadata suggestion
+         * @description Runs OCR on the current version of a document and returns suggested metadata (取引年月日, 取引金額, 取引先名). Suggestions are never applied automatically — the operator confirms via the metadata edit form. Requires `NENE_VAULT_OCR_ENABLED=true` and Tesseract installed on the server. Returns 422 if OCR fails (Tesseract not found, unreadable file, etc.).
+         */
+        get: operations["ocrSuggestDocument"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/vault/export": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Export documents
+         * @description Exports matched documents as a manifest CSV (`format: csv`, default) or a ZIP archive containing `manifest.csv` plus every matched document file (`format: zip`). Requires `ExportDocuments` capability (admin / member). Every exported document is recorded in the audit log.
+         */
+        post: operations["exportDocuments"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
         HealthResponse: {
-            /** @example ok */
+            /**
+             * @description `ok`, or `degraded` when any dependency check fails.
+             * @example ok
+             */
             status: string;
+            /** @example NENE2 */
+            service?: string;
+            /**
+             * @description Dependency-level health checks (`ok` / `error`) per check name.
+             * @example {
+             *       "database": "ok"
+             *     }
+             */
+            checks?: {
+                [key: string]: string;
+            };
         };
         LoginRequest: {
             /** Format: email */
@@ -384,7 +441,7 @@ export interface components {
             email: string;
             role: components["schemas"]["Role"];
             /** @description Organization ID; null for superadmin. */
-            org_id?: number | null;
+            org_id: number | null;
         };
         /** @enum {string} */
         Role: "superadmin" | "admin" | "member" | "viewer";
@@ -430,13 +487,13 @@ export interface components {
             /** Format: email */
             email: string;
             role: components["schemas"]["Role"];
-            organization_id?: number | null;
+            organization_id: number | null;
             /** @enum {string} */
             status: "active" | "invited";
             /** Format: date-time */
-            created_at?: string;
+            created_at: string;
             /** Format: date-time */
-            updated_at?: string;
+            updated_at: string;
         };
         UserListResponse: {
             items: components["schemas"]["UserResponse"][];
@@ -460,11 +517,11 @@ export interface components {
         VaultSettingsResponse: {
             organization_id: number;
             retention_years: number;
-            storage_path_override?: string | null;
-            invoice_api_base_url?: string | null;
-            clear_api_base_url?: string | null;
+            storage_path_override: string | null;
+            invoice_api_base_url: string | null;
+            clear_api_base_url: string | null;
             /** Format: date-time */
-            updated_at?: string | null;
+            updated_at: string | null;
         };
         UpdateVaultSettingsRequest: {
             /** @description Years to retain (from transaction date). Default 10; below 10 warns. See ADR 0004. */
@@ -487,32 +544,32 @@ export interface components {
              * Format: date
              * @description 取引年月日.
              */
-            transaction_date?: string | null;
+            transaction_date: string | null;
             /** @description 取引金額 in integer JPY. Null when the document carries no amount. */
-            amount_cents?: number | null;
+            amount_cents: number | null;
             /** @description 取引先名. */
             counterparty_name: string;
             category: components["schemas"]["DocumentCategory"];
-            tags?: string[];
+            tags: string[];
             file_sha256: string;
             /** @enum {string} */
-            mime_type?: "application/pdf" | "image/jpeg" | "image/png";
-            original_filename?: string;
-            file_size_bytes?: number;
+            mime_type: "application/pdf" | "image/jpeg" | "image/png";
+            original_filename: string;
+            file_size_bytes: number;
             version_number: number;
             source: components["schemas"]["DocumentSource"];
             /** Format: date-time */
             uploaded_at: string;
-            uploaded_by?: number | null;
+            uploaded_by: number | null;
             /** Format: date-time */
-            voided_at?: string | null;
-            voided_by?: number | null;
-            void_reason?: string | null;
-            date_uncertain?: boolean;
-            is_metadata_confirmed?: boolean;
-            retention_years?: number;
+            voided_at: string | null;
+            voided_by: number | null;
+            void_reason: string | null;
+            date_uncertain: boolean;
+            is_metadata_confirmed: boolean;
+            retention_years: number;
             /** Format: date */
-            retention_expires_at?: string;
+            retention_expires_at: string;
         };
         VaultDocumentListResponse: {
             items: components["schemas"]["VaultDocumentResponse"][];
@@ -564,11 +621,11 @@ export interface components {
             file_sha256: string;
             mime_type: string;
             original_filename: string;
-            file_size_bytes?: number;
+            file_size_bytes: number;
             source: components["schemas"]["DocumentSource"];
             /** Format: date-time */
             uploaded_at: string;
-            uploaded_by?: number | null;
+            uploaded_by: number | null;
         };
         DocumentHistoryResponse: {
             versions: components["schemas"]["DocumentVersionResponse"][];
@@ -579,16 +636,16 @@ export interface components {
             action: string;
             entity_type: string;
             entity_id: string;
-            actor_user_id?: number | null;
-            organization_id?: number | null;
-            before_json?: {
+            actor_user_id: number | null;
+            organization_id: number | null;
+            before_json: {
                 [key: string]: unknown;
             } | null;
-            after_json?: {
+            after_json: {
                 [key: string]: unknown;
             } | null;
-            source?: string;
-            metadata_json?: {
+            source: string;
+            metadata_json: {
                 [key: string]: unknown;
             } | null;
             /** Format: date-time */
@@ -600,7 +657,22 @@ export interface components {
             limit: number;
             offset: number;
         };
+        OcrSuggestionResponse: {
+            document_id: string;
+            /** Format: date */
+            transaction_date: string | null;
+            amount_cents: number | null;
+            counterparty_name: string | null;
+            /** @description True if at least one field was extracted by OCR. */
+            has_suggestion: boolean;
+        };
         ExportDocumentsRequest: {
+            /**
+             * @description `csv` — manifest CSV only (default). `zip` — ZIP archive with `manifest.csv` + all matched document files.
+             * @default csv
+             * @enum {string}
+             */
+            format: "csv" | "zip";
             /** Format: date */
             transaction_date_from?: string;
             /** Format: date */
@@ -784,6 +856,23 @@ export interface components {
                 "application/problem+json": components["schemas"]["ProblemDetails"];
             };
         };
+        /** @description Too many failed login attempts for this account/IP; retry after the indicated delay. */
+        TooManyLoginAttempts: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                /**
+                 * @example {
+                 *       "type": "https://nene-vault.dev/problems/too-many-login-attempts",
+                 *       "title": "Too Many Login Attempts",
+                 *       "status": 429,
+                 *       "retry_after_seconds": 900
+                 *     }
+                 */
+                "application/problem+json": components["schemas"]["ProblemDetails"];
+            };
+        };
         /** @description Request body failed validation. */
         ValidationFailed: {
             headers: {
@@ -889,6 +978,7 @@ export interface operations {
             };
             401: components["responses"]["InvalidCredentials"];
             422: components["responses"]["ValidationFailed"];
+            429: components["responses"]["TooManyLoginAttempts"];
         };
     };
     listOrganizations: {
@@ -1391,6 +1481,15 @@ export interface operations {
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];
             404: components["responses"]["DocumentNotFound"];
+            /** @description Document is not active (already voided). */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemDetails"];
+                };
+            };
             422: components["responses"]["ValidationFailed"];
         };
     };
@@ -1418,6 +1517,15 @@ export interface operations {
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];
             404: components["responses"]["DocumentNotFound"];
+            /** @description Document is not voided (already active). */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemDetails"];
+                };
+            };
         };
     };
     getDocumentHistory: {
@@ -1501,6 +1609,68 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AuditEventListResponse"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+        };
+    };
+    ocrSuggestDocument: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Resource ID. */
+                id: components["parameters"]["IdPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OCR suggestion (fields may be null if not detected). */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OcrSuggestionResponse"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["DocumentNotFound"];
+            /** @description OCR failed (Tesseract error or unsupported file type). */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemDetails"];
+                };
+            };
+        };
+    };
+    exportDocuments: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["ExportDocumentsRequest"];
+            };
+        };
+        responses: {
+            /** @description Manifest CSV (`text/csv`) or ZIP archive (`application/zip`). `Content-Disposition: attachment` with a timestamped filename. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/csv": string;
+                    "application/zip": string;
                 };
             };
             401: components["responses"]["Unauthorized"];


### PR DESCRIPTION
Closes #215

> **⚠️ これは契約変更です。** 施主レビューをお願いします。
> 方向は「**緩い契約を実態まで締める**」＝保証の強化なので、既存クライアントに対して後方互換です
> （クライアントは既にキーが在る前提で動いており、API は既に必ず返している）。

## なぜ今か

規約 `02-data-flow.md:139` **A-5** の是正（`schema.gen.ts` の re-export）に着手する前に、
**契約側に先に直すべき嘘がある**ことが実測で判明しました。**嘘をついている契約から型を生成しても意味がない**ので、
「契約 → 生成型 → re-export」の順で進めます。本 PR は最初の2つで、**re-export は別 PR** です。

## 変更 1: `required` を実装の実態に合わせる（30 フィールド）

**PHP のプレゼンタは全キーを無条件で emit しています。** 実測（`VaultDocumentPresenter` /
`UserPresenter` / `AuditEventPresenter` / `GetVaultSettingsHandler::toArray` / `LoginHandler`）:
いずれも**固定キーの literal 配列**で、**`if` ・ `unset` ・ `array_filter` が1つもありません**。
値が null になるだけで、キーは常に存在します。

にもかかわらず契約はそれを `required` に載せていませんでした:

| schema | props | required (前) | required (後) | 追加 |
|---|---|---|---|---|
| `VaultDocumentResponse` | 23 | 9 | **23** | 14 |
| `AuditEventResponse` | 11 | 5 | **11** | 6 |
| `VaultSettingsResponse` | 6 | 2 | **6** | 4 |
| `UserResponse` | 7 | 4 | **7** | 3 |
| `DocumentVersionResponse` | 9 | 7 | **9** | 2 |
| `LoginResponse` | 6 | 5 | **6** | 1 |

＝ **30 フィールド**が「API は必ず返すのに、契約は『無いかもしれない』と言っている」状態でした。

この状態で re-export すると、**PHP が必ず返す 30 フィールドが「存在しないかもしれない」型**になり、
UI に不要な null ガードを強制するか type-check が大量に落ちます。**契約の過少申告をフロントに焼き付ける**ことになります。

## 変更 2: `npm run codegen` で再生成（stale 183行の解消）

checked-in の `schema.gen.ts` は `openapi.yaml` から **183行 stale** で、**エンドポイント2本が丸ごと欠落**していました:

- `/admin/vault/documents/{id}/ocr-suggest`（`ocrSuggestDocument` / `OcrSuggestionResponse`）
- `/admin/vault/export`

### なぜ腐ったか（構造的で、vault 固有ではない）

- 誰も `import` していない（**0 参照**）
- `codegen` が **`check` に入っていない**
- **CI にも codegen の検証が無い**（`git grep codegen -- .github` → 0件）
- `knip.json:12` / `eslint.config.js:39` / `.prettierignore:5` が**全員このパスを ignore**

＝ **誰も import せず・誰も鮮度を検査せず・検出器は全員黙るよう設定済み。** 腐らないほうが不思議な配線です。
（統合リナの横断実測: codegen script を持つ **10リポ中、check に入っているのは 0リポ**・CI に入っているのは 2リポのみ。
`knip` ignore で `schema.gen` を隠しているのは **7リポ**。**vault 固有ではありません。**）

A-5 の required ルールが効けば、import された瞬間に型不整合が type-check を落とすので**鮮度が構造的に強制されます**。

## やっていないこと（意図的）

- **リクエスト系スキーマの `required` は触っていません。** `required` は「クライアントが送る義務」の意味で、
  `UpdateUserRequest` / `UpdateVaultSettingsRequest` 等が全任意なのは **PATCH セマンティクスとして正しい**
- **nullable は1つも変更していません**（下記）
- **型・プロパティの追加削除なし。** 差分は `required` の6行のみ
- `OrganizationResponse` / `HealthResponse` / `OcrSuggestionResponse` は**フロントの entity が消費していない**ため対象外
- `ProblemDetails` の `detail` / `instance` は **RFC 7807 上 optional が正しい**ので対象外
- ファイル移動・`types.ts` → `api-types.ts` rename・re-export・`knip` ignore 解除は**別 PR**（A-5 準拠本体）

## nullable は既に全部正しかった（危うく壊すところでした）

当初 PHP のコンストラクタ型（`?string $x = null`）を根拠に「nullable も直す」と判断しかけましたが、**誤り**でした。
`= null` は**挿入前オブジェクトを組むためのコンストラクタ都合**であって、レスポンスの実態ではありません。
**DB スキーマ（migrations 実測）が正**です:

- `users.created_at` / `updated_at` → **NOT NULL** ＝ 応答で null にならない
- `vault_documents.uploaded_at` / `retention_expires_at` → **NOT NULL**
- `audit_events.id` / `entity_id` / `created_at` → **NOT NULL**
- `vault_documents.tags` は DB NULL 可だが、`PdoVaultDocumentRepository::mapRow` が
  `isset(...) ? json_decode(...) : []` で **`[]` に coalesce** ＝ 応答では常に配列

唯一 `VaultSettingsResponse.updated_at` が「DB は NOT NULL なのに契約は nullable」で不一致に見えましたが、
`GetVaultSettingsUseCase::execute` が**設定行の無い組織に `new VaultSettings(organizationId:)` を合成して返す**
（`updatedAt = null`）ため、**契約の nullable が正しい**。DB の NOT NULL は DB 由来でないオブジェクトには効きません。

→ **nullable 変更は 0 件。`required` 追加 30 件のみ。**

## 検証: 契約を実態に合わせたら、生成型が手書き DTO と一致した

これが本 PR のいちばん強い裏付けです。**実 API を観察して手書きされた型**と、**修正後の契約から生成した型**が
同じものになりました:

| 生成型（修正後） | 手書き DTO | 結果 |
|---|---|---|
| `VaultSettingsResponse` | `VaultSettings` | **完全一致** |
| `AuditEventResponse` | `AuditEvent` | **完全一致** |
| `UserResponse` | `User` | `created_at`/`updated_at` のみ相違 |
| `VaultDocumentResponse` | `VaultDocument` | `mime_type`/`original_filename`/`file_size_bytes` のみ相違 |

残差はすべて**手書き側の `\| undefined`** です。DB が NOT NULL である以上これらは**手書きの誤り**（防御的な作り話）で、
契約は `mime_type` を3値 enum に絞っており手書きより厳密です。**A-5 が検出したかったものそのもの**で、
別 PR の re-export で解消されます。

## 受け入れ条件

- [x] `composer check` **exit 0** — PHPUnit **401 tests / 1243 assertions** ・PHPStan「No errors」・CS・locales・
      **「OpenAPI contract is valid.」**・「MCP tool catalog is valid.」・conformance
- [x] `npm run check --prefix frontend` **exit 0** — type-check / lint `--max-warnings 0` / prettier / **221 tests** / knip / storybook build
- [x] 再生成が冪等（`openapi-typescript` を再実行して checked-in と**差分ゼロ**を確認）
- [x] `git diff origin/main` 全数目視・NUL バイト混入なし
- [x] `required` 追加後の集合が **PHP プレゼンタの emit するキー集合と厳密一致**することを機械照合

## 出典

統合リナ指示書 `_work/handoff-vault-double-layer-2026-07-16-work-order.md` §2 の続き。
施主判断 **(a)**「openapi の required を PHP 実態に合わせて締める」。

🤖 Generated with [Claude Code](https://claude.com/claude-code)