### PR TITLE
test(frontend): env 検証と i18n catalogs に UT を追加する (#251)

### DIFF
--- a/frontend/src/shared/config/env.test.ts
+++ b/frontend/src/shared/config/env.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+describe('env', () => {
+  it('applies defaults when the VITE_ vars are absent', async () => {
+    vi.resetModules();
+    const { env } = await import('./env');
+
+    expect(env.apiBaseUrl).toBe('');
+    expect(env.uploadMaxFileSizeMb).toBe(20);
+  });
+
+  it('reads the API base URL and coerces the max file size to an integer', async () => {
+    vi.stubEnv('VITE_NENE_VAULT_API_BASE_URL', 'https://api.example.test');
+    vi.stubEnv('VITE_NENE_VAULT_MAX_FILE_SIZE_MB', '50');
+    vi.resetModules();
+    const { env } = await import('./env');
+
+    expect(env.apiBaseUrl).toBe('https://api.example.test');
+    expect(env.uploadMaxFileSizeMb).toBe(50);
+    expect(Number.isInteger(env.uploadMaxFileSizeMb)).toBe(true);
+  });
+});

--- a/frontend/src/shared/i18n/catalogs.test.ts
+++ b/frontend/src/shared/i18n/catalogs.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { catalogs, dynamicMessageKey } from './catalogs';
+
+/** Collects every dot-notation path to a non-object leaf. */
+function leafPaths(value: unknown, prefix = ''): string[] {
+  if (value === null || typeof value !== 'object') {
+    return [prefix];
+  }
+  const paths: string[] = [];
+  for (const [key, child] of Object.entries(value)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    paths.push(...leafPaths(child, path));
+  }
+  return paths;
+}
+
+describe('catalogs', () => {
+  it('exposes both supported locales', () => {
+    expect(Object.keys(catalogs).sort()).toEqual(['en', 'ja']);
+  });
+
+  it('ja and en share an identical key structure (#137 / #166 parity guard)', () => {
+    const ja = leafPaths(catalogs.ja).sort();
+    const en = leafPaths(catalogs.en).sort();
+
+    expect(ja.length).toBeGreaterThan(0);
+    expect(en).toEqual(ja);
+  });
+});
+
+describe('dynamicMessageKey', () => {
+  it('returns the key unchanged (runtime identity escape hatch)', () => {
+    const key = 'audit_event.action.document.uploaded';
+    expect(dynamicMessageKey(key)).toBe(key);
+  });
+});


### PR DESCRIPTION
## 概要

T1-lite TOP5 の #4・#5。いずれも小さい shared 層（env 19L・catalogs 33L）のため
統合リナ承認の「自明に小さい隣接対象は 2-3 本束ねても可」に従い 1 PR に束ねる。
これで #251 の TOP5 チェックリストが全消化。

## 変更

- `frontend/src/shared/config/env.test.ts`（2ケース）
  - VITE_ 未設定時のデフォルト（`apiBaseUrl=''`・`uploadMaxFileSizeMb=20`）
  - `VITE_NENE_VAULT_API_BASE_URL` 読み取り＋`VITE_NENE_VAULT_MAX_FILE_SIZE_MB` の int coerce（`vi.stubEnv` + `vi.resetModules` + 動的 import）
- `frontend/src/shared/i18n/catalogs.test.ts`（3ケース）
  - `catalogs` が ja/en 両ロケールを公開
  - **ja/en のリーフキー・パリティ**（#137/#166 の bug class を runtime でガード）
  - `dynamicMessageKey` の identity（backend 由来キーの escape hatch）

## 性質

- テスト追加のみ。プロダクトコード・config（vitest.config・package.json）・依存の変更ゼロ。base=main。

## 確認

- `npx vitest run src/shared/config/env.test.ts src/shared/i18n/catalogs.test.ts` → 5 passed
- `npm test`（全 suite）→ 43 files / 245 passed
- type-check / eslint / prettier → クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)
