### PR TITLE
chore(frontend): W1 — nene2-tokens を exact 1.1.0 に pin する (#265)

### DIFF
--- a/frontend/knip.json
+++ b/frontend/knip.json
@@ -12,6 +12,6 @@
   "ignoreIssues": {
     "src/shared/api/schema.gen.ts": ["types"]
   },
-  "ignoreDependencies": ["tailwindcss"],
+  "ignoreDependencies": ["tailwindcss", "@hideyukimori/nene2-tokens"],
   "ignoreExportsUsedInFile": true
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@hideyukimori/nene2-standards": "^1.2.0",
+        "@hideyukimori/nene2-tokens": "1.1.0",
         "@storybook/addon-a11y": "^10.1.4",
         "@storybook/addon-docs": "^10.1.4",
         "@storybook/react-vite": "^10.1.4",
@@ -1679,6 +1680,19 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/@hideyukimori/nene2-tokens": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@hideyukimori/nene2-tokens/-/nene2-tokens-1.1.0.tgz",
+      "integrity": "sha512-Z1aMo17+8/qHUYUB6oiqmNAFapOcvZ4hyJShzQyGE8CBNGiemSQ9YFRZ/vhzW8r2VcyYXMZnXIgYUh8PrzIVAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jscodeshift": "^17.3.0"
+      },
+      "bin": {
+        "nene2-tokens": "dist/cli.js"
       }
     },
     "node_modules/@hookform/resolvers": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,6 +37,7 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@hideyukimori/nene2-standards": "^1.2.0",
+    "@hideyukimori/nene2-tokens": "1.1.0",
     "@storybook/addon-a11y": "^10.1.4",
     "@storybook/addon-docs": "^10.1.4",
     "@storybook/react-vite": "^10.1.4",


### PR DESCRIPTION
## 概要

フリート **W1 波**（vault 手番・波順2番手）。vault の色 vocabulary は既に **#206/PR#207 で
Core Token Contract v1（`@hideyukimori/nene2-tokens` VAULT_TABLE 1.0.0）に適用済み**。
本 PR は **pin-only**（版固定のみ・codemod 再実行なし）。payout #230 と同型。

## 撃つ前 plan（M-1・証拠）

```
$ codemod-plan --theme themes/default.css --map vault   # tokens 1.1.0
ERROR token mapping conflict — 2+ sources map to a single target (silent overwrite prohibited):
  --color-surface-raised ← --color-surface, --color-surface-raised
```

**真因＝連鎖語彙**: vault 表が `bg→surface` と `surface→surface-raised` を両方持つ（ある rename の
新名が別 rename の旧キー）。**適用済みテーマ**へ再適用すると `--color-surface` が再改名対象に見えて衝突。
＝未適用作業ではなく「表が世代適用状態を知らない」ことの **loud な fail-closed 検出**。

hub 裏取り実測: 1.0.1→1.1.0 の vault 写像行の増分ゼロ（コメント1行のみ）／現テーマに旧専用キー
残存ゼロ・新名10箇所。→ codemod は撃たず pin-only が正。fleet#88 に「ケース3（連鎖語彙・vault）」起票。

## 変更

- `@hideyukimori/nene2-tokens` を **exact 1.1.0** で devDep 追加。
- `knip.json` の `ignoreDependencies` に `@hideyukimori/nene2-tokens` 追加（CLI 専用・import なし）。

## 証明束

- plan: 上記 ERROR（連鎖語彙・fail-closed）。
- 適用 diff: **なし**（codemod 未実行＝theme CSS 不変）。手動編集0。
- `npm run check`: **exit 0**（type-check/lint/format/test/knip/stylelint/build-storybook 全緑）。
- 受入（目視スモーク）: codemod 差分ゼロで CSS 出力不変のため外観影響なし。

Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)
