### PR TITLE
docs(journal): 2026-07-16 に日中セッション分を追記する (#233)

### DIFF
--- a/docs/journal/2026-07-16.md
+++ b/docs/journal/2026-07-16.md
@@ -367,3 +367,192 @@ it was tripped ten times across the fleet today — once here, in §D.
 - **`.mcp.json` is tracked despite `.git/info/exclude:7`** (exclude only binds untracked
   files; it was committed first). Untouched all day, never staged — `git add` was always
   explicit, never `.`. Cross-repo `git rm --cached` sweep belongs to 統合リナ.
+
+---
+
+## Session 2 (daytime) — Drift sweep: a stale PR closed, a release zip that shipped as a SHA, and the finding I merged without reading
+
+> Everything above is the **overnight session** that ended 03:20 (#219, merged as
+> #220 at 14:17 today). This part records the **daytime session** of the same
+> calendar date. The text above is left unchanged — it is that session's record.
+> Where this part supersedes it, it says so; it does not edit it. (Same principle
+> applied to the redteam document in §J below.)
+
+Started as a `/repo-status` drift check and turned into a sweep. Eight Issues/PRs.
+The through-line: **the drift list found things nobody was looking for** — a release
+zip that had been shipping under a commit SHA, an Issue rotting open because a PR
+forgot `Closes`, and a compliance-grade finding sitting in a journal I had merged
+myself, unread.
+
+## F. The drift list, and what it was hiding
+
+`/repo-status` produced seven discrepancies. Six were bookkeeping; two were not.
+
+- **`board.txt` L54** claimed the theme split was open. It was not: `default.css` is
+  129 lines and token-only (`@theme`, 0 selectors, 0 `@media`), and all six `@media`
+  sit at depth 2 inside `@layer components > responsive` (#212 + #214). Marked done
+  after measuring the surgery the board line actually asked for — not the file size.
+  统合リナ ratified.
+- **`docs/todo/current.md` was 45 commits stale.** #171 (07-11) was its last update;
+  security rounds 1–2 and the entire frontend W1 wave were **absent**. Fixed in #224.
+- **#204 was open with its PR (#205) merged** — a missing `Closes`. Verified the work
+  landed (`client.ts:7` imports `@hideyukimori/nene2-client`; `package.json:26` pins
+  `^1.1.0`), then closed it. 統合リナ found a second instance in `clear #264`: this is
+  a fleet pattern, not a one-off slip.
+- README carries no stale phase badge — because **#188 removed them on purpose**. The
+  one repo where "don't trust the badges" does not apply, and only measuring showed it.
+
+## G. #98: a month-old PR whose foundation `main` had already rebuilt, better
+
+`feat/document-inline-preview` (2026-06-17) rendered stored bytes with a **client-side
+SHA-256 re-check that refuses to render on mismatch**. Not decoration — that refusal is
+the feature.
+
+`main` was **69 commits ahead**; `merge-tree` showed 6 conflict hunks covering every
+substantive file. `client.ts` had been rebuilt on nene2-client (#205); `default.css`
+had been split to 129 token-only lines (#212), so the PR's diff had no target left.
+
+The decisive part: `main` had **independently created `entities/document/file.ts`**
+in #179/PR #180 — `fetchDocumentBlob()`, authenticated bytes keyed by version ULID.
+Exactly the foundation #98 needed, in a better shape (#98's version co-located a React
+hook and SHA-256 verification in the same file). `merge-tree` reported `added in both`:
+**two branches reached the same filename by different designs.**
+
+So resolving conflicts was rewriting. Closed #98, preserved the design in **#225** —
+the four-state model (`loading | verified | mismatch | error`) and the refuse-to-render
+core — and left the branch undeleted for reference. 統合リナ's fleet sweep found **no
+precedent**: records shows no PDFs at all, invoice has `requestBlob` but never embeds,
+deal has no media. Client-side `crypto.subtle` verification would be a **fleet first**.
+
+**#225 is deliberately blocked.** D11 widens `scope-contract.md`, and the compliance
+gate was approved by Review 2 **against the current scope**. Whether widening it
+disturbs Review 3 is a question the owner could not answer either — so the scope is
+not being moved until the 税理士 does. The question was filed into the Review 3 package
+instead (#229 → PR #230), worded to make clear nothing is built and nothing is amended.
+
+## H. The misreading was ours, and it was upstream of where it was caught
+
+Reviewing #224, 統合リナ flagged `*real, exploited*` — it reads as *exploited in the
+wild*. It was not: nene-records' **own self-assessment** demonstrated the two types,
+and records fixed them the same week.
+
+Two things only measuring showed:
+
+1. The phrase existed in **two** places in my draft — the flagged one and `actually
+   exploited` in the lead note. One report, two instances.
+2. **The wording is ours.** records' original report contains **zero** occurrences of
+   "exploit" (`grep -cin 'exploit'` → 0); it records F-01/F-02 as
+   `Fixed + regression-verified`. `*real, exploited*` was **invented by vault's summary**
+   at `2026-07-14-redteam-assessment.md:12` — which my `current.md` text had copied.
+
+Both repos are public, so this is not cosmetic. 統合リナ ruled: **do not rewrite the
+record; annotate it.** The assessment is signed in character. PR #227 adds a dated
+erratum and touches nothing else — `git diff --numstat` = **10 insertions, 0 deletions**.
+records had already invented this pattern (`2026-07-13-assessment.md:79`,
+`> **Revision 2026-07-14 (#826).**`), so the fleet had the idiom before we needed it.
+
+## I. The release zip has been shipping as a commit SHA
+
+`build-release.sh:19` resolved the version with `git describe --tags --always`. This
+repo has **zero tags** and **zero GitHub releases** — so `--always` degraded to the
+short SHA:
+
+```
+git describe --tags --always → f647a79        # this was the "version"
+```
+
+Every zip built without an explicit argument was `nene-vault-f647a79.zip`. For a product
+distributed as a zip for operators to install on shared hosting, **nobody could say which
+version they had installed.**
+
+Fixed in #232 on the shape records settled the same day (records #586 / `d8d8803`):
+repo-root `VERSION` as single source; `build-release.sh` resolves explicit arg > `VERSION`
+> `dev`; the `git describe` fallback is **gone**, so a SHA cannot creep back in.
+`frontend/package.json` pinned to `0.0.0` with a reason comment — records' judgement,
+adopted: syncing the version re-breaks the moment someone forgets to bump, and no code
+reads it (grepped: `package.json` reads, `import.meta.env`, `__APP_VERSION__` → 0 hits).
+One addition to records' shape: `VERSION` ships **inside** the zip, so an installed site
+can state its own version without the filename surviving the download.
+
+Initial value **0.9.0**, approved: phases 0–4 complete and the compliance gate passed,
+but the go-live gate is open, so `1.0.0` would claim something untrue — and `0.1.0`
+would repeat exactly the understatement #188 deleted. `1.0.0` when the gate clears.
+
+## J. §E was filed — and the reason it nearly was not is the lesson of the day
+
+The overnight session's **§E** investigated `@conformance`'s suppressed findings and
+stopped at *"Filing awaits the owner's decision"*. Today the owner said file it.
+
+**I did not recognise it as vault's own finding.** When 統合リナ relayed the GO, my first
+reaction was that I had never raised it. I had not — the overnight session had, in the
+journal **I merged myself at 14:17** (#220) without reading. It took an external prompt
+to make me open the file I had just landed.
+
+*Making the journal the source of truth does nothing if nobody reads it.*
+
+Filed as **#228**, with every claim re-measured first — §E's own "Errors made today"
+warns about asserting what was not measured, and that warning applies hardest to the
+person quoting it. One number changed:
+
+> §E says `conformance.baseline.json` carries **15 ignore entries**. It carries **8**
+> entries whose `count` fields sum to **15 findings** (5+2+2+1+1+1+1+2), matching the
+> tool's `15 suppressed by baseline/ignore`. The substance is unchanged; #228 carries
+> the corrected figure. §E's text is left as written.
+
+What re-measurement confirmed: `allow: []`, all 8 entries rule **D4**, **zero** with a
+`reason` — debt with no recorded rationale, and the tool prints `OK`. Two are benign
+(S3 SigV4 `gmdate`, an export filename); **13 write DB timestamps in host-local time**.
+`ClockInterface` reaches Audit, Auth, Demo, Organization only. And #161's commit message
+(`429de4d`) claims *"All fleet products now write UTC"* — **false for vault's own core
+tables**; it fixed `organizations`.
+
+The result is worse than uniform JST: `AuditServiceProvider:28` binds
+`ClockInterface => UtcClock`, so `audit_events` is UTC, while
+`PdoVaultDocumentRepository:47,110` still calls `date()`. In an archive whose hard rule
+is *every mutation goes through `AuditRecorder`*, **the audit trail and the act it
+records disagree by nine hours**. `retention_expires_at` — the column governing
+*no hard-delete during the retention window* — is a JST date
+(`UploadDocumentUseCase:74`).
+
+Stated as honestly as §E did: **nothing is breaking.** No time-based reaping path
+touches documents. The accurate claim is that a **production-observed** bug class
+(#143 recorded "JST on HETEML" in vault's own words) was untracked. Now it is tracked.
+The fix stays gated: it needs `ClockInterface` in four classes *plus* a #161-style
+migration, and `20260711000002`'s docstring already warns **DEPLOY ORDER MATTERS** —
+the demo host holds real data.
+
+## Errors made in this session
+
+1. **Merged a journal without reading it** (§J). The timezone finding was in my own
+   repo, in a file I landed, and I needed 統合リナ to point at it. Everything else here
+   is a footnote to this one.
+2. **Trusted a transport's `ok` as delivery.** `relay-send.sh` returned `ok -> :8790`
+   for three messages sent 14:29–14:32; hub was dead 13:56–15:00 (a stray root
+   `.mcp.json` let another session's child seize port 8790) and **all three were
+   dropped**. `ok` means the POST reached the port, not that the right process read it.
+   Caught only because hub recovered and asked for resends. Timestamps confirmed all
+   three sat inside the dead window.
+3. **Nearly propagated §E's "15 ignore entries" unmeasured** (§J). Caught by re-measuring
+   before filing — because §E's own error log said to.
+
+## Carry-over (session 2)
+
+- **§E's "filing decision pending" is resolved** — filed as **#228** today. The
+  overnight Carry-over above still reads as pending; it is left as written. #228 is
+  the live item.
+- **#228's fix needs a migration plan** (`ClockInterface` × 4 classes + a #161-shape
+  conversion migration + 2-TZ acceptance + baseline cleanup, with `DEPLOY ORDER MATTERS`).
+  统合リナ: write the plan into #228 and it goes on the owner's docket. **Not started.**
+- **#225 (D11) waits on the 税理士.** The question is in the Review 3 package (#230).
+  `scope-contract.md` is unamended and nothing is implemented, on purpose.
+- **`VERSION` → `1.0.0` when the go-live gate clears** (税理士 Review 3 + Tier A live
+  testing). Both remain external.
+- **`Closes`-leak sweep belongs to the fleet.** #204 here, `clear #264` suspected —
+  two instances, so the pattern is worth a cross-repo pass. 統合リナ has it.
+- **`.mcp.json` still tracked and still modified** (`cc-vault` relay, owner's call to
+  leave it). Never staged today; every `git add` was explicit. The overnight session's
+  note on `.git/info/exclude:7` stands — cross-repo `git rm --cached` is 統合リナ's.
+- **The journal's dating convention has a hole.** An overnight session names its file
+  by the date it finishes, taking the next day's filename; the work actually done that
+  next day then has nowhere to go. Today it was resolved by appending (owner's call,
+  #233). `_work/board.txt` tracks fleet-wide journal placement as @hide's decision.


### PR DESCRIPTION
Closes #233

## 何をするか

`docs/journal/2026-07-16.md` に**日中セッション分**を追記する。
既存本文は**一切変更しない** — `git diff --numstat` = **189 insertions / 0 deletions**。

## なぜ

既存の `2026-07-16.md` は**徹夜セッション（07-15 夜 → 07-16 03:20）**の記録で、扱うのは
#210〜#218。**同日 07-16 日中のセッション（#222 以降の8本）が未記録**だった。

CLAUDE.md の "Journal: record each working day" は **#222 で明文化したばかりの規律**。
その当日に当の作業が抜けるのは筋が通らない。

## 慣習の穴（記録として残した）

日報の初出コミット時刻を実測すると、**書いた時点の日付でファイル名を決める**慣習:

| 日報 | 初出コミット |
| --- | --- |
| `2026-07-10.md` | 2026-07-11 **00:33** |
| `2026-07-14.md` | 2026-07-14 **04:47** |

→ **徹夜セッションが翌日のファイル名を先取りすると、その翌日に実際に働いた分の置き場が無くなる。**
施主判断で 1日=1ファイルの規約に従い**同ファイルへ追記**。穴自体も Carry-over に記録した。

## 既存本文を書き換えなかった理由

**今日 #227 で上流 redteam 文書に適用したのと同じ原則**（記録は書き換えず注記で足す）を、
自分の repo の日報にも適用した。

既存 `## Carry-over` は「§E の 15 D4 findings — **filing decision pending**」と書いているが、
**今日 #228 として起票され解決済み**。原文は残し、**追記パート側で解決を明示**した:

> §E's "filing decision pending" is resolved — filed as **#228** today. The overnight
> Carry-over above still reads as pending; it is left as written. #228 is the live item.

## 記録した主題

| 節 | 内容 |
| --- | --- |
| **F** | 齟齬スイープ — board L54 / #204 の `Closes` 漏れ（`clear #264` が2例目＝フリートのパターン）/ #224 / **#188 でバッジを撤去済みだったから README が健全だった**件 |
| **G** | #98 → #225 温存。`main` が #180 で土台を独立に、しかも良い形で作っていた（`added in both`）。D11 は税理士ブロック |
| **H** | erratum — **誤読の発生源は vault 自身の要約**。records 原文は "exploit" が 0件 |
| **I** | VERSION — **リリース zip が `nene-vault-f647a79.zip` で出ていた** |
| **J** | timezone #228 — **自分がマージした日報を読んでいなかった** |

## Errors made in this session（3件・正直に書いた）

1. **日報を読まずにマージした**（§J）。他は全部この脚注。
2. **transport の `ok` を配達確認と誤認**。hub 停止中（13:56–15:00）に送った3通が全滅。
3. **§E の「15 ignore entries」を未実測のまま引用しかけた**。§E 自身の error log が
   「測っていないことを書くな」と警告していたので再実測し、8 entries / 15 findings に訂正。

🤖 Generated with [Claude Code](https://claude.com/claude-code)