### PR TITLE
chore(frontend): js-yaml を overrides ^4.3.0 で巻き上げ CI audit ゲートを緑化する (#273)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8329,9 +8329,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,10 @@
     "stylelint": "stylelint \"src/**/*.css\"",
     "check": "npm run type-check && npm run lint && npm run format && npm run test && npm run knip && npm run stylelint && npm run build-storybook"
   },
+  "//overrides": "js-yaml is pulled transitively by @redocly/openapi-core and trips the CI npm audit high gate (GHSA-52cp-r559-cp3m). Bump it here rather than via `npm audit fix` (platform-binary risk) or a redocly bump (churn). (#273)",
+  "overrides": {
+    "js-yaml": "^4.3.0"
+  },
   "dependencies": {
     "@hideyukimori/nene2-client": "^1.1.0",
     "@hookform/resolvers": "^3.10.0",


### PR DESCRIPTION
Closes #273 · hub 裁定 Q5（全艦事前承認パターン / suite#404 型・NENE2 #1615 実証済み）に基づく即時 GO。

## 何を
`frontend/package.json` に `"overrides": { "js-yaml": "^4.3.0" }` を追加。transitive（`@redocly/openapi-core` → js-yaml 4.2.0）で high 勧告 **GHSA-52cp-r559-cp3m** を踏み、`npm audit --audit-level=high` が rc=1 → Open PR (#270/#271/#272) が差分無関係に全赤化していた。

## なぜこの方式
- `npm audit fix` 不採用（platform binary 混入リスク）
- redocly bump 不要（churn 大）
- overrides で最小巻き上げ

## 受入（実測）
- `npm audit --audit-level=high` → **rc=0 / found 0 vulnerabilities**
- `package-lock.json` diff は **js-yaml 4.2.0→4.3.0 のみ**（3+/3-）
- `npm run test` 262 passed / `npm run build` OK

## 後続
merge 後 #270/#271/#272 を rebase で一括緑化する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)