### PR TITLE
docs(journal): 日報規約 v2 §8 D2 — NG1 インフラ固有情報を除去する (#262)

### DIFF
--- a/docs/journal/2026-07-10.md
+++ b/docs/journal/2026-07-10.md
@@ -5,13 +5,13 @@ The whole day was demo work, in three waves. (Spills into the small hours of
 
 ## Fixed-org demo live + Tier A fallout (morning)
 
-`https://vault.ayane.co.jp` went live on the fixed `ayane` org (T-relative
+The fixed-org prospect demo went live on shared hosting (T-relative
 seed, ~20 generated received-invoice PDFs, void/restore history). Shipping to
 real shared hosting surfaced four genuine Tier A bugs, all fixed same day:
 installer unreachable at the documented docroot (#120), release zip shipping
 no framework because the path-repo symlink was never dereferenced (#122),
-`.env` never reaching raw `getenv()` readers (#124), and HETEML's front proxy
-stripping `Authorization` (#118, `X-Authorization` mirror). The public seat
+`.env` never reaching raw `getenv()` readers (#124), and the shared hosting's
+front proxy stripping `Authorization` (#118, `X-Authorization` mirror). The public seat
 was then demoted from admin to viewer (#130 → PR #133) — upload/void 403
 verified in production — making `/demo/standard` distributable. The installer
 also got the ClaudeDesign visual treatment (#134).
@@ -33,27 +33,19 @@ audit log and it all evaporates at TTL 3 h. The fixed viewer seat moved to
 
 ## Demo cron ops (owner + session Rina)
 
-All demo maintenance crons were registered in the HETEML panel and verified:
+All demo maintenance crons (hourly disposable-org sweeps and nightly reseeds)
+were registered on the shared hosting and verified firing.
 
-| command (home-relative) | schedule | verified |
-|---|---|---|
-| `bin/sweep-invoice-demo.sh` | `0 * * * *` | pre-existing; fired 16:00/17:00 |
-| `bin/sweep-clear-demo.sh` | `10 * * * *` | fired 18:10 (4 orgs reaped) |
-| `bin/reseed-clear-demo.sh` | `0 4 * * *` | first firing 07-11 — check log |
-| `bin/reseed-vault-demo.sh` | `30 4 * * *` | wrapper manual run EXIT=0; first firing 07-11 — check log |
-
-Operational lesson, the hard way: the panel **prepends `$HOME` to the command
-path**, so entries must be written home-relative (`bin/xxx.sh`). A full-path
-entry gets double-prefixed and silently never fires — this is why the clear
-sweep missed its 17:10 slot before being corrected. The 07-08 workspace note
-claiming "full home paths work as-is" was wrong and has been corrected in
-`_work/discussion-log/2026-07-08.md`.
+Operational lesson, the hard way: the hosting's cron panel prepends the home
+directory to the command path, so entries must be written home-relative. A
+full-path entry gets double-prefixed and silently never fires — this is why an
+early sweep missed a slot before being corrected. A prior workspace note
+claiming "full home paths work as-is" was wrong and has since been corrected.
 
 ## Carry-over
 
-- **Owner (board, due 07-11):** register `bin/sweep-vault-demo.sh` at
-  `40 * * * *` — wrapper installed; until then disposable orgs accumulate but
-  the 200-org cap + 503 keeps it fail-safe. Verify the 04:30 reseed firing in
-  `vault/var/reseed.log` next session.
-- README Live-demo screenshots (workspace board, due 07-13) and the second
-  Doi follow-up (due 07-17) reference this demo.
+- **Owner (board, due 07-11):** register the disposable-org sweep cron —
+  wrapper installed; until then disposable orgs accumulate but the 200-org
+  cap + 503 keeps it fail-safe. Verify the nightly reseed firing next session.
+- README Live-demo screenshots (due 07-13) and a later prospect follow-up
+  reference this demo.

--- a/docs/journal/2026-07-14.md
+++ b/docs/journal/2026-07-14.md
@@ -66,14 +66,14 @@ preserved (no over-deletion).
 
 ## 07-12 deploy hand-off follow-ups closed
 
-- **Sweep cron (board C) — registered and running.** The HETEML panel cron is
-  not SSH-visible, so confirmed by evidence: `var/sweep.log` mtime `00:40:01`
-  (the `:40` hourly tick) against host time `01:35 JST`, prior stale orgs
-  (id42/id43) reaped, steady state `1 org, 0 expired`. The 07-12 "looks
+- **Sweep cron (board C) — registered and running.** The shared hosting's cron
+  panel is not SSH-visible, so confirmed by evidence: the sweep log's mtime
+  `00:40:01` (the `:40` hourly tick) against host time `01:35 JST`, prior stale
+  orgs (id42/id43) reaped, steady state `1 org, 0 expired`. The 07-12 "looks
   unregistered from shell" concern is resolved.
 - **X-Authorization re-acceptance (#173/#177 export, #179/#180 single
   download) — GREEN behind the real proxy.** Using a real viewer token minted
-  by production `/demo/guided`, confirmed HETEML strips `Authorization`
+  by production `/demo/guided`, confirmed the shared hosting strips `Authorization`
   (→ 401) while the `X-Authorization` mirror (#118) recovers it: single-doc
   download → 200 (real PDF, `attachment`, `nosniff`, no storage path), export
   → 403 (auth recovered, viewer lacks the capability — 403 not 401 proves the

--- a/docs/journal/2026-07-16.md
+++ b/docs/journal/2026-07-16.md
@@ -250,7 +250,7 @@ required) while `allow` is the false-positive lane and **requires a `reason`**. 
 15 are debt with **no recorded rationale**, and the tool prints `OK`.
 
 This is not theoretical. **#143 (closed) records the production observation in vault's
-own words**: "JST on HETEML"; an org created at `2026-07-11 00:03` (JST) read as 9
+own words**: "JST on the shared hosting"; an org created at `2026-07-11 00:03` (JST) read as 9
 hours in the future under a UTC parse, stretching a 3 h TTL to 12 h. The migration
 docstring for `20260711000002` says the same: host default timezone, "**JST on the
 live demo host**".
@@ -516,7 +516,7 @@ records disagree by nine hours**. `retention_expires_at` — the column governin
 
 Stated as honestly as §E did: **nothing is breaking.** No time-based reaping path
 touches documents. The accurate claim is that a **production-observed** bug class
-(#143 recorded "JST on HETEML" in vault's own words) was untracked. Now it is tracked.
+(#143 recorded "JST on the shared hosting" in vault's own words) was untracked. Now it is tracked.
 The fix stays gated: it needs `ClockInterface` in four classes *plus* a #161-style
 migration, and `20260711000002`'s docstring already warns **DEPLOY ORDER MATTERS** —
 the demo host holds real data.

--- a/docs/journal/2026-07-18.md
+++ b/docs/journal/2026-07-18.md
@@ -1,7 +1,7 @@
 # 2026-07-18 — Measure-first day: a stale W-Spec re-order caught, Lane 1 park hardened, current.md + CI hygiene merged
 
 A relay-coordinated day under 統合リナ / hub, spanning the night of the
-`ayane.co.jp` relaunch. No product code changed. The through-line was
+public-site relaunch. No product code changed. The through-line was
 measure-before-acting: three stale hand-offs/orders were caught by measuring
 first, turning would-be duplicate work into confirmations. Lane 1 stayed parked
 but its state was hardened; two small PRs merged (current.md freshness,
@@ -107,5 +107,5 @@ BLOCKED (admins included, under `enforce_admins`)" trap and its three escapes �
 - **`.stat` cleanup (#239)** still open (from 07-17); would drop those classes
   from the Lane 1 seed if done first.
 - **timezone #228/#235 and inline-preview D11 #225** untouched — out of scope.
-- **`ayane.co.jp` relaunched on the NeNe Records SSR stack** tonight [reported] —
+- **The public site relaunched on the sibling SSR stack** tonight [reported] —
   not a vault change; recorded as fleet context for the day.


### PR DESCRIPTION
## 概要

日報規約 v2 §8（内容セキュリティ・全艦 MUST）の **D2 自己点検**で検出した **NG1（インフラ固有情報）** を、
公開物である `docs/journal/` から除去する。統合リナ裁定（2026-07-18）で NG1 先行（cron 表・運用パス・FQDN は
今も公開され続けている server ops の地図＝公開最小化の時間価値が最も高い）。

## 方針（承認済み）

- 行全体が NG（cron 表等）は**行削除**、prose 内は**一般化語彙で token redact**。
- 一般化語彙: shared hosting / production hosting / internal layer（英語 journal に合わせた英語形）。
- **履歴改変はしない**（現行ツリー＝docs サイトの露出を止める）。技術的事実（PR/Issue 番号・教訓）は保持。

## 変更

- `2026-07-10.md`: HETEML panel cron 表を行削除・サーバ運用パス（`bin/*.sh`・`var/reseed.log`）・`$HOME` prepend の具体・FQDN を一般化。**見落としていた lead 名 "Doi"（NG5）も同時 redact**。
- `2026-07-14.md`: ホスティング名・sweep ログのサーバパスを一般化。
- `2026-07-16.md`: #143 引用中のホスティング名を一般化。
- `2026-07-18.md`: 公開サイトの FQDN を一般化。

## 対象外（別 PR）

- **NG4（`_work/` パス）** と **NG3 の型一般化**（records 異議なし・公開 assessment へのリンクで仕上げ）は
  §10 **D1 の `journal→daily` 移設 PR** に同梱予定。

## 確認

- 残存 NG1 スキャン（HETEML/FQDN/`bin/*-demo.sh`/`reseed.log`/`Doi`）→ **0 件**。
- docs のみ・コード変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
