### PR TITLE
docs: CLAUDE.md に Issue 駆動と日報の規律を明記し、正本側にドリフト検出を置く (#221)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,11 @@ See [ADR 0009](docs/adr/0009-separate-from-billing-and-reconciliation.md).
 
 ## Operating Rules
 
-- Issue-driven; no direct commits to `main`
+> The two rules marked ⇄ are restated in `CLAUDE.md` § Workflow, because a session
+> reads that file first and rules it cannot see get broken. **Change both together.**
+
+- ⇄ Issue-driven; no direct commits to `main`. Branch `type/issue-number-summary`, then PR
+- ⇄ Journal: record each working day in `docs/journal/YYYY-MM-DD.md`, same Issue → PR flow
 - Do **not** add quote/invoice issuance — **`nene-invoice`**
 - Do **not** add bank reconciliation/dunning — **`nene-clear`**
 - Do **not** add bank CSV mapping engine — **`nene-profile`**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,15 @@ docker compose up       # local stack — API :8600 · Frontend :5186 · MySQL :
 API **8600** · Frontend **5186** · MySQL **3386** — unique across the NeNe
 portfolio; never reuse sibling ports. See README "Local port allocation".
 
+## Workflow
+
+- **Issue-driven**: no Issue, no code or doc change. Branch `type/issue-number-summary`
+  from `main`; **never commit directly to `main`**. Then PR. (`AGENTS.md` is the source
+  of truth for the full operating rules.)
+- **Journal**: record each working day in `docs/journal/YYYY-MM-DD.md` — English
+  (ADR 0008), via the same Issue → branch → PR flow. Precedents: `docs/journal/2026-07-14.md`
+  (shape: headline title, lead paragraph, one `##` per topic, closing `## Carry-over`).
+
 ## Hard rules (never violate without an ADR)
 
 - **No hard-delete** of documents during the retention window


### PR DESCRIPTION
Closes #221

## 問題: 規律はあるが、読まれる場所に書かれていない

| 規律 | 所在 | CLAUDE.md |
|---|---|---|
| Issue 駆動・`main` へ直接コミットしない | **`AGENTS.md:41`** | **無い** |
| 日報を書く | **どこにも無い**（現物が `docs/journal/` に2本あるだけ） | **無い** |

CLAUDE.md は「Full agent guide: `AGENTS.md`」と案内していますが、**辿らないと分からない規律は踏まれます。**

## 実際に踏まれました（2026-07-16・統合リナ）

1. **「docs のみなら直接 `main` へでも」と指示された** — `AGENTS.md:41` の
   「Issue-driven; no direct commits to `main`」を見落としたため。**CLAUDE.md を読んで 0 ヒットだったのが理由**
2. **「vault には日報の慣習が無い」と指示された** — `docs/daily` を探して不在だったため。
   実際は **`docs/journal/`**（`2026-07-10.md` / `2026-07-14.md`）

どちらも「**CLAUDE.md を読んで、無いから無いと判断した**」形です。次のセッションも同じ読み方をします。

## 変更

`## Workflow` 節を `Local ports` と `Hard rules` の間に追加。**正本は `AGENTS.md` のまま**で、
CLAUDE.md には**最初に読む者が要る分だけ再掲**します。

`Hard rules` に混ぜませんでした。あそこは全部プロダクトの不変条件（hard-delete 禁止・
byte overwrite 禁止・SHA-256・`AuditRecorder`・`organization_id`・storage path）で、
**手順規律とは種類が違う**ためです。

## 裏取りの状態（書き分けます）

- ✅ **Issue 駆動・main 直コミット禁止**: `AGENTS.md:41` に現物。CLAUDE.md は grep 0件 — **実測**
- ✅ **日報の置き場・書式**: `docs/journal/` に現物2本 — **実測**
- ✅ **手順**: #202 → PR #203（ブランチ `docs/202-journal-2026-07-14`）— **実測**
- ✅ **英文である理由**: **ADR 0008「Repository docs: English only」**（`AGENTS.md:48`）— **実測**
- ⚠️ **「作業日に書く」という頻度方針**: **統合リナ経由で伝わった施主の言葉**
  （「すべてのリポジトリに日報の慣習があって、可能な限り作業日に日報を書いてもらっている」）で、
  **リポ内の成果物では裏が取れていません。** 文面が方針とずれていたら指摘してください

## 手順

`AGENTS.md:41` に従い Issue → ブランチ → PR。**規約を書き足す PR が規約違反で入る、では話にならないため。**
docs のみ・コード変更なし。日報（#219 → PR #220）とは**別 PR**にしました
（片方は今日の記録、片方は今後の全セッションに効くガバナンス変更で、レビューの性質が違うため）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)