### PR TITLE
test(frontend): auth useLogin の session マッピングに UT を追加する (#251)

### DIFF
--- a/frontend/src/entities/auth/mutations.test.ts
+++ b/frontend/src/entities/auth/mutations.test.ts
@@ -1,0 +1,65 @@
+import { act, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { renderHookWithProviders } from '@tests/render/render-with-providers';
+import { authStore } from './model';
+import { useLogin } from './mutations';
+
+const VALID = { email: 'admin@example.com', password: 'secret' };
+
+afterEach(() => {
+  sessionStorage.clear();
+});
+
+describe('useLogin', () => {
+  it('maps the snake_case login response to a camelCase session', async () => {
+    const { result } = renderHookWithProviders(() => useLogin());
+
+    act(() => {
+      result.current.mutate(VALID);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    // toSession maps user_id → userId and org_id → orgId.
+    expect(result.current.data).toEqual({
+      token: 'test-jwt-token',
+      userId: 1,
+      email: 'admin@example.com',
+      role: 'admin',
+      orgId: 1,
+    });
+  });
+
+  it('persists the session so getToken/getSession reflect it', async () => {
+    const { result } = renderHookWithProviders(() => useLogin());
+
+    act(() => {
+      result.current.mutate(VALID);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(authStore.getToken()).toBe('test-jwt-token');
+    expect(authStore.getSession()?.orgId).toBe(1);
+  });
+
+  it('does not persist a session and surfaces an error on invalid credentials', async () => {
+    const { result } = renderHookWithProviders(() => useLogin());
+
+    act(() => {
+      result.current.mutate({ email: 'admin@example.com', password: 'wrong' });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error).not.toBeNull();
+    expect(result.current.data).toBeUndefined();
+    expect(authStore.getToken()).toBeNull();
+  });
+});


### PR DESCRIPTION
## 概要

T1-lite（フロントテスト厳格化キャンペーン）の TOP5 #2。`entities/auth/mutations.ts` の
`useLogin` を **entity 単体**で固める。従来は feature `useLoginPage`（`use-login.test.tsx`）
経由の間接カバーのみで、`toSession` の snake_case→camelCase マッピングが直接は検証されていなかった。

#251 の TOP5 チェックリストのうち auth mutations の1項目を消化。

## 変更

- `frontend/src/entities/auth/mutations.test.ts` 新規（3ケース・MSW `/admin/auth/login` handler 流用）。
  - 成功時: `user_id→userId`・`org_id→orgId` を含む camelCase `AuthSession` への写像
  - 永続化: `authStore.getToken()`/`getSession()` にセッション反映
  - 認証失敗(401): セッション未永続・`isError`／`error` 表面化・`data` は undefined

## 性質

- **テスト追加のみ**。プロダクトコード・config・依存の変更ゼロ。base=main。中断可能な粒度（1ファイル）。

## 確認

- `npx vitest run src/entities/auth/mutations.test.ts` → 3 passed
- `npm test`（全 suite）→ 40 files / 236 passed
- type-check / eslint / prettier → クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)
