### PR TITLE
test(frontend): AppShell nav ゲートに member/superadmin role の網羅を足す (#261)

### DIFF
--- a/frontend/src/shared/ui/components/AppShell.test.tsx
+++ b/frontend/src/shared/ui/components/AppShell.test.tsx
@@ -49,6 +49,36 @@ describe('AppShell navigation gating', () => {
     }
   });
 
+  it('shows every route to a superadmin', () => {
+    renderShell({ role: 'superadmin', email: 'root@example.com' });
+
+    for (const name of [
+      'Home',
+      'Received Documents',
+      'Audit Log',
+      'Vault Settings',
+      'Users',
+      'Export',
+    ]) {
+      expect(screen.getByRole('button', { name })).toBeInTheDocument();
+    }
+  });
+
+  it('shows a member only Home and Received Documents (member capabilities)', () => {
+    renderShell({ role: 'member', email: 'member@example.com' });
+
+    // A member has ViewDocuments (plus Upload/Edit, which have no nav route),
+    // so the visible nav matches a viewer's even though the backing capability
+    // differs — Home stays ungated and Received Documents is ViewDocuments.
+    expect(screen.getByRole('button', { name: 'Home' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Received Documents' })).toBeInTheDocument();
+    // The admin routes gate on ManageVaultSettings/ManageUsers/ExportDocuments,
+    // none of which a member holds.
+    for (const name of ['Audit Log', 'Vault Settings', 'Users', 'Export']) {
+      expect(screen.queryByRole('button', { name })).not.toBeInTheDocument();
+    }
+  });
+
   it('hides admin-only routes from a viewer (capability gating)', () => {
     renderShell({ role: 'viewer', email: 'viewer@example.com' });
 


### PR DESCRIPTION
Closes #261

## 概要
`AppShell.test.tsx` の nav capability ゲートテストに、実在するが未網羅だった **member** / **superadmin** role のケースを1つずつ追加する（既存は admin / viewer / unknown の3系統）。

## 追加ケース
- **superadmin**: 全 capability true → 全ナビ（Home / Received Documents / Audit Log / Vault Settings / Users / Export）表示。
- **member**: `UploadDocument` / `EditMetadata` / `ViewDocuments` のみ → Home + Received Documents のみ表示。viewer と可視 nav は同じだが根拠 capability が異なる（Received=ViewDocuments）。admin 系ルートは `ManageVaultSettings` / `ManageUsers` / `ExportDocuments` を持たず非表示。

## 検証
- 対象スイート 8 tests passed。
- `npm run check --prefix frontend` 緑（type-check / lint / format / test / knip / stylelint / build-storybook）。

## 運用
テスト追加のみ（プロダクト/config/依存 変更なし）＝test-only の self-merge 運用に乗る。CI 緑を確認して self-merge → 事後報告予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)