### PR TITLE
test(frontend): UsersPage にセマンティッククエリの UT を追加する (#258)

### DIFF
--- a/frontend/src/pages/UsersPage.test.tsx
+++ b/frontend/src/pages/UsersPage.test.tsx
@@ -1,0 +1,116 @@
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '@tests/render/render-with-providers';
+import { server } from '@tests/msw/server';
+import { authStore } from '@/entities/auth';
+import { UsersPage } from './UsersPage';
+
+// jsdom resolves to the 'en' catalog (navigator.language = 'en-US').
+// The seeded list has one user: id 42, member@example.com.
+
+function signInAs(userId: number) {
+  authStore.setSession({
+    token: 'test-jwt-token',
+    userId,
+    email: 'admin@example.com',
+    role: 'admin',
+    orgId: 1,
+  });
+}
+
+function renderPage() {
+  return renderWithProviders(
+    <MemoryRouter>
+      <UsersPage />
+    </MemoryRouter>,
+  );
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('UsersPage', () => {
+  it('renders the user list', async () => {
+    signInAs(1);
+    renderPage();
+
+    expect(await screen.findByRole('heading', { level: 1, name: 'Users' })).toBeInTheDocument();
+    expect(await screen.findByText('member@example.com')).toBeInTheDocument();
+    expect(screen.getByRole('table')).toBeInTheDocument();
+  });
+
+  it('hides the delete action on the signed-in user’s own row (self-delete guard)', async () => {
+    signInAs(42); // same id as the seeded user
+    renderPage();
+
+    await screen.findByText('member@example.com');
+    expect(screen.queryByRole('button', { name: 'Delete' })).not.toBeInTheDocument();
+  });
+
+  it('deletes another user after confirmation', async () => {
+    signInAs(1); // different id → the row is deletable
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    let deletedId: string | undefined;
+    server.use(
+      http.delete('/admin/users/:id', ({ params }) => {
+        deletedId = params['id'] as string;
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    renderPage();
+    await screen.findByText('member@example.com');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => {
+      expect(deletedId).toBe('42');
+    });
+  });
+
+  it('does not delete when the confirmation is dismissed', async () => {
+    signInAs(1);
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+
+    let deleteCalled = false;
+    server.use(
+      http.delete('/admin/users/:id', () => {
+        deleteCalled = true;
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    renderPage();
+    await screen.findByText('member@example.com');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    expect(deleteCalled).toBe(false);
+  });
+
+  it('opens the invite modal', async () => {
+    signInAs(1);
+    renderPage();
+
+    await screen.findByText('member@example.com');
+    await userEvent.click(screen.getByRole('button', { name: 'Invite User' }));
+
+    const dialog = await screen.findByRole('dialog');
+    // The submit button ('Invite') distinguishes the modal from the page button.
+    expect(within(dialog).getByRole('button', { name: 'Invite' })).toBeInTheDocument();
+  });
+
+  it('shows an error message when the list request fails', async () => {
+    signInAs(1);
+    server.use(http.get('/admin/users', () => HttpResponse.json({}, { status: 500 })));
+
+    renderPage();
+
+    expect(await screen.findByText('An error occurred')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要

T1-lite 大型ページ tsx の第二弾（#258・AuditPage に続く）。`UsersPage.tsx`（246L）に UT を追加。
承認済み条件を厳守: **セマンティッククエリのみ**・**className/style/snapshot 断言なし**（W3 CSS 再生成に頑健）。

## 変更

- `frontend/src/pages/UsersPage.test.tsx` 新規（6ケース）
  - 一覧描画（`heading`「Users」・`table`・email）
  - **self-delete ガード**: サインイン中ユーザ自身の行に「Delete」が出ない
  - 他ユーザは `window.confirm` 承認後に `DELETE /admin/users/:id`（id=42 を検証）
  - `confirm` 却下時は削除リクエストを出さない
  - 「Invite User」で作成モーダル（`role="dialog"`）が開く（submit「Invite」で判別）
  - 一覧取得失敗（500）でエラーメッセージ

## 確認

- `npx vitest run src/pages/UsersPage.test.tsx` → 6 passed
- `npm test`（全 suite）→ 45 files / 256 passed
- type-check / eslint / prettier → クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)
