### PR TITLE
docs(journal): 2026-07-16 日報を追加 (#219)

### DIFF
--- a/docs/journal/2026-07-16.md
+++ b/docs/journal/2026-07-16.md
@@ -1,0 +1,369 @@
+# 2026-07-16 — Frontend standards day: layer double-spec fixed, the OpenAPI contract made true, generated types finally connected
+
+A fleet-standards day run against three axes of `_work/reports/2026-07-14-frontend-standards/`.
+Two PRs merged (#214, #216) and one is awaiting owner review (#218). The through-line
+was not the code: **twice the work order pointed the opposite way from what the
+standards actually say, and measuring first is what caught it.** The instructions
+themselves said to expect this — "the numbers in this hand-off may be doubted" —
+and they were right to.
+
+## Headline — A-5 says *connect*, not *delete*, and the detector had been muted
+
+The hand-off's second task framed `shared/api/generated/schema.gen.ts` (1,510 lines,
+0 references) as dead code: "if you delete it, attach the knip output to the PR body."
+
+Two measurements said otherwise, so the task was **stopped before implementing**:
+
+1. **A-5 (`02-data-flow.md:139`) requires the import to exist.** It is a
+   dependency-cruiser **`required`** rule — CI fails when `entities/*/api-types.ts`
+   does *not* import the generated schema. Deleting the file would make the rule
+   permanently unsatisfiable. The Wave table (`05:1179`) assigns vault
+   "required ルールで生成型**是正**" — *correct it*, not remove it; the same table
+   writes "knip **削除**" for nene-corpus when deletion is meant.
+2. **`knip.json:12` carried `"ignore": ["src/shared/api/generated/**"]`.** The
+   detector was configured not to see the very file the standards name as their
+   real-world negative example. `npm run check` had been green on knip the whole
+   time — that green was never evidence about this file. The instruction to attach
+   knip output could not have been satisfied: there would have been no output.
+
+`entities/auth/api-types.ts` said the same thing in its own comment, written by
+whoever built the slice: *"Post-codegen these can alias from shared/api/generated;
+kept explicit here so the slice compiles before the first `npm run codegen` run."*
+Codegen had long since run. Only the swap was never finished. The file was not dead
+code — it was **scaffolding nobody removed**.
+
+統合リナ measured and agreed: the work order was wrong, the reading was right.
+
+## A. Theme `layer(components)` double-spec (#213 → PR #214, **merged** `08b21bd`)
+
+`themes/default.css:14` imported `./default.components.css` with `layer(components)`
+while that file already wraps itself in `@layer components { … }`. Declaring
+membership on both sides nests the rules as sub-layer `components.components`, which
+**loses to any rule sitting directly in `components` regardless of specificity**.
+
+Measured in the emitted CSS on `origin/main` (`5aa5577`) — the byte string is
+unambiguous:
+
+```
+@layer vendor,legacy;@layer components{@layer components{@layer main{.muted{…
+                     ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^
+                     the import's layer()  the file's own wrapper
+```
+
+Nothing was visibly broken: Tailwind v4 declares `components` but puts nothing in it,
+so the root layer is empty and the sub-layer has no one to lose to. It is a latent
+trap — the day anything lands in root `components`, 1,868 lines of component CSS
+sink silently.
+
+**The fix turned out not to be discretionary.** `03-styling-theming.md:192` (general
+rule, added 2026-07-15, `[S:no-double-layer-import]`) has a table that names this
+exact file shape: `themes/*.components.css` → file wraps itself → `@import
+'./<name>.components.css';` (**no layer()**). The PR is the second row of that table,
+nothing more. The hand-off had framed it as "a latent bug / the lint's target",
+which undersells it: reviewing discretion costs more than reviewing conformance.
+
+**No visual change, measured rather than asserted.** Emitted CSS before/after,
+normalized on `{`/`}` and diffed in full:
+
+```
+127d126
+< @layer components{
+758d756
+< }
+```
+
+Exactly two lines — the redundant wrapper's open and close. **Not one declaration
+byte moved** (41,234 → 41,215 = 19 bytes = the wrapper's own length).
+
+A second commit (`0e15d59`) corrected `index.css:4-11`, which still claimed vault was
+*"deviating from the ST-06 reference form"* and pointed at a *"proposed"* correction.
+That correction landed on 07-15; vault's shape is now canonical (`03:182` forbids
+`layer(base)` with `[C]`, and `03:189` reproduces vault's own Chromium measurement).
+Left alone, the comment would have invited someone to "fix" it back — into the shape
+the standard forbids and the measurement shows breaks heading weights.
+
+Merge order was agreed directly with the fleet-tooling Rina: **vault first, lint
+after**. Reversed, their `no-double-layer-import` lint would land as `error` and turn
+`origin/main` red until this PR merged. With vault first they could ship at `error`
+from the start, avoiding the `warning`-first shape that KU-1 warns creates a
+permanent false green. Their cross-repo measurement found this line was **the only
+violation in any real product**.
+
+3 files, +18/−10. `npm run check` exit 0.
+
+## B. The OpenAPI contract was under-declaring what the API always returns (#215 → PR #216, **merged** `7c2e7da`)
+
+Prerequisite for A-5. Two independent drifts, found while measuring whether the
+generated types could be re-exported at all.
+
+**Drift A — the generated file had rotted.** Checked-in vs regenerated: **183 lines**
+of diff, **171 lines missing**, including two entire endpoints
+(`/admin/vault/documents/{id}/ocr-suggest`, `/admin/vault/export`), the
+`OcrSuggestionResponse` schema and the `ocrSuggestDocument` operation.
+
+The reason is structural, and not vault-specific: nobody imports it, `codegen` is
+**not in `check`**, there is **no codegen verification in CI**
+(`git grep codegen -- .github` → 0 hits), and knip / eslint / prettier all ignored
+the path. Nobody imports it, nobody checks its freshness, every detector was told to
+look away. It would have been surprising if it *hadn't* rotted.
+
+**Drift B — `required` was lying.** Every presenter emits a fixed literal array with
+no `if`, no `unset`, no `array_filter`: the key is always present, only the value can
+be null. The contract did not say so:
+
+| schema | props | required (before) | added |
+|---|---|---|---|
+| `VaultDocumentResponse` | 23 | 9 | **14** |
+| `AuditEventResponse` | 11 | 5 | **6** |
+| `VaultSettingsResponse` | 6 | 2 | **4** |
+| `UserResponse` | 7 | 4 | **3** |
+| `DocumentVersionResponse` | 9 | 7 | **2** |
+| `LoginResponse` | 6 | 5 | **1** |
+
+**30 fields** the API always returns, which the contract called optional. Re-exporting
+on top of that would have burned the contract's own error into the frontend.
+
+Scope was deliberately narrow: **`required` additions only**. Request schemas were
+left alone — there `required` means *what the client must send*, and `UpdateUserRequest`
+being all-optional is correct PATCH semantics. `ProblemDetails` keeps `detail` /
+`instance` optional per RFC 7807. `HealthResponse` was left alone because its producer
+is not in `src` and appears to be framework-side — **not measured, therefore not
+touched**.
+
+**The near-miss on nullable is the part worth remembering.** The plan was to "fix
+nullable too", reasoning from PHP constructor types (`?string $x = null`). That was
+wrong. Those `= null` defaults exist to build objects *before insert*; they are not
+the response's shape. The DB schema is the authority — `users.created_at`,
+`vault_documents.uploaded_at`, `audit_events.id` are all **NOT NULL**. Following the
+PHP types would have **loosened the contract incorrectly**. The one apparent mismatch
+(`VaultSettingsResponse.updated_at`: contract nullable, column NOT NULL) turned out
+to be the contract being *right*: `GetVaultSettingsUseCase::execute` synthesises
+`new VaultSettings(organizationId:)` for an org with no settings row, and that object
+carries `updatedAt = null`. NOT NULL does not constrain an object that never came
+from the DB. Final scope: **30 required additions, zero nullable changes**.
+
+**The strongest evidence was accidental**: making the contract true produced types
+that *match the hand-written DTOs*. `VaultSettingsResponse` ≡ `VaultSettings` and
+`AuditEventResponse` ≡ `AuditEvent`, exactly. Types written by watching the real API,
+and types generated from the corrected contract, converged.
+
+2 files, +220/−36. `composer check` exit 0 (401 tests, 1,243 assertions, "OpenAPI
+contract is valid."), `npm run check` exit 0 (221 tests). Regeneration verified
+idempotent.
+
+## C. Generated types connected to the entities (#217 → PR #218, **open — CI green, owner review pending**)
+
+`schema.gen.ts` → `shared/api/`, four `types.ts` → `api-types.ts`, **all five entities**
+(auth included) re-exporting from the generated schema, `knip`'s ignore removed.
+
+Every naming decision rests on physical evidence rather than preference — the
+cross-repo counts came from 統合リナ (**7:1** on the path, **115:4** on the filename,
+vault the sole outlier on both), and vault itself pointed the same way three times:
+`eslint.config.js:16` already listed `./src/entities/*/api-types.ts` in
+`entityInternalFiles` — **the config had been written for the post-rename shape all
+along**; auth's comment stated the intent; `01-structure.md:190` defines `api-types.ts`
+as "re-export of the openapi-typescript generated types". auth was added to the
+work order's four because A-5's regex matches it too — leaving it hand-written would
+fail the required rule on auth.
+
+**Then the type-check failed, in the opposite place from the prediction.** #216 had
+predicted the residual would be the hand-written `| undefined` on response DTOs.
+Those produced **zero errors** — narrowing a response type from `string | undefined`
+to `string` is safe for consumers; you get a *more certain* value than you expected.
+Nothing breaks; **the guards just die**.
+
+What actually failed was the **input** side. Under `exactOptionalPropertyTypes: true`,
+the generated `?: T` means "absent, or a T — never an explicit undefined", while call
+sites build `{ entity_type: cond ? value : undefined }`. **The hand-written
+`?: T | undefined` had been written to permit that call style.** The hand-written type
+was not wrong; it had been shaped to the callers. No contract lie, no runtime bug —
+`JSON.stringify` drops undefined-valued keys, so the wire behaviour is identical. A
+pure type-modelling difference. The callers were adapted rather than the generated
+types widened, and behaviour-identity was verified on both sides
+(`UpdateVaultSettingsHandler:34-41` folds absent/null/`''` alike into null;
+`buildAuditPath:18-20` skips absent and explicit-undefined alike).
+
+The prediction *was* right — it simply surfaced in **lint** instead of the type-checker:
+
+```
+DocumentDetailPage.tsx  63:18  Unnecessary conditional, expected left-hand side of ?? …
+UsersPage.tsx          128:10  Unnecessary conditional, the types have no overlap
+```
+
+`doc.original_filename ?? \`document-${doc.id}\`` and
+`user.created_at !== undefined ? … : '—'` — **defensive code written because the type
+had lied**, revealed as unreachable the moment the contract became true. Both fields
+are NOT NULL in the DB and unconditionally emitted. This is what A-5 exists to expose.
+
+**knip was not muted to make it pass.** Removing the ignore surfaces
+openapi-typescript's boilerplate exports (`paths`, `webhooks`, `$defs` — `components`
+and `operations` are now used). Restoring a whole-file ignore would have recreated the
+exact defect this PR removes, so `ignoreIssues` narrows the exemption to this file's
+`types` issue — knip's own schema offers `"src/generated/**": ["exports", "types"]`
+as the example for precisely this case.
+
+Claiming "detection is preserved" is not worth much unstated, so it was **tested**:
+with all entities disconnected from `schema.gen`, knip reports
+
+```
+Unused files (1)
+src/shared/api/schema.gen.ts
+```
+
+— the A-5 violation itself. The old `ignore` hid that. `ignoreIssues` does not.
+
+27 files, **+94/−180** (net −86: hand-written DTOs replaced by re-exports).
+`npm run check` exit 0 with the ignore removed (221 tests, knip included);
+`composer check` exit 0 (401 tests, 1,243 assertions). Generated output byte-identical
+to `npm run codegen`.
+
+## D. `composer check` red on the merged HEAD — and it was the local tree, not `main`
+
+Asked to verify the post-merge HEAD, the frontend check was the only one requested.
+Running `composer check` as well — the point being not to assume the untouched half is
+fine — returned **exit 2, 253 errors**: `Unknown named parameter
+$enableAuthorizationHeaderFallback`.
+
+Reporting that as "`main` is red after merge" would have been false. Installed
+`hideyukimori/nene2` was **v1.10.0** while `composer.lock` pins **v1.11.0**, and the
+parameter does not exist in v1.10.0 — but `src/Http/RuntimeServiceProvider.php` on
+`origin/main` uses it (added by #210). `composer install` → v1.11.0 → **exit 0**.
+`origin/main` was innocent throughout.
+
+This is the PHP sibling of the trap the hand-off itself names ("if lint dies with
+ERR_MODULE_NOT_FOUND, run npm install — node_modules not tracking origin/main"). The
+hand-off warns about `node_modules`; **`vendor/` has the same hole**. Worth noting
+that a local PHP with no `date.timezone` defaults to UTC, so a purely local reading
+makes several of these problems invisible.
+
+## E. `@conformance`'s 15 suppressed findings — investigated, **not filed** (owner decision pending)
+
+`composer check` prints `Conformance OK — no findings (15 suppressed by
+baseline/ignore)`. All 15 are rule **D4** (raw wall-clock reads; inject
+`Nene2\Http\ClockInterface`). Two are benign — `S3DocumentStorage`'s `gmdate` is a
+UTC-correct SigV4 stamp, `ExportDocumentsHandler`'s is a filename. **The other 13
+write DB timestamp columns in host-local time.**
+
+`conformance.baseline.json` carries `"allow": []` and 15 `ignore` entries. Per the
+tool, `--write-baseline` pours existing drift into `ignore` (a debt bucket, no reason
+required) while `allow` is the false-positive lane and **requires a `reason`**. So all
+15 are debt with **no recorded rationale**, and the tool prints `OK`.
+
+This is not theoretical. **#143 (closed) records the production observation in vault's
+own words**: "JST on HETEML"; an org created at `2026-07-11 00:03` (JST) read as 9
+hours in the future under a UTC parse, stretching a 3 h TTL to 12 h. The migration
+docstring for `20260711000002` says the same: host default timezone, "**JST on the
+live demo host**".
+
+#161 fixed **`organizations` only**, and its commit message claims "All fleet products
+now write UTC" — **false for vault's own core tables**. `ClockInterface` reaches Auth,
+Organization, Audit and Demo; Document, DocumentVersion, User and VaultSettings still
+call `date()`. The 15 D4 entries are exactly that remainder. The result is worse than
+uniform JST: **one database with mixed timezone semantics** — `audit_events.created_at`
+in UTC (verified: `AuditServiceProvider` binds `ClockInterface => new UtcClock()` and
+NENE2's `AuditRecorder` stamps `occurredAt` from it) while the documents it audits are
+in JST.
+
+For a 電子帳簿保存法 archive whose hard rule is "every mutation goes through
+`AuditRecorder`", **the audit trail and the act it records disagree by nine hours**.
+`retention_expires_at` — the statutory retention deadline gating "no hard-delete
+during the retention window" — is anchored on `date('Y-m-d')`, a JST date.
+
+Stated honestly: **nothing is breaking right now.** `sweep-demo.php` touches only
+`organizations` and parses UTC correctly since #161; no time-based reaping path for
+documents exists. The accurate claim is that **a production-observed bug class remains
+untracked in the core tables** — all three timezone issues (#143/#155/#161) are closed
+and nothing tracks the rest.
+
+Not fixed (out of the frontend-standards remit, and NENE2's conformance tool is
+PHP-side). **Filing awaits the owner's decision**: a fix needs `ClockInterface` in four
+classes *plus* a #161-style migration of existing rows, and #161's docstring warns
+"DEPLOY ORDER MATTERS" — the demo host holds real data.
+
+## Errors made today, and how they were caught
+
+Three, plus two mechanical slips. All caught before or during execution — none reached
+a PR body or a merged commit — but the honest reading is that the tools caught the
+third, not the author.
+
+1. **Claimed a measurement that was never made.** Reported to 統合リナ that "vault has
+   neither dependency-cruiser nor **stylelint** (measured)" having grepped only for
+   dependency-cruiser. The conclusion held on re-measurement (0 files, 0 deps in either
+   `package.json`), but **there was no basis at the time it was asserted** — and it was
+   labelled "実測", which makes it worse than an unmarked guess. Caught by the
+   fleet-tooling Rina re-measuring instead of trusting it.
+2. **A broken regex nearly produced a spectacular false finding.** A hand-rolled parser
+   counting `required` reported `VaultDocumentResponse: props=22, required=0` — "the
+   product's core resource declares every field optional". It matched only the inline
+   `required: [...]` form and missed the block-list form, which is what that schema
+   uses. Caught by opening the raw YAML immediately before reporting. **The detector
+   was not silent; the detector was broken** — the mirror image of the `knip.json`
+   ignore this same day. Re-measured with PyYAML; every number above comes from the
+   parser.
+3. **Proposed a knip config key that does not exist** (`ignoreExports`), from memory.
+   knip rejected it (`unrecognized_keys`) and the real mechanism (`ignoreIssues`, with
+   generated files as its documented example) was found. Proposing from memory is
+   normal; the failure mode would have been treating the guess as verified and shipping
+   it.
+4. **Measured from the wrong directory.** `git ls-tree … -- frontend/src/entities` run
+   with `cwd=frontend` returned empty and nearly read as "zero entities". Same class as
+   the trap the hand-off warns about; caught immediately.
+5. **A CI wait-loop that exits when there are no checks.** `until ! gh pr checks | grep
+   -q pending` reports "done" before CI has registered anything. Silence read as
+   success.
+
+**And a delivery accident worth recording**, because the fix belongs in the tooling:
+a report to hub broke mid-send. The body contained a `tsc` error message, and `tsc`
+quotes types as `'this'` — the single quote closed the single-quoted shell string and
+the remainder ran as commands. The relay README warns that *double* quotes expand
+backticks and `$`; **single quotes fail the same way when the body contains one**, and
+compiler output structurally does. The fix used since: write the body to a file and
+pass `"$(cat file)"` — command-substitution output is not re-parsed.
+
+## Where the work order was pointed the wrong way
+
+Six times measuring first changed the outcome. Recording them for the pattern, not the
+scoreboard:
+
+- **A-5 is *connect*, not *delete*** — deleting would have made a `required` rule
+  permanently unsatisfiable.
+- **`knip.json:12`'s ignore** — the instruction "attach the knip output" could not have
+  been satisfied; the detector was muted against that exact file.
+- **`03:192`** — the fix was conformance, not discretion; the PR body was rewritten to
+  say so.
+- **nullable direction** — the framing implied the hand-written types were wrong; they
+  matched reality and the *contract* was under-declaring. Following the PHP types would
+  have loosened the contract.
+- **residual direction** — response-side, not input-side, was predicted; the response
+  side produced zero errors.
+- **the journal convention itself** — today's instruction stated vault has no daily-report
+  habit, measured from `docs/daily`. Vault keeps them in **`docs/journal/`** (2026-07-10,
+  2026-07-14, via issue → `docs/<issue>-journal-<date>` → PR). This file follows vault's
+  own shape rather than the prescribed one.
+
+Every one is the same shape the day converged on fleet-wide: **taking what is at hand
+for the thing that was named.** `02-data-flow.md:169` (**A-10**: "compliance is judged
+by CI on `origin/main`; local greps are advisory") exists precisely to prevent it, and
+it was tripped ten times across the fleet today — once here, in §D.
+
+## Carry-over
+
+- **PR #218 — CI green, LGTM, awaiting owner approval.** Not merged. Once in, vault's
+  A-5 non-conformance (the standards' own named negative example) is closed.
+- **`@conformance`'s 15 D4 findings (§E) — filing decision pending.** The heaviest
+  finding of the day: audit trail in UTC, audited documents in JST, in a compliance
+  archive. Investigated only; nothing changed.
+- **`codegen` in `check`/CI — deliberately not done here.** The rot in §B is structural
+  and cross-repo (per 統合リナ: of 10 repos with a `codegen` script, **0** run it in
+  `check`, 2 in CI). The standards invent regen-diff for themegen (`03:575`: validate
+  regenerates deterministically and fails on mismatch) but never apply it to codegen
+  (`05:716` checks only that the import exists). Same problem, solved on one side only —
+  a standards patch, held by 統合リナ.
+- **knip's `ignoreIssues` as fleet precedent.** Seven repos hide `schema.gen` behind a
+  knip ignore. Vault's measurement suggests at least part of the reason is that
+  connecting it correctly *still* goes red on the generator's boilerplate exports —
+  "had to mute it", not "couldn't be bothered". If so, the fleet needs a shared idiom
+  and #218 is the first instance. The other six are unmeasured.
+- **`.mcp.json` is tracked despite `.git/info/exclude:7`** (exclude only binds untracked
+  files; it was committed first). Untouched all day, never staged — `git add` was always
+  explicit, never `.`. Cross-repo `git rm --cached` sweep belongs to 統合リナ.


### PR DESCRIPTION
Closes #219

`docs/journal/2026-07-16.md` を追加します。

## 中身

フロント規約3軸の作業日。**マージ済み2本・レビュー待ち1本**を書き分けています。

- **#213 → PR #214（マージ済み `08b21bd`）** テーマ `layer(components)` 二重指定の解消
- **#215 → PR #216（マージ済み `7c2e7da`）** レスポンス契約の `required` を実態に合わせる（30フィールド）
- **#217 → PR #218（レビュー待ち・CI green・未マージ）** 生成型を entity へ接続（A-5 準拠）

加えて、実装せず報告のみで止めた `@conformance` 15件（D4 タイムゾーン債務）と、
**自分の誤り3件＋機械的な取りこぼし2件＋送信事故1件**、明日への引き継ぎを記録しています。

## 数字は全部自分で測ったものです

「渡された数字」は出典を明記して書き分けました
（フリート横断の現物量 7:1 / 115:4 は統合リナの実測、と本文に明記）。

## 書式は vault の慣習に合わせています

統合リナの指示は `docs/daily/` ＋ nene-records 形式（和文）でしたが、実測すると:

- **vault の日報は `docs/journal/`** です（`2026-07-10.md` / `2026-07-14.md`）。`docs/daily/` は存在しません
- **ADR 0008「Repository docs: English only」**（`AGENTS.md:48`）があるため、**和文で書くと vault 自身の ADR に反します**

よって英文・`# YYYY-MM-DD — <headline>`・リード段落・トピック別 `##` 節・`## Carry-over` という
既存2本と同じ形にしました。**リポの慣習を正としています**（この判断自体、日報本文にも記録しました）。

## 手順

`AGENTS.md:41`「Issue-driven; no direct commits to `main`」に従いました。先例は #202 → PR #203。
docs のみでコード変更は含みません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)