### PR TITLE
docs(p3): 公開 docs の生き導線を private 運用ログへ repoint する (#267)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,8 @@ NENE_VAULT_PORT=8601 NENE_VAULT_FRONTEND_PORT=5187 docker compose up
 ## Status
 
 **All roadmap phases (0–4) complete; compliance gate approved.** See
-[`docs/roadmap.md`](./docs/roadmap.md) and [`docs/todo/current.md`](./docs/todo/current.md).
+[`docs/roadmap.md`](./docs/roadmap.md); operational status and handoff are tracked in
+the private `nene-origin/internal-docs/vault/`.
 
 | Phase | Scope | Status |
 | --- | --- | --- |
@@ -150,8 +151,8 @@ NENE_VAULT_PORT=8601 NENE_VAULT_FRONTEND_PORT=5187 docker compose up
 (Review 2, [`docs/compliance-review/signoff-record.md`](./docs/compliance-review/signoff-record.md)).
 
 **Remaining before production go-live:** pre-production 税理士 Review 3 and
-Tier A live testing on real shared hosting — see
-[`docs/todo/current.md`](./docs/todo/current.md).
+Tier A live testing on real shared hosting — tracked in the private
+`nene-origin/internal-docs/vault/todo/current.md`.
 
 ## Ecosystem
 

--- a/docs/compliance-review/2026-review-3-preprod-package.md
+++ b/docs/compliance-review/2026-review-3-preprod-package.md
@@ -138,7 +138,7 @@ Append a **Review 3** block to
 - **Changes required** ⇒ production stays blocked.
 
 Then update the "Review status" table in `signoff-record.md` and check off the
-**税理士 Review 3** item in [`../todo/current.md`](../todo/current.md).
+**税理士 Review 3** item in the private `nene-origin/internal-docs/vault/todo/current.md`.
 
 ---
 


### PR DESCRIPTION
## 概要

**P3 Phase 3 ③生き導線 sweep**（vault 手番）。②削除（PR #268・SHA `817050a`）で `docs/todo/current.md` が
private 移設・公開側から削除されたため、公開 docs に残った**生きた導線（clickable link）**を解消する。
新ポリシー（2026-07-18）: ③は CI 緑 self-merge・事後報告。

## 変更（生き導線 = clickable link のみ）

- `README.md`（Status / Remaining before go-live の2箇所）: 削除済み `docs/todo/current.md` への
  clickable link を撤去し、private `nene-origin/internal-docs/vault/` への参照へ repoint。
- `docs/compliance-review/2026-review-3-preprod-package.md`: 同 current.md リンクを private 参照へ repoint。

## 方針

- **public README を private 404 リンクにしない**ため、clickable link ではなく非リンクの code 参照にする
  （runbook の「読者向けリンク切れを解消」を満たす）。
- 歴史記述（`docs/security/2026-07-14-redteam-assessment.md` の言及）は**放置**（歴史 milestone）。
- prose 言及（`CONTRIBUTING.md`・`workflow.md`・`review/docs-policy.md`）は follow-up 可。

## 確認

- 削除済み `current.md` への clickable link 残存 **0**（スキャン確認）。

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)
