### PR TITLE
test(frontend): AppShell にセマンティッククエリの UT を追加する (#258)

### DIFF
--- a/frontend/src/shared/ui/components/AppShell.test.tsx
+++ b/frontend/src/shared/ui/components/AppShell.test.tsx
@@ -1,0 +1,96 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '@tests/render/render-with-providers';
+import { AppShell } from './AppShell';
+
+// jsdom resolves to the 'en' catalog (navigator.language = 'en-US').
+// Nav visibility mirrors roleHasCapability: admin sees every route; a viewer
+// only sees Home + Received Documents (ViewDocuments), never the admin routes.
+
+function LocationProbe() {
+  const { pathname } = useLocation();
+  return <div>{`path:${pathname}`}</div>;
+}
+
+function renderShell(props: {
+  role?: string;
+  email?: string;
+  onLogout?: () => void;
+  initialPath?: string;
+}) {
+  return renderWithProviders(
+    <MemoryRouter initialEntries={[props.initialPath ?? '/']}>
+      <AppShell
+        onLogout={props.onLogout ?? (() => undefined)}
+        userEmail={props.email}
+        userRole={props.role}
+      >
+        <LocationProbe />
+      </AppShell>
+    </MemoryRouter>,
+  );
+}
+
+describe('AppShell navigation gating', () => {
+  it('shows every route to an admin', () => {
+    renderShell({ role: 'admin', email: 'admin@example.com' });
+
+    for (const name of [
+      'Home',
+      'Received Documents',
+      'Audit Log',
+      'Vault Settings',
+      'Users',
+      'Export',
+    ]) {
+      expect(screen.getByRole('button', { name })).toBeInTheDocument();
+    }
+  });
+
+  it('hides admin-only routes from a viewer (capability gating)', () => {
+    renderShell({ role: 'viewer', email: 'viewer@example.com' });
+
+    // A viewer keeps Home and Received Documents (ViewDocuments)…
+    expect(screen.getByRole('button', { name: 'Home' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Received Documents' })).toBeInTheDocument();
+    // …but the admin routes are gone (never dead-end a viewer on Forbidden, #174).
+    for (const name of ['Audit Log', 'Vault Settings', 'Users', 'Export']) {
+      expect(screen.queryByRole('button', { name })).not.toBeInTheDocument();
+    }
+  });
+
+  it('treats an unknown role as having no admin capabilities (fail-closed)', () => {
+    renderShell({ role: 'nonsense', email: 'x@example.com' });
+
+    expect(screen.getByRole('button', { name: 'Home' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Users' })).not.toBeInTheDocument();
+  });
+});
+
+describe('AppShell interactions', () => {
+  it('navigates when a rail link is activated', async () => {
+    renderShell({ role: 'admin', email: 'admin@example.com' });
+    expect(screen.getByText('path:/')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Users' }));
+
+    expect(screen.getByText('path:/users')).toBeInTheDocument();
+  });
+
+  it('calls onLogout when the log-out control is activated', async () => {
+    const onLogout = vi.fn();
+    renderShell({ role: 'admin', email: 'admin@example.com', onLogout });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Log Out' }));
+
+    expect(onLogout).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the signed-in user’s email in the rail footer', () => {
+    renderShell({ role: 'admin', email: 'admin@example.com' });
+
+    expect(screen.getByText('admin@example.com')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要

T1-lite 大型ページ tsx の第三弾（#258・最後）。共有レイアウト `AppShell.tsx`（264L）に UT を追加。
目玉は **capability ゲート付きナビ**（`roleHasCapability` によるルート出し分け＝authz の UX 面）。
承認済み条件を厳守: **セマンティッククエリのみ**・**className/style/snapshot 断言なし**（W3 CSS 再生成に頑健）。

## 変更

- `frontend/src/shared/ui/components/AppShell.test.tsx` 新規（6ケース）
  - admin は全ルート（Home/Received Documents/Audit Log/Vault Settings/Users/Export）のナビを表示
  - **viewer は Home + Received Documents のみ**・管理ルートは非表示（viewer を Forbidden で dead-end させない #174）
  - 未知ロールは capability なし扱い（**fail-closed**）
  - rail リンク活性化で遷移（`useLocation` プローブで pathname 検証）
  - 「Log Out」で `onLogout` 呼出
  - rail フッタにサインイン中 email 表示

## 補足

- AppShell は fetch を持たない共有コンポーネントのため MSW 不要。Router のみ `MemoryRouter` で供給。

## 確認

- `npx vitest run src/shared/ui/components/AppShell.test.tsx` → 6 passed
- `npm test`（全 suite）→ 46 files / 262 passed
- type-check / eslint / prettier → クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)
