### PR TITLE
test(frontend): document OCR suggest フックに UT を追加する (#251)

### DIFF
--- a/frontend/src/entities/document/ocr.test.ts
+++ b/frontend/src/entities/document/ocr.test.ts
@@ -1,0 +1,104 @@
+import { act, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+import { renderHookWithProviders } from '@tests/render/render-with-providers';
+import { server } from '@tests/msw/server';
+import { useOcrSuggest } from './ocr';
+
+const OCR_PATH = '/admin/vault/documents/:id/ocr-suggest';
+const DOC_ID = 'doc-123';
+
+describe('useOcrSuggest', () => {
+  it('maps the suggestion response to a prefill, dropping non-prefill fields', async () => {
+    server.use(
+      http.get(OCR_PATH, () =>
+        HttpResponse.json({
+          document_id: DOC_ID,
+          transaction_date: '2026-07-01',
+          amount_cents: 12345,
+          counterparty_name: 'ACME Corp',
+          has_suggestion: true,
+        }),
+      ),
+    );
+
+    const { result } = renderHookWithProviders(() => useOcrSuggest());
+
+    let prefill: unknown;
+    await act(async () => {
+      prefill = await result.current.suggest(DOC_ID);
+    });
+
+    // document_id and has_suggestion are intentionally not part of OcrPrefill.
+    expect(prefill).toEqual({
+      transaction_date: '2026-07-01',
+      amount_cents: 12345,
+      counterparty_name: 'ACME Corp',
+    });
+  });
+
+  it('passes null fields through when the server has no suggestion', async () => {
+    server.use(
+      http.get(OCR_PATH, () =>
+        HttpResponse.json({
+          document_id: DOC_ID,
+          transaction_date: null,
+          amount_cents: null,
+          counterparty_name: null,
+          has_suggestion: false,
+        }),
+      ),
+    );
+
+    const { result } = renderHookWithProviders(() => useOcrSuggest());
+
+    let prefill: unknown;
+    await act(async () => {
+      prefill = await result.current.suggest(DOC_ID);
+    });
+
+    expect(prefill).toEqual({
+      transaction_date: null,
+      amount_cents: null,
+      counterparty_name: null,
+    });
+  });
+
+  it('returns null when the request fails', async () => {
+    server.use(http.get(OCR_PATH, () => HttpResponse.json({}, { status: 500 })));
+
+    const { result } = renderHookWithProviders(() => useOcrSuggest());
+
+    let prefill: unknown = 'unset';
+    await act(async () => {
+      prefill = await result.current.suggest(DOC_ID);
+    });
+
+    expect(prefill).toBeNull();
+  });
+
+  it('is not loading once a request settles', async () => {
+    server.use(
+      http.get(OCR_PATH, () =>
+        HttpResponse.json({
+          document_id: DOC_ID,
+          transaction_date: null,
+          amount_cents: null,
+          counterparty_name: null,
+          has_suggestion: false,
+        }),
+      ),
+    );
+
+    const { result } = renderHookWithProviders(() => useOcrSuggest());
+    expect(result.current.isLoading).toBe(false);
+
+    await act(async () => {
+      await result.current.suggest(DOC_ID);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## 概要

T1-lite TOP5 #3。`entities/document/ocr.ts` の `useOcrSuggest`（受領文書の OCR 事前入力）を固める。
per-test の `server.use()` で OCR エンドポイントを差し込むため、共有 MSW handler は変更しない。

#251 の TOP5 チェックリストのうち document OCR の1項目を消化。

## 変更

- `frontend/src/entities/document/ocr.test.ts` 新規（4ケース）。
  - 成功時: レスポンスを `OcrPrefill` に写像し `document_id`／`has_suggestion` を落とす
  - 提案なし(has_suggestion=false): null フィールドをそのまま通す
  - リクエスト失敗(500): `null` を返す（呼び出し側フォールバックの契約）
  - `isLoading` が settle 後に false

## 性質

- テスト追加のみ。プロダクトコード・config・依存・共有 handler の変更ゼロ。base=main。

## 確認

- `npx vitest run src/entities/document/ocr.test.ts` → 4 passed
- `npm test`（全 suite）→ 41 files / 240 passed
- type-check / eslint / prettier → クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)
