### PR TITLE
test(frontend): audit diff の純関数に UT を追加する (#251)

### DIFF
--- a/frontend/src/entities/audit/diff.test.ts
+++ b/frontend/src/entities/audit/diff.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { diffAuditEvent, formatAuditValue } from './diff';
+
+describe('formatAuditValue', () => {
+  it('renders null and undefined as "null"', () => {
+    expect(formatAuditValue(null)).toBe('null');
+    expect(formatAuditValue(undefined)).toBe('null');
+  });
+
+  it('wraps strings in double quotes', () => {
+    expect(formatAuditValue('hello')).toBe('"hello"');
+    expect(formatAuditValue('')).toBe('""');
+  });
+
+  it('renders numbers and booleans via JSON', () => {
+    expect(formatAuditValue(42)).toBe('42');
+    expect(formatAuditValue(0)).toBe('0');
+    expect(formatAuditValue(true)).toBe('true');
+    expect(formatAuditValue(false)).toBe('false');
+  });
+
+  it('renders arrays and objects as JSON', () => {
+    expect(formatAuditValue([1, 2])).toBe('[1,2]');
+    expect(formatAuditValue({ a: 1 })).toBe('{"a":1}');
+  });
+});
+
+describe('diffAuditEvent', () => {
+  it('returns an empty list when both snapshots are null', () => {
+    expect(diffAuditEvent(null, null)).toEqual([]);
+  });
+
+  it('reports every field as an addition on a creation event (before null)', () => {
+    const after = { amount_cents: 1000, counterparty_name: 'ACME' };
+
+    expect(diffAuditEvent(null, after)).toEqual([
+      { key: 'amount_cents', kind: 'add', before: null, after: 1000 },
+      { key: 'counterparty_name', kind: 'add', before: null, after: 'ACME' },
+    ]);
+  });
+
+  it('reports only the fields that changed between two snapshots', () => {
+    const before = { amount_cents: 1000, counterparty_name: 'ACME', note: 'x' };
+    const after = { amount_cents: 2000, counterparty_name: 'ACME', note: 'x' };
+
+    expect(diffAuditEvent(before, after)).toEqual([
+      { key: 'amount_cents', kind: 'mod', before: 1000, after: 2000 },
+    ]);
+  });
+
+  it('excludes fields whose values are deeply equal', () => {
+    const before = { tags: ['a', 'b'], meta: { n: 1 } };
+    const after = { tags: ['a', 'b'], meta: { n: 1 } };
+
+    expect(diffAuditEvent(before, after)).toEqual([]);
+  });
+
+  it('detects changes inside nested structures', () => {
+    const before = { meta: { n: 1 } };
+    const after = { meta: { n: 2 } };
+
+    expect(diffAuditEvent(before, after)).toEqual([
+      { key: 'meta', kind: 'mod', before: { n: 1 }, after: { n: 2 } },
+    ]);
+  });
+
+  it('reports a key present only in the after snapshot as a modification', () => {
+    const before = { amount_cents: 1000 };
+    const after = { amount_cents: 1000, counterparty_name: 'ACME' };
+
+    expect(diffAuditEvent(before, after)).toEqual([
+      { key: 'counterparty_name', kind: 'mod', before: undefined, after: 'ACME' },
+    ]);
+  });
+
+  it('reports a removed field (after null) as a modification to undefined', () => {
+    const before = { amount_cents: 1000, note: 'x' };
+
+    expect(diffAuditEvent(before, null)).toEqual([
+      { key: 'amount_cents', kind: 'mod', before: 1000, after: undefined },
+      { key: 'note', kind: 'mod', before: 'x', after: undefined },
+    ]);
+  });
+
+  it('does not treat a field that is absent on both sides as a change', () => {
+    const before = { amount_cents: 1000 };
+    const after = { amount_cents: 1000 };
+
+    expect(diffAuditEvent(before, after)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## 概要

T1-lite（フロントテスト厳格化キャンペーン・計画正本 `_work/reports/2026-07-18-front-test-hardening-plan.md`）の初弾。
T0 棚卸しの「テスト0の重要ロジック TOP5」筆頭 `entities/audit/diff.ts`（監査 before/after diff の純関数）に UT を追加する。

Closes なし（#251 の TOP5 チェックリストのうち audit diff の1項目を消化。残りは後続 PR）。

## 変更

- `frontend/src/entities/audit/diff.test.ts` を新規追加（12 ケース）。
  - `formatAuditValue`: null/undefined→`"null"`・文字列の二重引用・数値/真偽・配列/オブジェクトの JSON 表現
  - `diffAuditEvent`: 両 null→空・生成イベント(before null)の全 `add`・変更フィールドのみ抽出・
    深い等価(JSON.stringify)での除外・ネスト構造の変更検知・after のみのキー/削除(after null)の `mod` 表現

## 性質

- **テスト追加のみ**。プロダクトコード・config（vitest.config・package.json）・依存の変更は一切なし。
- base=main。中断可能な粒度（1ファイル）。arm/W1 号令が来たら本レーンは中断可。

## 確認

- `npx vitest run src/entities/audit/diff.test.ts` → 12 passed
- `npm test`（全 suite）→ 39 files / 233 passed
- `npm run type-check` / `eslint`（新規ファイル）/ `prettier --check` → いずれもクリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)
