### PR TITLE
refactor(css): W-Spec #236 — selector-max-specificity 48件 + !important 1件を解消する

### DIFF
--- a/frontend/src/shared/ui/theme/themes/default.components.css
+++ b/frontend/src/shared/ui/theme/themes/default.components.css
@@ -7,10 +7,11 @@
    Sub-layer order (`main` then `responsive`) reproduces the pre-split
    cascade: the responsive overrides used to sit OUTSIDE any layer and so
    beat the base component rules regardless of specificity. Inside one flat
-   layer they would instead lose on specificity — e.g. `.tbl.tbl-cards td`
-   (0,2,1) vs `table.tbl td.right` (0,2,2) — silently right-aligning the
-   mobile card cells. Sub-layers restore "responsive always wins" without
-   touching a single selector.
+   layer a lower-specificity responsive rule could instead lose to a
+   higher-specificity base rule — silently dropping a mobile override.
+   Sub-layers restore "responsive always wins" without touching a single
+   selector, which also lets the base selectors below stay low-specificity
+   (`:where(...)` scoping, per selector-max-specificity) without risk.
    ============================================================ */
 @layer components {
   @layer main, responsive;
@@ -499,7 +500,7 @@
       cursor: not-allowed;
       box-shadow: none;
     }
-    .btn[disabled]:active {
+    :where(.btn)[disabled]:active {
       transform: none;
     }
 
@@ -605,7 +606,7 @@
       padding: 7px 13px;
       cursor: pointer;
     }
-    .file-input::file-selector-button:hover {
+    :where(.file-input)::file-selector-button:hover {
       background: var(--color-accent-hover);
     }
 
@@ -630,7 +631,7 @@
       border-bottom: 1px solid var(--color-x-line-mid);
       white-space: nowrap;
     }
-    table.tbl thead th.right {
+    :where(.tbl) thead th.right {
       text-align: right;
     }
     table.tbl tbody td {
@@ -639,16 +640,16 @@
       vertical-align: top;
       color: var(--color-text-primary);
     }
-    table.tbl tbody tr:last-child td {
+    :where(.tbl) tbody tr:last-child td {
       border-bottom: 0;
     }
-    table.tbl tbody tr:hover {
+    :where(.tbl) tbody tr:hover {
       background: var(--color-surface-overlay);
     }
-    table.tbl td.right {
+    :where(.tbl) td.right {
       text-align: right;
     }
-    table.tbl td .pri {
+    :where(.tbl) td .pri {
       font-weight: 600;
       color: var(--color-x-ink-deep);
     }
@@ -692,7 +693,7 @@
       border-radius: 50%;
       background: currentColor;
     }
-    .badge.no-dot::before {
+    :where(.badge).no-dot::before {
       display: none;
     }
     .badge-success {
@@ -830,7 +831,7 @@
       line-height: 1;
       font-variant-numeric: tabular-nums;
     }
-    .stat .v small {
+    :where(.stat) .v small {
       font-family: var(--font-sans);
       font-size: 0.85rem;
       font-weight: 500;
@@ -877,7 +878,7 @@
       align-items: center;
       justify-content: center;
     }
-    .qlink .ic svg {
+    :where(.qlink) .ic svg {
       width: 19px;
       height: 19px;
       stroke: currentColor;
@@ -927,7 +928,7 @@
       padding: 30px 30px 4px;
       text-align: center;
     }
-    .center-card .head .brand-name {
+    :where(.center-card) .head .brand-name {
       color: var(--color-x-ink-deep);
       font-size: 1.5rem;
     }
@@ -1010,7 +1011,7 @@
     .audit-row {
       cursor: pointer;
     }
-    .audit-row:hover .row-chev {
+    :where(.audit-row):hover .row-chev {
       color: var(--color-accent);
       transform: translateX(2px);
     }
@@ -1054,23 +1055,23 @@
     table.audit-table {
       table-layout: fixed;
     }
-    .audit-table thead th:nth-child(1) {
+    :where(.audit-table) thead th:nth-child(1) {
       width: 13%;
     }
-    .audit-table thead th:nth-child(2) {
+    :where(.audit-table) thead th:nth-child(2) {
       width: 17%;
     }
-    .audit-table thead th:nth-child(3) {
+    :where(.audit-table) thead th:nth-child(3) {
       width: 9%;
     }
-    .audit-table thead th:nth-child(4) {
+    :where(.audit-table) thead th:nth-child(4) {
       width: 14%;
     }
-    .audit-table thead th:nth-child(6) {
+    :where(.audit-table) thead th:nth-child(6) {
       width: 34px;
     }
-    .audit-row td.pri,
-    .audit-row td:nth-child(2) {
+    :where(.audit-row) td.pri,
+    :where(.audit-row) td:nth-child(2) {
       overflow-wrap: anywhere;
       word-break: break-word;
     }
@@ -1097,12 +1098,13 @@
       display: block;
     }
     /* keep the chevron vertically centered even when 対象/変更内容 wrap and the
-         row grows tall; the base `table.tbl tbody td { vertical-align: top }` rule
-         would otherwise win on specificity, so !important guarantees we override it */
-    td.chev-cell {
+         row grows tall; scoping to `.audit-table .chev-cell` (0,2,0) outranks the
+         base `table.tbl tbody td { vertical-align: top }` (0,1,3) on specificity,
+         so no !important is needed to override it */
+    .audit-table .chev-cell {
       width: 34px;
       text-align: center;
-      vertical-align: middle !important;
+      vertical-align: middle;
       line-height: 0;
     }
 
@@ -1235,7 +1237,7 @@
     .seg button + button {
       border-left: 1px solid var(--color-x-line-mid);
     }
-    .seg button.is-on {
+    :where(.seg) button.is-on {
       background: var(--color-accent);
       color: var(--color-on-accent);
     }
@@ -1605,12 +1607,12 @@
       }
 
       /* a form's action row spans full width, primary on its own line & reachable */
-      form .row.end {
+      :where(form) .row.end {
         flex-direction: column-reverse;
         align-items: stretch;
         gap: 10px;
       }
-      form .row.end .btn {
+      :where(form .row.end) .btn {
         width: 100%;
       }
 
@@ -1666,26 +1668,26 @@
       .tbl-wrap:has(.tbl-cards) {
         overflow-x: visible;
       }
-      table.tbl.tbl-cards,
-      .tbl.tbl-cards tbody {
+      .tbl.tbl-cards,
+      :where(.tbl.tbl-cards) tbody {
         display: block;
         width: 100%;
       }
-      .tbl.tbl-cards thead {
+      :where(.tbl.tbl-cards) thead {
         display: none;
       }
-      .tbl.tbl-cards tr {
+      :where(.tbl.tbl-cards) tr {
         display: block;
         padding: 14px 16px;
         border-bottom: 1px solid var(--color-border);
       }
-      .tbl.tbl-cards tr:last-child {
+      :where(.tbl.tbl-cards) tr:last-child {
         border-bottom: 0;
       }
-      .tbl.tbl-cards tr:hover {
+      :where(.tbl.tbl-cards) tr:hover {
         background: transparent;
       }
-      .tbl.tbl-cards td {
+      :where(.tbl.tbl-cards) td {
         display: flex;
         align-items: baseline;
         gap: 12px;
@@ -1693,7 +1695,7 @@
         border: 0;
         text-align: left;
       }
-      .tbl.tbl-cards td::before {
+      :where(.tbl.tbl-cards) td::before {
         content: attr(data-label);
         flex: none;
         width: 6.5rem;
@@ -1705,7 +1707,7 @@
         letter-spacing: 0.04em;
       }
       /* title cell (.cell-title): full-width heading, no label */
-      .tbl.tbl-cards td.cell-title {
+      :where(.tbl.tbl-cards) td.cell-title {
         display: block;
         text-align: left;
         font-size: var(--text-body);
@@ -1715,10 +1717,10 @@
         margin-bottom: 6px;
         border-bottom: 1px solid var(--color-border);
       }
-      .tbl.tbl-cards td.cell-title::before {
+      :where(.tbl.tbl-cards) td.cell-title::before {
         display: none;
       }
-      .tbl.tbl-cards td.cell-title .pri {
+      :where(.tbl.tbl-cards td.cell-title) .pri {
         font-weight: 600;
       }
 
@@ -1812,30 +1814,30 @@
         padding: 0;
         border: 0;
       }
-      .audit-row td.pri {
+      :where(.audit-row) td.pri {
         font-size: var(--text-body);
         order: 1;
       }
-      .audit-row td:nth-child(2) {
+      :where(.audit-row) td:nth-child(2) {
         order: 2;
         font-size: var(--text-2xs);
         color: var(--color-text-muted);
         margin-top: 3px;
       }
-      .audit-row td:nth-child(3) {
+      :where(.audit-row) td:nth-child(3) {
         display: none; /* actor — secondary, hidden on mobile */
       }
-      .audit-row td:nth-child(4) {
+      :where(.audit-row) td:nth-child(4) {
         order: 4;
         font-size: var(--text-2xs);
         color: var(--color-text-faint);
         margin-top: 9px;
       }
-      .audit-row td:nth-child(5) {
+      :where(.audit-row) td:nth-child(5) {
         order: 3;
         margin-top: 10px;
       }
-      .audit-row td.chev-cell {
+      :where(.audit-row) td.chev-cell {
         position: absolute;
         right: 14px;
         top: 0;
@@ -1845,7 +1847,7 @@
         align-items: center;
         padding: 0;
       }
-      .audit-row td.chev-cell .row-chev svg {
+      :where(.audit-row td.chev-cell) .row-chev svg {
         width: 18px;
         height: 18px;
       }

--- a/frontend/src/shared/ui/theme/themes/default.components.css
+++ b/frontend/src/shared/ui/theme/themes/default.components.css
@@ -167,7 +167,7 @@
       height: 17px;
       flex: none;
       stroke: currentColor;
-      opacity: 0.78;
+      opacity: var(--rail-icon-op, 0.78);
     }
     .rail-link:hover {
       background: var(--color-x-rail-deep);
@@ -177,10 +177,10 @@
       background: var(--color-x-brass);
       color: var(--color-x-rail);
       font-weight: 600;
-    }
-    .rail-link.is-active svg {
-      opacity: 1;
-      stroke: var(--color-x-rail);
+      /* icon opacity lifted to a custom property so the active-state override
+         needs no descendant selector (was `.rail-link.is-active svg`, 0,2,1).
+         stroke follows `currentColor` from the color above. */
+      --rail-icon-op: 1;
     }
     .rail-foot {
       border-top: 1px solid var(--color-x-rail-line);
@@ -203,11 +203,11 @@
       font-size: 0.8rem;
       text-transform: uppercase;
     }
-    .rail-foot .who {
+    .who {
       min-width: 0;
       flex: 1;
     }
-    .rail-foot .who b {
+    .who b {
       display: block;
       font-size: var(--text-xs);
       color: var(--color-x-rail-ink);
@@ -216,11 +216,11 @@
       overflow: hidden;
       text-overflow: ellipsis;
     }
-    .rail-foot .who span {
+    .who span {
       font-size: var(--text-2xs);
       color: var(--color-x-rail-faint);
     }
-    .rail-foot .out {
+    .out {
       background: none;
       border: 0;
       color: var(--color-x-rail-faint);
@@ -229,11 +229,11 @@
       border-radius: var(--radius-sm);
       display: flex;
     }
-    .rail-foot .out:hover {
+    .out:hover {
       color: var(--color-x-rail-text);
       background: var(--color-x-rail-deep);
     }
-    .rail-foot .out svg {
+    .out svg {
       width: 16px;
       height: 16px;
       stroke: currentColor;
@@ -1400,8 +1400,8 @@
         justify-content: center;
         padding: 14px 0;
       }
-      .rail-foot .who,
-      .rail-foot .out {
+      .who,
+      .out {
         display: none;
       }
       .content {
@@ -1477,10 +1477,10 @@
         z-index: 70;
       }
       .rail-foot .avatar,
-      .rail-foot .who {
+      .who {
         display: none;
       }
-      .rail-foot .out {
+      .out {
         display: flex;
         width: 38px;
         height: 38px;
@@ -1491,11 +1491,11 @@
         border: 1px solid var(--color-x-line-mid);
         border-radius: var(--radius-sm);
       }
-      .rail-foot .out:hover {
+      .out:hover {
         background: var(--color-surface-sunken);
         color: var(--color-x-ink-deep);
       }
-      .rail-foot .out svg {
+      .out svg {
         width: 17px;
         height: 17px;
       }
@@ -1528,7 +1528,7 @@
       .rail-link svg {
         width: 21px;
         height: 21px;
-        opacity: 0.9;
+        opacity: var(--rail-icon-op, 0.9);
       }
       .rail-link:hover {
         background: transparent;
@@ -1538,10 +1538,7 @@
         background: transparent;
         color: oklch(76% 0.1 77);
         font-weight: 700;
-      }
-      .rail-link.is-active svg {
-        stroke: oklch(76% 0.1 77);
-        opacity: 1;
+        --rail-icon-op: 1;
       }
 
       /* top app bar */


### PR DESCRIPTION
## 概要

Closes #236。`selector-max-specificity`（上限 `0,2,0`）違反 **48件**と
`declaration-no-important` **1件**を、対象1ファイル
`frontend/src/shared/ui/theme/themes/default.components.css` の中だけで解消する。

**全変更が視覚 no-op**（マッチ集合を一切変えず specificity のみ低下）・**tsx 無変更**。

## 計測（fleet nene2-standards stylelint 実測）

| ルール | before | after |
|---|---|---|
| `selector-max-specificity` | 48 | **0** |
| `declaration-no-important` | 1 | **0** |

## 手法

2コミット構成:

1. **`2bc9ced` rail 8件**: 祖先削除（`.rail-foot .who/.out` → `.who/.out`、グローバル
   ユニーク確認済み）＋ 変数リフト（`.rail-link.is-active svg` → `--rail-icon-op`
   カスタムプロパティ継承）。base と子を一律に下げカスケード順を保存。

2. **`3b9d006` 残り40件 + !important**:
   - **`:where()` スコープ中和**（主手法）: 先頭のスコープ用クラス/祖先を `:where()`
     で括り specificity を 0 に落とす。マッチ対象は不変なので rail の「祖先削除」を
     **スコープ破壊なしで行う非破壊版**に相当。table / audit / tbl-cards / seg /
     form / badge / stat / qlink / center-card の擬似クラス・`:nth-child`・多クラス
     複合に適用。
     例) `.tbl.tbl-cards tr:hover` (0,3,1) → `:where(.tbl.tbl-cards) tr:hover` (0,1,1)
   - **要素タグ落とし**: `table.tbl.tbl-cards` (0,2,1) → `.tbl.tbl-cards` (0,2,0)
   - **!important 除去**: `td.chev-cell` → `.audit-table .chev-cell` (0,2,0) へ昇格し、
     base `table.tbl tbody td` (0,1,3) を specificity で上回らせ `!important` 不要に。

### 引継ぎ案からの設計変更（レビュー観点）

当初案は audit 系（`:nth-child`）を tsx の列クラス付与で解く想定だったが、
`.audit-table th:nth-child(1)` は `:nth-child` がクラス級で **0,2,1**（`thead` 削除
だけでは 0,2,0 に収まらない）という誤算に基づいていた。`:where()` なら **CSS のみ・
厳密 no-op・markup churn ゼロ**で全件解けるため、「視覚 no-op 最優先」に照らしこちらを
採用。ファイル冒頭のサブレイヤ説明コメントの旧 specificity 例も実態に合わせ更新した。
`:where()` は全モダンブラウザ対応（管理 UI・React+Vite）。

## 検証

- `npx stylelint`（fleet config）: `selector-max-specificity` 0 / `declaration-no-important` 0
- `npm run check --prefix frontend` **緑**: tsc / eslint `--max-warnings 0` /
  format / vitest **221 passed** / knip / build-storybook
- **目視スモーク**: `docker compose up`（Front 5186）でログイン・ホーム・一覧テーブル
  （＋モバイル幅カード）・監査ログ（＋モバイル）・ドロワー各画面を確認、**視覚差分なし**を
  施主確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
