### PR TITLE
chore(css): 未使用 CSS `.stat`（統計タイル）を掃除する (#239)

### DIFF
--- a/frontend/src/shared/ui/theme/themes/default.components.css
+++ b/frontend/src/shared/ui/theme/themes/default.components.css
@@ -796,54 +796,6 @@
       color: var(--color-text-muted);
     }
 
-    /* ---- stat tiles (home) ---- */
-    .stat {
-      background: var(--color-surface-raised);
-      border: 1px solid var(--color-border);
-      border-radius: var(--radius-md);
-      padding: 18px 18px 16px;
-      box-shadow: var(--shadow-sm);
-      position: relative;
-      overflow: hidden;
-    }
-    .stat::before {
-      content: '';
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 2px;
-      background: var(--color-x-brass);
-    }
-    .stat .k {
-      font-size: var(--text-2xs);
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-      color: var(--color-text-muted);
-      font-weight: 600;
-    }
-    .stat .v {
-      font-family: var(--font-serif);
-      font-size: 1.85rem;
-      font-weight: 600;
-      color: var(--color-x-ink-deep);
-      margin-top: 8px;
-      line-height: 1;
-      font-variant-numeric: tabular-nums;
-    }
-    :where(.stat) .v small {
-      font-family: var(--font-sans);
-      font-size: 0.85rem;
-      font-weight: 500;
-      color: var(--color-text-muted);
-      margin-left: 3px;
-    }
-    .stat .meta {
-      margin-top: 9px;
-      font-size: var(--text-2xs);
-      color: var(--color-text-faint);
-    }
-
     /* ---- quick links (home) ---- */
     .qlink {
       display: flex;
@@ -1653,15 +1605,6 @@
       table.tbl thead th,
       table.tbl tbody td {
         padding: 11px 13px;
-      }
-
-      /* stat tiles: keep big numbers from overflowing their tile */
-      .stat {
-        padding: 15px 15px 13px;
-      }
-      .stat .v {
-        font-size: 1.55rem;
-        word-break: break-word;
       }
 
       /* opt-in card tables (.tbl.tbl-cards): label/value rows, no horizontal scroll */


### PR DESCRIPTION
Closes #239

## 概要
`frontend/src/shared/ui/theme/themes/default.components.css` のデッド CSS `.stat`（統計タイル）系ブロックを削除する。

## 根拠（削除前に再確認済み）
- tsx/ts のどこからも `className="stat"` 等で描画されていない（`grep -rniE '\bstat\b' src --include='*.ts' --include='*.tsx'` ヒット 0・clsx/テンプレート/文字列連結の動的生成も無し）。
- 全文検索の "stat" ヒットはコメント中の "statutory" のみ。
- ホームのダッシュボード用に用意され未配線のまま残ったデッド CSS。knip は JS 依存のみを見て CSS クラス未使用を検出しないため自動では拾われない。

## 変更
- `@layer main` の `.stat` / `.stat::before` / `.stat .k` / `.stat .v` / `:where(.stat) .v small` / `.stat .meta` ブロックを削除
- responsive の `.stat` / `.stat .v` オーバーライドを削除

## 検証
- `npm run check --prefix frontend` 緑（type-check / lint / format / test 262 / knip / stylelint / build-storybook）。
- 削除後 `.stat` セレクタ残存 0 を確認。

## 補足
Lane1（#238）の allowlist seed（156 class）に `.stat` 系が含まれるため、本 PR 先行で seed からも落ちる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)