### PR TITLE
docs(journal): 2026-07-17 の作業日報を書く（#242）

### DIFF
--- a/docs/journal/2026-07-17.md
+++ b/docs/journal/2026-07-17.md
@@ -1,0 +1,105 @@
+# 2026-07-17 — Frontend refactor burst: W-Spec specificity shipped, Lane 1 blocker diagnosed, A1 migrated
+
+A relay-coordinated frontend day inside the fleet burst (統合リナ / hub middling).
+Three lanes moved: the W-Spec `selector-max-specificity` rewrite reached zero and
+merged; the Lane 1 stylelint-gate wiring was diagnosed as blocked on a fleet-level
+registry and parked with a seed handed upstream; and the A1 `hooks/`→`model/`
+migration was applied by codemod and merged. All numbers below are measured on this
+machine unless tagged [reported] (relayed via hub) — the daily-report discipline of
+splitting measured from hearsay.
+
+## W-Spec #236 — selector-max-specificity 48→0 + !important 1→0 (#236 → PR #237, merged)
+
+Closed out the remaining 40 `selector-max-specificity` violations (rail's 8 were
+done in `2bc9ced`) plus the lone `declaration-no-important`, all in
+`frontend/src/shared/ui/theme/themes/default.components.css`. Final stylelint on the
+fleet config: `selector-max-specificity` 0, `declaration-no-important` 0 [measured].
+
+The technique diverged from the hand-off's plan. The hand-off proposed solving the
+audit `:nth-child` cases by adding column classes in the `.tsx` — but that rested on
+a miscalculation: `.audit-table th:nth-child(1)` is `0,2,1` (a `:nth-child` counts as
+a class, not an element), so dropping `thead` alone would still fail `0,2,0`. Instead
+every offending selector was fixed by wrapping its scoping class/ancestor in
+`:where()`, which zeroes that part's specificity while leaving the match set
+untouched — the non-destructive form of "ancestor deletion", and an exact visual
+no-op with **zero** `.tsx` churn. Verified empirically that the fleet stylelint
+plugin scores `:where()` contents as 0. The `!important` was removed by promoting
+`td.chev-cell` to `.audit-table .chev-cell` (`0,2,0`), which outranks the base
+`table.tbl tbody td` (`0,1,3`) on specificity without it.
+
+`npm run check --prefix frontend` green: tsc, eslint `--max-warnings 0`, format,
+vitest **221 passed / 38 files**, knip, build-storybook [measured]. Owner ran the
+docker smoke (front 5186) across login / home / tables (+ mobile card layout) / audit
+(+ mobile) / drawer — **no visual difference** confirmed. hub reviewed and APPROVE'd
+[reported]; squash-merged to `ace0cf0`.
+
+One dev-env aside surfaced during the smoke: the container frontend (5186) failed to
+resolve `@hideyukimori/nene2-client` because its `frontend_modules` named volume
+predated that dependency. Fixed with `docker compose exec frontend npm ci` + restart;
+unrelated to the CSS change.
+
+## Lane 1 stylelint gate — blocked on a fleet registry, parked (#238, open)
+
+Attempting to wire the payout-style gate (one-line `extends` of
+`@hideyukimori/nene2-standards/stylelint`) turned **409 red** — not on specificity
+(that is genuinely 0) but on a *different* rule, `nene2/layer-components-allowlist`,
+which fail-closed rejects every `@layer components` class not enumerated in a central
+allowlist. The diagnosis corrected the burst's premise:
+
+- **payout was a false template**: payout's frontend has *no* `@layer components` CSS
+  (26 lines of token CSS total), so its gate is green vacuously. The "one-line extends
+  = green" proves the plumbing, not that a real component-CSS repo can pass.
+- vault has a real 1864-line `@layer components` file = **156 classes**, all
+  unregistered (`nene2-check init --scan`) [measured].
+- the central allowlist ledger **does not exist yet** — `init-scan.js`'s `initCheck`
+  itself states the ledger is undefined and reports all tokens as "要分類".
+- registration is fleet-tooling-only; a product-repo-side allowlist **fails
+  gate-integrity** (`fleet.jsonc` REG-2), so no local workaround was taken.
+- `nene-invoice` is in the same position (real component CSS, gate unwired).
+
+So vault's gate cannot go green until fleet-tooling defines the component-allowlist
+ledger and registers vault's 156 classes (and invoice's) and republishes. The blocker
+was relayed to hub, who confirmed the hand-off premise was wrong and moved fleet#65
+(ledger design) forward [reported]. The 156-class scan was written to
+`_work/reports/2026-07-17-vault-components-allowlist-seed.json` as the registration
+seed and its path relayed to hub/fleet. Lane 1 parked, the throwaway wiring reverted,
+#238 kept open with the diagnosis.
+
+## Unused CSS `.stat` — cleanup filed (#239)
+
+While mapping #236, found the `.stat` "stat tiles (home)" block (`.stat` / `.k` / `.v`
+/ `.v small` / `.meta` / `::before` + responsive) defined but rendered nowhere — no
+`.tsx`/`.ts` usage at all (the only "stat" hit is the word "statutory" in a comment).
+knip sees JS deps only, not dead CSS classes, so it never flags this. Filed #239 as a
+low-priority cleanup candidate.
+
+## A1 — features' hooks/ → model/ migrated by codemod (#240 → PR #241, merged)
+
+Applied the fleet A1 codemod `nene2-a1-hooks-to-model`
+(`@hideyukimori/nene2-standards@1.1.0`) to bring the 4 features into FSD §1-3 ("hooks
+live in `model/`"). fleet ruled **(a) directory-move-only** (no rename) with vault as
+pilot [reported]; no manual moving.
+
+Result [measured]: **10 files moved** (5 hooks + 5 co-located tests), `hooks/` →
+`model/`, all detected by git as **100% pure renames** (content unchanged); all 4
+features gained `model/`, no `hooks/` dir remains. **7 importer files / 8 sites**
+rewritten (2 barrels + 6 ui→hooks relative imports) — a single `hooks/`→`model/` path
+token each, product logic untouched. `shared/i18n/use-translation.ts` left alone
+(shared segment, out of A1 scope). Confirmed the dry-run's `rewrite 0` is the known
+lie hub flagged (dry-run does not tally rewrites) — the real apply reported rewrite 7.
+`npm run check` green (vitest **221 passed**); merged to `d46a21e` under
+evidence-3-point self-merge (dry-run plan + full check green + move-only diff).
+
+## Carry-over
+
+- **Lane 1 resume** is gated on fleet-tooling shipping the component-allowlist ledger
+  (fleet#65) and registering vault's 156 classes + invoice's; hub middles the restart.
+  The plan is fixed: payout plumbing + 156 registration + mutation-injection red proof.
+- **`.stat` cleanup (#239)** — do at discretion anytime; will drop those classes from
+  the Lane 1 seed if done first.
+- **Daily-report convention divergence.** The fleet daily-report 正本
+  (`_work/daily-report-convention.md`, confirmed today) mandates `docs/daily/` in
+  Japanese, but vault still uses `docs/journal/` in English (ADR 0008 is live). This
+  entry follows vault's current rule; migrating to `docs/daily/` + the language split
+  needs the pending ADR 0008 partial-supersession first (separate Issue).
+- **timezone #228/#235** stays a post-launch gate — untouched.


### PR DESCRIPTION
Closes #242。2026-07-17 の vault 作業を `docs/journal/2026-07-17.md` に記録（ADR 0008・英語・precedent `2026-07-14.md` の shape）。

## トピック
- **W-Spec #236**（specificity 48→0 + !important・`:where()` 中和・PR #237 merged）
- **Lane 1 blocker**（`layer-components-allowlist` 中央台帳未定義・REG-2・156-class seed 転送・#238 park）
- **`.stat` 未使用 CSS**（#239 起票）
- **A1**（hooks→model codemod・10ファイル100%純粋rename・PR #241 merged・証拠3点 self-merge）

数字は実測/[reported]（hub 経由伝聞）を書き分け（fleet 日報規律）。

## 補足（別件）
fleet 日報正本（`docs/daily/`・日本語）と vault 現行（`docs/journal/`・英語・ADR 0008 live）の乖離は Carry-over に明記。移行は ADR 0008 部分 supersede と併せ別 Issue。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
