### PR TITLE
feat(i18n): C4 — nene2-i18n ^0.2.0 の expectCatalogParity を採用する（vault 完全クローズの最後の栓）

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,6 +18,7 @@
         "zod": "^3.24.1"
       },
       "devDependencies": {
+        "@hideyukimori/nene2-i18n": "^0.2.0",
         "@hideyukimori/nene2-standards": "^2.1.0",
         "@hideyukimori/nene2-tokens": "1.1.0",
         "@playwright/test": "^1.61.1",
@@ -1621,6 +1622,13 @@
         "node": ">=22 <25",
         "npm": ">=10 <12"
       }
+    },
+    "node_modules/@hideyukimori/nene2-i18n": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@hideyukimori/nene2-i18n/-/nene2-i18n-0.2.0.tgz",
+      "integrity": "sha512-L7A/xRoXSObQtvaFDdVVT0blBsWakzG6K3aal4KFI75Je4YczyPI30CBw6KHRZN4AvQL0+MLUeUNkCo55jPHiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@hideyukimori/nene2-standards": {
       "version": "2.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,6 +45,7 @@
     "zod": "^3.24.1"
   },
   "devDependencies": {
+    "@hideyukimori/nene2-i18n": "^0.2.0",
     "@hideyukimori/nene2-standards": "^2.1.0",
     "@hideyukimori/nene2-tokens": "1.1.0",
     "@playwright/test": "^1.61.1",

--- a/frontend/src/shared/i18n/catalogs.test.ts
+++ b/frontend/src/shared/i18n/catalogs.test.ts
@@ -1,17 +1,26 @@
+import { expectCatalogParity } from '@hideyukimori/nene2-i18n/testing';
 import { describe, expect, it } from 'vitest';
 import { catalogs, dynamicMessageKey } from './catalogs';
 
-/** Collects every dot-notation path to a non-object leaf. */
-function leafPaths(value: unknown, prefix = ''): string[] {
+// Flatten a nested catalog to `{ 'a.b.c': value }`. nene2-i18n 0.2.0's
+// `expectCatalogParity` operates on a FLAT `Record<string, string>` catalog
+// (the skeleton MessageCatalog); the nested "vault JSON form" (DotPaths) is a
+// 0.3.0 / W0b feature (see catalog.d.ts) and is not yet natively accepted. This
+// thin adapter feeds the shared parity logic the real leaf keys so shape and
+// lazy-copy checks run on the actual message keys, not just the top-level groups.
+function flatten(
+  value: unknown,
+  prefix = '',
+  out: Record<string, string> = {},
+): Record<string, string> {
   if (value === null || typeof value !== 'object') {
-    return [prefix];
+    out[prefix] = String(value);
+    return out;
   }
-  const paths: string[] = [];
   for (const [key, child] of Object.entries(value)) {
-    const path = prefix ? `${prefix}.${key}` : key;
-    paths.push(...leafPaths(child, path));
+    flatten(child, prefix ? `${prefix}.${key}` : key, out);
   }
-  return paths;
+  return out;
 }
 
 describe('catalogs', () => {
@@ -19,12 +28,17 @@ describe('catalogs', () => {
     expect(Object.keys(catalogs).sort()).toEqual(['en', 'ja']);
   });
 
-  it('ja and en share an identical key structure (#137 / #166 parity guard)', () => {
-    const ja = leafPaths(catalogs.ja).sort();
-    const en = leafPaths(catalogs.en).sort();
-
-    expect(ja.length).toBeGreaterThan(0);
-    expect(en).toEqual(ja);
+  it('ja/en share an identical key shape and en is not a lazy copy of ja (#137/#166)', () => {
+    // Fleet-shared parity guard (nene2-i18n `./testing`, AM-17): shape 100% vs the
+    // authority (ja) plus a lazy-copy ratio check. ja is the authority (ADR 0008).
+    // `_meta` carries locale self-description (label/direction/note) that is
+    // legitimately identical or per-locale; allowlist the keys that are the same
+    // in every locale by design (direction; the shared English note).
+    const flat = { ja: flatten(catalogs.ja), en: flatten(catalogs.en) };
+    expectCatalogParity(flat, {
+      authority: 'ja',
+      identicalAllowlist: ['_meta.direction', '_meta.note'],
+    });
   });
 });
 


### PR DESCRIPTION
fleet **C4**（B-2a スコープ）。nene2-i18n 0.2.0 landed（`./testing`=expectCatalogParity）を受け、自前 leafPaths parity を**共有 expectCatalogParity**へ置換。**これで vault C1-C7 全クローズ候補**。

## 変更
- `@hideyukimori/nene2-i18n ^0.2.0` pin
- `catalogs.test.ts`: **ja 権威**の shape 100%＋lazy-copy 比率検査（AM-17）を共有ロジックへ
- **flatten アダプタ（hub 要確認）**: 0.2.0 の expectCatalogParity は FLAT `Record<string,string>`（skeleton MessageCatalog）対象。**vault のネスト JSON 形（DotPaths）は 0.3.0/W0b 未実装**（catalog.d.ts 明記）。よって vault catalog を leaf-path へ flatten して渡し、shape/lazy-copy を実キー（`common.buttons.close` 等）で走らせる
- **sanity 実測**: ネストキー欠落を捕捉（shape 不一致 欠落1）＝**中空でない・自前 leafPaths 同等の厳密さ**
- `_meta.direction`/`_meta.note` は全ロケール同値が正当（locale 自己記述）→ identicalAllowlist
- renderWithI18n は 0.3.0 待ち＝B-2a 範囲外

## 受入
- `npm run check` **exit 0**・parity 272 tests 緑・type-check（flat=MessageCatalog 適合）

## hub 判断ポイント
flatten アダプタは vault のネスト catalog を 0.2.0 の flat expectCatalogParity へ橋渡しする暫定形（`nene2.overrides.vaultJsonCatalog` marker が示す vault JSON 形の 0.3.0 native 対応まで）。共有 parity **ロジック**は使い、入力だけ適合させる方針で妥当か。

🤖 Generated with [Claude Code](https://claude.com/claude-code)