### PR TITLE
docs(compliance): Review 3 の確認論点に D11（見読可能性）の質問を足す (#229)

### DIFF
--- a/docs/compliance-review/2026-review-3-preprod-package.md
+++ b/docs/compliance-review/2026-review-3-preprod-package.md
@@ -150,6 +150,22 @@ Then update the "Review status" table in `signoff-record.md` and check off the
 - Should `retention_expires_at` become an operator-editable master setting before
   go-live (§3), or is the ADR 0004 constant acceptable for the first release?
 - Any 電帳法 guidance updates since 2026-05-31 that change the posture?
+- **見読可能性 and in-browser display (proposed scope item D11, Issue #225).**
+  Today an operator reads a stored document by downloading it and opening it
+  locally; the Admin UI does not render the bytes. We have a candidate feature
+  that would display image/PDF bytes inline, re-computing SHA-256 in the browser
+  and **refusing to render on mismatch**. Three questions, in order:
+  1. Is the current download-and-open flow sufficient for 見読可能性の確保, or
+     would inline display materially help at an actual 税務調査?
+  2. Would adding it **widen the scope you approved at Review 2** — i.e. does it
+     need your re-confirmation rather than being an implementation detail of the
+     already-approved D9 (Admin UI)?
+  3. If it is in scope, should Review 3 verify it (a sample to inspect), or is it
+     out of Review 3's remit?
+
+  We have **not** implemented it and have **not** amended
+  [`scope-contract.md`](../explanation/scope-contract.md); both are deliberately
+  held until this question is answered.
 
 ---
 
@@ -161,4 +177,4 @@ Then update the "Review status" table in `signoff-record.md` and check off the
 - Integrity/download, void/restore, audit: `tests/Document/`
 - API contract: [`docs/openapi/openapi.yaml`](../openapi/openapi.yaml)
 
-Last updated: 2026-06-01
+Last updated: 2026-07-16 (§5: added the D11 / 見読可能性 question, #229)


### PR DESCRIPTION
Closes #229

## 何をするか

`docs/compliance-review/2026-review-3-preprod-package.md` の
**§5 Open questions for Review 3** に、D11（#225）の論点を1つ追加する。

**これは D11 の採否を決める PR ではない。税理士に聞く質問を積むだけ。**

## なぜ

#225（integrity-verified inline preview）は `scope-contract.md` という **binding 文書の
scope を広げる**提案。コンプラゲートは Review 2（2026-05-31）で**現 scope に対して**承認済み。
「scope 拡大が pre-production Review 3 に影響するか」は**施主も判断できず＝税理士確認待ち**。

統合リナ裁定（2026-07-16）: **Review 3 準備パッケージの確認論点に積む**ことで確定。

## 追加した質問（3段構え）

既存3問と同じ粒度に合わせ、答えやすい順に並べました:

1. 現行（DL してローカルで開く）で **見読可能性の確保**は足りるか。inline 表示は
   実際の税務調査で意味のある差になるか。
2. 追加は **Review 2 の承認範囲を広げる行為にあたるか** — それとも承認済み D9（Admin UI）の
   実装詳細か。**ここが本題**（再確認が要るかどうか）。
3. in scope なら Review 3 で確認すべきか（サンプル提示）、それとも Review 3 の対象外か。

あわせて「**未実装であること・scope-contract を未改訂であること・回答まで両方保留すること**」を
明記しました。税理士に「もう作ってしまったものの追認」と受け取られないためです。

## 変更しなかったもの

- **`scope-contract.md` は触っていない**（D11 を足していない）— 回答待ち。
- **#225 は保留のまま**。本 PR は論点を積むだけ。

## 関連

- #225 — D11 の設計温存先（🔴 着手保留・本質問の回答待ち）
- #98 — 設計先例（closed・ブランチは参照用に残置）

🤖 Generated with [Claude Code](https://claude.com/claude-code)