### PR TITLE
fix(audit): diffAuditEvent の比較をキー順非依存の deep-equal にする (#253)

### DIFF
--- a/frontend/src/entities/audit/diff.test.ts
+++ b/frontend/src/entities/audit/diff.test.ts
@@ -55,6 +55,22 @@ describe('diffAuditEvent', () => {
     expect(diffAuditEvent(before, after)).toEqual([]);
   });
 
+  it('treats objects with the same entries in a different key order as equal', () => {
+    const before = { meta: { a: 1, b: 2 } };
+    const after = { meta: { b: 2, a: 1 } };
+
+    expect(diffAuditEvent(before, after)).toEqual([]);
+  });
+
+  it('keeps array element order significant', () => {
+    const before = { tags: ['a', 'b'] };
+    const after = { tags: ['b', 'a'] };
+
+    expect(diffAuditEvent(before, after)).toEqual([
+      { key: 'tags', kind: 'mod', before: ['a', 'b'], after: ['b', 'a'] },
+    ]);
+  });
+
   it('detects changes inside nested structures', () => {
     const before = { meta: { n: 1 } };
     const after = { meta: { n: 2 } };

--- a/frontend/src/entities/audit/diff.ts
+++ b/frontend/src/entities/audit/diff.ts
@@ -22,6 +22,41 @@ export function formatAuditValue(value: unknown): string {
 }
 
 /**
+ * Key-order-independent deep equality. Two objects with the same entries in a
+ * different key order are equal; arrays stay order-sensitive. Used instead of
+ * `JSON.stringify` comparison so a change in the server's JSON serialization
+ * order does not surface as a spurious `mod` in the audit change summary.
+ */
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) {
+    return true;
+  }
+  if (typeof a !== 'object' || typeof b !== 'object' || a === null || b === null) {
+    return false;
+  }
+  const aIsArray = Array.isArray(a);
+  const bIsArray = Array.isArray(b);
+  if (aIsArray !== bIsArray) {
+    return false;
+  }
+  if (aIsArray && bIsArray) {
+    const aArr = a as unknown[];
+    const bArr = b as unknown[];
+    return aArr.length === bArr.length && aArr.every((item, i) => deepEqual(item, bArr[i]));
+  }
+  const aObj = a as Record<string, unknown>;
+  const bObj = b as Record<string, unknown>;
+  const aKeys = Object.keys(aObj);
+  const bKeys = Object.keys(bObj);
+  return (
+    aKeys.length === bKeys.length &&
+    aKeys.every(
+      (key) => Object.prototype.hasOwnProperty.call(bObj, key) && deepEqual(aObj[key], bObj[key]),
+    )
+  );
+}
+
+/**
  * Returns the fields that changed between two snapshots. When `before` is null
  * (a creation event), every field of `after` is reported as an addition.
  */
@@ -46,7 +81,7 @@ export function diffAuditEvent(
   for (const key of keys) {
     const b = before[key];
     const a = afterObj[key];
-    if (JSON.stringify(b) !== JSON.stringify(a)) {
+    if (!deepEqual(b, a)) {
       fields.push({ key, kind: 'mod', before: b, after: a });
     }
   }


### PR DESCRIPTION
Closes #253

## 背景
PR #252（audit diff の UT 追加）の hub レビューで判明した latent な偽陽性。`diffAuditEvent` はフィールド変更判定を `JSON.stringify(b) !== JSON.stringify(a)` で行っており、この比較は**オブジェクトのキー順に敏感**。`{a:1,b:2}` と `{b:2,a:1}` は深い等価だが `mod` として報告される。現状は before/after JSON のキー順が安定している間は無害だが、サーバ側のシリアライズ順が変わる経路が挟まると、実際には変わっていないフィールドが「変更」として並ぶ。

## 対応
- 非公開ヘルパ `deepEqual(a, b)` を追加（再帰的な構造比較）:
  - **オブジェクト**: キー順非依存（同じエントリなら等価）
  - **配列**: 順序依存のまま（要素順は有意）
  - プリミティブ / null は `===` 相当
- `diffAuditEvent` の比較を `!deepEqual(b, a)` に置換。

## テスト（diff.test.ts）
- 追加: 「オブジェクトのキー順を入れ替えても等価とみなす」→ `[]`
- 追加: 「配列要素順は有意のまま」→ `mod`
- 既存の挙動固定テストは不変で緑（14 tests passed）。

## 検証
`npm run check --prefix frontend` 緑（type-check / lint / format / test / knip / stylelint / build-storybook）。

## 補足
プロダクトコードを触るため test-only の self-merge 運用外＝通常の事前レビュー PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)