### PR TITLE
ci: frontend-ci を全 PR で常時実行にし job 名を一意化する（#246）

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -4,18 +4,12 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'frontend/**'
-      - '.github/workflows/frontend-ci.yml'
   pull_request:
     branches:
       - main
-    paths:
-      - 'frontend/**'
-      - '.github/workflows/frontend-ci.yml'
 
 jobs:
-  check:
+  frontend-check:
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
## 概要

完全準拠 Phase 0-1b。施錠済み required `check` の実効性を full にする。

## 変更（`frontend-ci.yml` のみ）

- `paths: frontend/**` フィルタを `push`/`pull_request` 両方から**除去** → 全 PR・main push で常時実行（backend-ci と同じ形）。**0-1b②**（docs/backend-only PR で frontend check が走らない設計を解消）。
- job 名 `check` → **`frontend-check`** に一意化（backend の `check` と status context が衝突していた）。**0-1b①③**。

## 🔴 デッドロック回避（backend を `check` のまま維持する理由）

backend job 名 `check` を変えると、施錠済み required context `check` を生成する job が消え、**この PR 自身が required 未達で merge 不能**（enforce_admins:true）。よって backend は `check` を維持し、frontend のみ改名。これで:

- 本 PR は backend `check` が required を満たすので **self-merge 可能**。
- job 名の衝突（①）は解消（`check` と `frontend-check` で一意）。

## merge 後の hub 手番

- required contexts に `frontend-check` を **追加**（`check` は維持）→ ①②③ 機能的クローズ。
- backend の `backend-check` 化を望む場合は required から `check` を外す hub 順序が先に要る（別タスク）。

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)