### PR TITLE
chore(frontend): coverage ratchet を導入する（shrink-only floor・#277） (#277)

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -29,9 +29,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # npm run check = type-check + lint + format + test (vitest) + knip
+      # npm run check = type-check + lint + format + coverage:check
+      # (vitest --coverage + shrink-only ratchet) + knip + stylelint
       # + build-storybook.
-      - name: Check (type-check, lint, format, test, knip, storybook build)
+      - name: Check (type-check, lint, format, coverage:check, knip, storybook build)
         run: npm run check
 
       - name: Audit (fail on high/critical)

--- a/frontend/coverage.baseline.json
+++ b/frontend/coverage.baseline.json
@@ -1,0 +1,9 @@
+{
+  "_comment": "Frozen coverage floor (fleet T1 ratchet, Issue #277; payout #241 型). Shrink-only: coverage-ratchet.mjs fails CI if any metric drops below these values. Raise these numbers when coverage improves; never lower them. Regenerate the measurement with `npm run coverage`.",
+  "metrics": {
+    "statements": 74.93,
+    "branches": 68.47,
+    "functions": 67.3,
+    "lines": 75.6
+  }
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -33,6 +33,7 @@
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
+        "@vitest/coverage-v8": "^4.1.10",
         "eslint": "^10.3.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-import-resolver-typescript": "^4.4.4",
@@ -706,6 +707,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@cacheable/memory": {
@@ -4534,6 +4545,75 @@
         }
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
+      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.10",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.10",
+        "vitest": "4.1.10"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
@@ -5011,6 +5091,35 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
+      "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -7618,6 +7727,13 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/html-tags": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
@@ -8301,6 +8417,87 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
@@ -8949,6 +9146,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
       }
     },
     "node_modules/make-dir": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,12 +17,14 @@
     "format:fix": "prettier --write .",
     "test": "vitest run",
     "test:watch": "vitest",
+    "coverage": "vitest run --coverage",
+    "coverage:check": "vitest run --coverage && node tools/coverage-ratchet.mjs",
     "codegen": "openapi-typescript ../docs/openapi/openapi.yaml -o src/shared/api/schema.gen.ts",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "knip": "knip",
     "stylelint": "stylelint \"src/**/*.css\"",
-    "check": "npm run type-check && npm run lint && npm run format && npm run test && npm run knip && npm run stylelint && npm run build-storybook"
+    "check": "npm run type-check && npm run lint && npm run format && npm run coverage:check && npm run knip && npm run stylelint && npm run build-storybook"
   },
   "//overrides": "js-yaml is pulled transitively by @redocly/openapi-core and trips the CI npm audit high gate (GHSA-52cp-r559-cp3m). Bump it here rather than via `npm audit fix` (platform-binary risk) or a redocly bump (churn). (#273)",
   "overrides": {
@@ -54,6 +56,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
+    "@vitest/coverage-v8": "^4.1.10",
     "eslint": "^10.3.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^4.4.4",

--- a/frontend/tools/coverage-ratchet.mjs
+++ b/frontend/tools/coverage-ratchet.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+// Coverage ratchet — fleet T1 (Issue #277; payout #241 型).
+//
+// Compares the freshly measured coverage summary against the frozen floor in
+// coverage.baseline.json. The gate is SHRINK-ONLY: it fails if any metric drops
+// below its baseline. It deliberately does NOT enforce a uniform numeric target
+// (council G-5) — the floor is whatever the repo already achieves, and it may
+// only go up. When coverage improves, raise coverage.baseline.json in the same PR.
+//
+// Reads:  coverage/coverage-summary.json  (written by `vitest run --coverage`)
+// Floor:  coverage.baseline.json
+// Exit:   0 = all metrics >= baseline; 1 = a regression or missing input.
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const summaryPath = path.join(root, 'coverage', 'coverage-summary.json');
+const baselinePath = path.join(root, 'coverage.baseline.json');
+
+// Float noise guard: v8 coverage is deterministic, but summary pct is rounded to
+// two decimals, so allow equality within a hundredth before flagging a drop.
+const EPSILON = 0.01;
+const METRICS = ['statements', 'branches', 'functions', 'lines'];
+
+function readJson(p, label) {
+  try {
+    return JSON.parse(readFileSync(p, 'utf8'));
+  } catch (err) {
+    console.error(`coverage-ratchet: cannot read ${label} at ${p}`);
+    console.error(`  ${err.message}`);
+    if (label === 'coverage summary') {
+      console.error('  Run `npm run coverage` first (it writes coverage/coverage-summary.json).');
+    }
+    process.exit(1);
+  }
+}
+
+const summary = readJson(summaryPath, 'coverage summary');
+const baseline = readJson(baselinePath, 'coverage baseline');
+
+const total = summary.total;
+const floor = baseline.metrics;
+
+let failed = false;
+const rows = [];
+for (const metric of METRICS) {
+  const current = total[metric].pct;
+  const min = floor[metric];
+  const delta = current - min;
+  const ok = delta >= -EPSILON;
+  if (!ok) failed = true;
+  rows.push(
+    `  ${ok ? 'OK  ' : 'FAIL'} ${metric.padEnd(11)} ${current.toFixed(2)}%  (floor ${min.toFixed(2)}%, Δ ${delta >= 0 ? '+' : ''}${delta.toFixed(2)})`,
+  );
+}
+
+console.log('coverage-ratchet (shrink-only floor):');
+console.log(rows.join('\n'));
+
+if (failed) {
+  console.error(
+    '\ncoverage-ratchet: FAIL — coverage dropped below the frozen floor.\n' +
+      '  Add tests to restore it, or, if the drop is intentional and justified,\n' +
+      '  lower coverage.baseline.json in the same PR with a reason in the review.',
+  );
+  process.exit(1);
+}
+console.log('\ncoverage-ratchet: OK — no metric below its floor.');

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -23,5 +23,23 @@ export default defineConfig({
     globals: true,
     setupFiles: ['./tests/setup/vitest-setup.ts'],
     css: false,
+    coverage: {
+      provider: 'v8',
+      // json-summary feeds the shrink-only ratchet (tools/coverage-ratchet.mjs);
+      // text-summary is for humans, json for drill-down. Never write html into the repo.
+      reporter: ['text-summary', 'json-summary', 'json'],
+      reportsDirectory: './coverage',
+      // Measure the application source only. Test/story/mock/setup files and
+      // type-only barrels are not units under test.
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: [
+        'src/**/*.test.{ts,tsx}',
+        'src/**/*.stories.{ts,tsx}',
+        'src/**/*.d.ts',
+        'src/**/index.ts',
+        'src/main.tsx',
+        'src/**/__mocks__/**',
+      ],
+    },
   },
 });


### PR DESCRIPTION
Closes #277 · fleet Phase A 自力 green 化1本目・payout #241 型。

## 何を
frontend に **shrink-only coverage ratchet** を導入。現状カバレッジを floor に凍結し、下回ったら CI fail。一律目標値は課さない（council G-5・floor は現状達成値・上げるのは同 PR）。

## 変更
- `@vitest/coverage-v8` 追加・`vitest.config.ts` に coverage 配線（v8・json-summary・include=src・test/stories/d.ts/index/main/__mocks__ exclude）
- `tools/coverage-ratchet.mjs`（summary vs baseline・EPSILON 0.01・4 metric）
- `coverage.baseline.json` に**実測値凍結**: statements 74.93 / branches 68.47 / functions 67.30 / lines 75.60（テスト厳格化キャンペーンで payout の 55% 台より高い）
- scripts `coverage`/`coverage:check`・`check` チェーンに組込み（CI は `npm run check` 経由で自動配線）

## 受入（実測）
- `coverage:check` **緑**（floor=実測値・Δ+0.00）
- **red-on-drop 実証**: floor を 99 に上げると `exit 1`（FAIL statements Δ-24.07）→ 復元で緑
- `coverage/` は `.gitignore` 済み（成果物非コミット）

🤖 Generated with [Claude Code](https://claude.com/claude-code)