### PR TITLE
docs(security): redteam 文書の "real, exploited" に日付入り erratum 注記を足す (#226)

### DIFF
--- a/docs/security/2026-07-14-redteam-assessment.md
+++ b/docs/security/2026-07-14-redteam-assessment.md
@@ -15,6 +15,16 @@ by live fire, that **NeNe Vault does not have either type**, hardens the one
 latent-fragility that maps to the sibling's root cause, and corrects one round-1
 probe gap.
 
+> **Erratum 2026-07-16 (#226).** "*real, exploited*" above means **demonstrated
+> exploitable by nene-records' own self-assessment** on 2026-07-13, and **fixed
+> there the same week** — *not* exploited in the wild by an attacker. Both
+> repositories are public, so the distinction matters. nene-records' original
+> report uses no "exploit" wording at all: it records F-01 (Critical) and F-02
+> (Medium) as **"Fixed + regression-verified"**. The wording above is this
+> report's own summary, not a quotation. The sentence is **left unchanged** —
+> this document is a record of the assessment as it was written. The equivalent
+> summary in `docs/todo/current.md` was reworded instead (#224).
+
 **Scope / target.** Disposable local Docker stack (`docs/security/harness/`),
 project `vaultsec` / `vaultsec-tenant`, port 8600. **No production host**
 (`vault.ayane.co.jp` or any live system) was touched; no DoS/destructive payloads.


### PR DESCRIPTION
Closes #226

## 何を直すか

`docs/security/2026-07-14-redteam-assessment.md:12` の "*real, exploited*" が
**「野生で攻撃者に悪用された」と誤読され得る**。実際は nene-records **自身の
self-assessment** が実証したもので、records 側で同週に修正済み。

**`nene-vault` / `nene-records` とも public** なので、対外誤読リスクは実在する。

## 発生源はこの :12（実測で確定）

records 原文（`nene-records/docs/security/2026-07-13-assessment.md`）を実測:

| 実測 | 結果 |
| --- | --- |
| `grep -cin 'exploit'` | **0件** — records は "exploit" 系の語を一切使っていない |
| F-01（Critical）の記載 | `Fixed + regression-verified` |
| F-02（Medium）の記載 | `Fixed + regression-verified` |

→ **"real, exploited" は引用ではなく vault 側要約が発明した語**。発生源は :12 そのもの。

## 方針: 本文不変・日付入り erratum（統合リナ裁定 2026-07-16）

- **原文は書き換えない** — `10 insertions / 0 deletions`（`git diff --numstat` で検証済み）。
  assessment は署名的性格を持つ記録であり、後から歴史を書き換えない。
- 直後に日付＋Issue 番号入りの注記を足し、記録の完全性と対外表現を両立させる。

**先例に倣った**: records 自身が原文保存のまま同種の追記を使っている
（`2026-07-13-assessment.md:79` の `> **Revision 2026-07-14 (#826).**`）。
引用ブロック＋太字ラベル＋日付＋Issue 番号という構造をそのまま採用。
ラベルのみ性質に応じて分けた — records のそれは**実質の改訂**、本件は**語法の訂正**なので `Erratum`。

## 追加した注記

> **Erratum 2026-07-16 (#226).** "*real, exploited*" above means **demonstrated
> exploitable by nene-records' own self-assessment** on 2026-07-13, and **fixed
> there the same week** — *not* exploited in the wild by an attacker. Both
> repositories are public, so the distinction matters. nene-records' original
> report uses no "exploit" wording at all: it records F-01 (Critical) and F-02
> (Medium) as **"Fixed + regression-verified"**. The wording above is this
> report's own summary, not a quotation. The sentence is **left unchanged** —
> this document is a record of the assessment as it was written. The equivalent
> summary in `docs/todo/current.md` was reworded instead (#224).

## 関連

- current.md 側の同じ語法は **#224**（commit `5fe0fe4`）で是正済み。本 PR は上流側。
- 「fixed the same week」の裏取り: 本文書の Conclusion（166行目）が
  "The two vulnerability types nene-records found **and fixed**" と明記。
  records の評価が 07-13 で、その時点で既に `Fixed + regression-verified`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)