### PR TITLE
sec(document): アップロードにマジックバイト検査を追加し MIME 偽装受理を塞ぐ（#294）

### DIFF
--- a/src/Document/MimeTypeNotAllowedException.php
+++ b/src/Document/MimeTypeNotAllowedException.php
@@ -8,8 +8,20 @@ use RuntimeException;
 
 final class MimeTypeNotAllowedException extends RuntimeException
 {
-    public function __construct(string $mimeType)
+    /**
+     * @param string      $mimeType     the client-declared media type
+     * @param string|null $sniffedType  the type detected from the file's magic
+     *                                   bytes, when the rejection is a content
+     *                                   mismatch (a spoofed declaration) rather
+     *                                   than a disallowed declaration
+     */
+    public function __construct(string $mimeType, ?string $sniffedType = null)
     {
-        parent::__construct("File type '{$mimeType}' is not allowed. Only PDF, JPEG, and PNG are accepted.");
+        $message = $sniffedType === null
+            ? "File type '{$mimeType}' is not allowed. Only PDF, JPEG, and PNG are accepted."
+            : "Declared file type '{$mimeType}' does not match the file content "
+                . "('{$sniffedType}'). Only genuine PDF, JPEG, and PNG files are accepted.";
+
+        parent::__construct($message);
     }
 }

--- a/src/Document/UploadDocumentUseCase.php
+++ b/src/Document/UploadDocumentUseCase.php
@@ -41,9 +41,20 @@ final readonly class UploadDocumentUseCase implements UploadDocumentUseCaseInter
 
     public function execute(UploadDocumentInput $input): UploadDocumentOutput
     {
-        // 1. MIME allowlist (compliance §2.1, backend-standards §5)
+        // 1. MIME allowlist (compliance §2.1, backend-standards §5) — the
+        // client-declared media type is a cheap first gate.
         if (!in_array($input->mimeType, self::ALLOWED_MIME_TYPES, true)) {
             throw new MimeTypeNotAllowedException($input->mimeType);
+        }
+
+        // 1b. Content sniffing (QA VLT-B7-01): the declared media type is
+        // client-controlled — an .exe can claim `application/pdf` and slip
+        // through the allowlist above. Verify the actual magic bytes match an
+        // allowed type; reject the declaration/content mismatch at intake rather
+        // than relying only on the download-side nosniff+attachment mitigation.
+        $sniffed = $this->sniffMimeType($input->tmpPath);
+        if ($sniffed === null || !in_array($sniffed, self::ALLOWED_MIME_TYPES, true)) {
+            throw new MimeTypeNotAllowedException($input->mimeType, $sniffed ?? 'unknown');
         }
 
         // 2. Size limit
@@ -166,5 +177,38 @@ final readonly class UploadDocumentUseCase implements UploadDocumentUseCaseInter
             'date_uncertain'    => $doc->dateUncertain,
             'retention_expires_at' => $doc->retentionExpiresAt,
         ];
+    }
+
+    /**
+     * Detect the media type from a file's leading magic bytes, restricted to the
+     * three accepted formats. Returns the detected type, or null when the header
+     * matches none of them (e.g. an executable, SVG, or truncated file). This is
+     * content-based, so it cannot be spoofed by a client-declared media type.
+     */
+    private function sniffMimeType(string $tmpPath): ?string
+    {
+        $handle = @fopen($tmpPath, 'rb');
+        if ($handle === false) {
+            return null;
+        }
+
+        $header = fread($handle, 8);
+        fclose($handle);
+
+        if ($header === false || $header === '') {
+            return null;
+        }
+
+        if (str_starts_with($header, '%PDF-')) {
+            return 'application/pdf';
+        }
+        if (str_starts_with($header, "\xFF\xD8\xFF")) {
+            return 'image/jpeg';
+        }
+        if (str_starts_with($header, "\x89PNG\r\n\x1A\n")) {
+            return 'image/png';
+        }
+
+        return null;
     }
 }

--- a/tests/Document/UploadDocumentUseCaseTest.php
+++ b/tests/Document/UploadDocumentUseCaseTest.php
@@ -82,6 +82,55 @@ final class UploadDocumentUseCaseTest extends TestCase
         $useCase->execute($this->input(mimeType: 'application/zip'));
     }
 
+    public function test_rejects_executable_spoofed_as_pdf(): void
+    {
+        // QA VLT-B7-01: an .exe whose client-declared media type is
+        // application/pdf must be rejected by magic-byte content sniffing, even
+        // though the declaration alone passes the allowlist.
+        $useCase = $this->makeUseCase();
+
+        $this->expectException(MimeTypeNotAllowedException::class);
+        $this->expectExceptionMessage('does not match the file content');
+
+        $useCase->execute($this->input(
+            mimeType: 'application/pdf',
+            content: "MZ\x90\x00\x03fake-exe-bytes",
+        ));
+    }
+
+    public function test_rejects_svg_spoofed_as_png(): void
+    {
+        // An SVG (an XSS vector) declared image/png is rejected: its bytes do not
+        // match the PNG signature.
+        $useCase = $this->makeUseCase();
+
+        $this->expectException(MimeTypeNotAllowedException::class);
+
+        $useCase->execute($this->input(
+            mimeType: 'image/png',
+            content: '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>',
+        ));
+    }
+
+    public function test_accepts_genuine_jpeg(): void
+    {
+        // Regression: real JPEG/PNG (matching magic bytes) still upload.
+        $useCase = $this->makeUseCase();
+
+        $output = $useCase->execute($this->input(mimeType: 'image/jpeg'));
+
+        $this->assertSame('active', $output->document->status);
+    }
+
+    public function test_accepts_genuine_png(): void
+    {
+        $useCase = $this->makeUseCase();
+
+        $output = $useCase->execute($this->input(mimeType: 'image/png'));
+
+        $this->assertSame('active', $output->document->status);
+    }
+
     public function test_rejects_oversized_file(): void
     {
         $useCase = $this->makeUseCase();
@@ -160,7 +209,31 @@ final class UploadDocumentUseCaseTest extends TestCase
         );
     }
 
-    /** @param list<string> $tags */
+    /** Magic-byte headers for the accepted formats. */
+    private const PDF_BYTES = "%PDF-1.4\n%%EOF\n";
+    private const JPEG_BYTES = "\xFF\xD8\xFF\xE0hello";
+    private const PNG_BYTES = "\x89PNG\r\n\x1A\nhello";
+
+    /** @var list<string> temp files to unlink after each test */
+    private array $tmpFiles = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tmpFiles as $path) {
+            if (is_file($path)) {
+                unlink($path);
+            }
+        }
+        $this->tmpFiles = [];
+        parent::tearDown();
+    }
+
+    /**
+     * @param list<string> $tags
+     * @param string|null  $content the actual file bytes written to the tmp path.
+     *                              Defaults to a valid header for $mimeType; pass
+     *                              spoofed bytes to exercise content sniffing.
+     */
     private function input(
         string $mimeType = 'application/pdf',
         int $fileSizeBytes = 1024,
@@ -168,10 +241,20 @@ final class UploadDocumentUseCaseTest extends TestCase
         ?int $amountCents = null,
         bool $confirmDuplicate = false,
         array $tags = [],
+        ?string $content = null,
     ): UploadDocumentInput {
+        $bytes = $content ?? match ($mimeType) {
+            'image/jpeg' => self::JPEG_BYTES,
+            'image/png' => self::PNG_BYTES,
+            default => self::PDF_BYTES,
+        };
+        $tmpPath = (string) tempnam(sys_get_temp_dir(), 'vault-upload-test');
+        file_put_contents($tmpPath, $bytes);
+        $this->tmpFiles[] = $tmpPath;
+
         return new UploadDocumentInput(
             organizationId: 1,
-            tmpPath: '/tmp/fake-upload',
+            tmpPath: $tmpPath,
             originalFilename: 'invoice.pdf',
             mimeType: $mimeType,
             fileSizeBytes: $fileSizeBytes,


### PR DESCRIPTION
Closes #294 · QA発見 **優先1🔴セキュリティ**（VLT-B7-01: MIME 偽装受理）の根治。

## 背景
QA live 打鍵（#287）で **`.exe` を client MIME `application/pdf` 申告→素通り受理**を実証。サーバ検証は `getClientMediaType()`（クライアント申告）のみで content sniffing/拡張子検査が無かった。

## 修正
- **マジックバイト検査（content sniffing）** を `UploadDocumentUseCase` に追加。申告 MIME allowlist（既存）の後に、**実バイト先頭**で PDF(`%PDF-`)/JPEG(`FF D8 FF`)/PNG(`89 50 4E 47 0D 0A 1A 0A`)を検証し、許可型の実体でなければ `MimeTypeNotAllowedException`。依存追加なし。受理段階で弾くのが根治
- `MimeTypeNotAllowedException`: content mismatch メッセージ用に `sniffedType` 任意引数

## UT（受入）
- ✅ 偽装 .exe（申告 pdf・中身 exe）拒否
- ✅ SVG（XSS ベクタ・申告 png）拒否
- ✅ 正規 jpeg/png 受理（**回帰なし**）
- `composer check` 全緑（PHPUnit **405**/PHPStan 264/CS/conformance 0 error）

## 後続
残 QA 修正: 優先2(0バイト)・優先3(amount 範囲)・優先4(RFC5987)・🟢仕様確認(TTL/楽観ロック issue 起票のみ)。1PR=1発見で順次。

🤖 Generated with [Claude Code](https://claude.com/claude-code)