### PR TITLE
test(frontend): AuditPage にセマンティッククエリの UT を追加する (#258)

### DIFF
--- a/frontend/src/pages/AuditPage.test.tsx
+++ b/frontend/src/pages/AuditPage.test.tsx
@@ -1,0 +1,108 @@
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { renderWithProviders } from '@tests/render/render-with-providers';
+import { DOCUMENT_ID, mockAuditEventList } from '@tests/msw/fixtures';
+import { server } from '@tests/msw/server';
+import { authStore } from '@/entities/auth';
+import { AuditPage } from './AuditPage';
+
+// Default locale in jsdom resolves to 'en' (navigator.language = 'en-US'),
+// so assertions reference the English catalog. Data values (entity id, type,
+// snapshot contents) are locale-independent and preferred where possible.
+
+function renderPage() {
+  return renderWithProviders(
+    <MemoryRouter>
+      <AuditPage />
+    </MemoryRouter>,
+  );
+}
+
+// The entity cell renders `{entity_type}/{entity_id}` as several text nodes in
+// one <td>, so match the cell by its full textContent rather than a fragment.
+const ENTITY_TEXT = `vault_document/${DOCUMENT_ID}`;
+const entityCell = (_: string, el: Element | null): boolean =>
+  el?.tagName === 'TD' && el.textContent === ENTITY_TEXT;
+
+beforeEach(() => {
+  authStore.setSession({
+    token: 'test-jwt-token',
+    userId: 1,
+    email: 'admin@example.com',
+    role: 'admin',
+    orgId: 1,
+  });
+});
+
+describe('AuditPage', () => {
+  it('renders the audit log with the seeded event', async () => {
+    renderPage();
+
+    expect(await screen.findByRole('heading', { level: 1, name: 'Audit Log' })).toBeInTheDocument();
+    // The event row exposes its entity type and id (locale-independent data).
+    expect(await screen.findByText(entityCell)).toBeInTheDocument();
+    expect(screen.getByRole('table')).toBeInTheDocument();
+  });
+
+  it('opens the detail dialog with the created values when a row is activated', async () => {
+    renderPage();
+
+    const idCell = await screen.findByText(entityCell);
+    const row = idCell.closest('[role="button"]');
+    expect(row).not.toBeNull();
+
+    await userEvent.click(row as HTMLElement);
+
+    const dialog = await screen.findByRole('dialog');
+    // before_json is null → a creation event → the after snapshot is shown.
+    expect(within(dialog).getByText(/Sample Inc\./)).toBeInTheDocument();
+  });
+
+  it('shows the empty state and no table when there are no events', async () => {
+    server.use(
+      http.get('/admin/audit-events', () =>
+        HttpResponse.json({ items: [], total: 0, limit: 20, offset: 0 }),
+      ),
+    );
+
+    renderPage();
+
+    expect(await screen.findByText('No audit events')).toBeInTheDocument();
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    expect(screen.queryByText(entityCell)).not.toBeInTheDocument();
+  });
+
+  it('shows an error message when the request fails', async () => {
+    server.use(http.get('/admin/audit-events', () => HttpResponse.json({}, { status: 500 })));
+
+    renderPage();
+
+    expect(await screen.findByText('An error occurred')).toBeInTheDocument();
+  });
+
+  it('re-queries with the entity_type filter when a search is committed', async () => {
+    const requestedUrls: string[] = [];
+    server.use(
+      http.get('/admin/audit-events', ({ request }) => {
+        requestedUrls.push(request.url);
+        return HttpResponse.json(mockAuditEventList);
+      }),
+    );
+
+    renderPage();
+    await screen.findByText(entityCell);
+
+    // The three filter inputs are the page's text boxes, in document order:
+    // entity type, entity id, action.
+    const [entityTypeInput] = screen.getAllByRole('textbox');
+    await userEvent.type(entityTypeInput as HTMLElement, 'vault_document');
+    await userEvent.click(screen.getByRole('button', { name: 'Search' }));
+
+    await waitFor(() => {
+      expect(requestedUrls.some((u) => u.includes('entity_type=vault_document'))).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## 概要

T1-lite の大型ページ tsx 第一弾（統合リナ推奨順 AuditPage→UsersPage→AppShell の 1本目）。
`AuditPage.tsx`（429L・監査ログ＝vault の Hard Rule 中核）に UT を追加する。

承認済み条件を厳守: **セマンティッククエリのみ**（`getByRole`/`getByText`）・
**className/style/snapshot 断言なし** ＝ W3 の sub-layer 解体（CSS 再生成）を生き延びる書き方。

## 変更

- `frontend/src/pages/AuditPage.test.tsx` 新規（5ケース）
  - 一覧が seed イベントを描画（`heading`「Audit Log」・`table`・entity セル値）
  - 行アクティベートで**詳細ドロワー**（`role="dialog"`）が開き created 値（`Sample Inc.`）を表示
  - イベント0件で空状態（`No audit events`）・`table` 非表示
  - 取得失敗（500）でエラーメッセージ（`An error occurred`）
  - `entity_type` フィルタ確定で `entity_type=...` クエリ付きの再取得（request URL で検証）

## 補足

- 既定ロケールは jsdom の `navigator.language='en-US'` → `en`。翻訳文言は英カタログ実値、
  それ以外はロケール非依存のデータ値（entity id/type・スナップショット内容）で断言。
- entity セルは `{entity_type}/{entity_id}` を1つの `<td>` に複数テキストノードで描画するため、
  セル全体の `textContent` に一致する関数マッチャで参照（要素分割に頑健）。

## 確認

- `npx vitest run src/pages/AuditPage.test.tsx` → 5 passed
- `npm test`（全 suite）→ 44 files / 250 passed
- type-check / eslint / prettier → クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)
