### PR TITLE
fix(document): 0バイトファイルのアップロードを拒否する（#296）

### DIFF
--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -27,6 +27,7 @@ use NeneVault\Demo\SeatFixedDemoHandler;
 use NeneVault\Document\DocumentRouteRegistrar;
 use NeneVault\Document\DocumentServiceProvider;
 use NeneVault\Document\DuplicateFileExceptionHandler;
+use NeneVault\Document\EmptyFileExceptionHandler;
 use NeneVault\Document\FileIntegrityExceptionHandler;
 use NeneVault\Document\FileTooLargeExceptionHandler;
 use NeneVault\Document\InvalidDocumentStateExceptionHandler;
@@ -221,6 +222,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $c->get(DuplicateFileExceptionHandler::class),
                     $c->get(MimeTypeNotAllowedExceptionHandler::class),
                     $c->get(FileTooLargeExceptionHandler::class),
+                    $c->get(EmptyFileExceptionHandler::class),
                     $c->get(FileIntegrityExceptionHandler::class),
                     $c->get(InvalidDocumentStateExceptionHandler::class),
                     $c->get(UserNotFoundExceptionHandler::class),

--- a/src/Document/DocumentServiceProvider.php
+++ b/src/Document/DocumentServiceProvider.php
@@ -375,6 +375,18 @@ final readonly class DocumentServiceProvider implements ServiceProviderInterface
                 },
             )
             ->set(
+                EmptyFileExceptionHandler::class,
+                static function (ContainerInterface $c): EmptyFileExceptionHandler {
+                    $pd = $c->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$pd instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('ProblemDetailsResponseFactory service is invalid.');
+                    }
+
+                    return new EmptyFileExceptionHandler($pd);
+                },
+            )
+            ->set(
                 FileTooLargeExceptionHandler::class,
                 static function (ContainerInterface $c): FileTooLargeExceptionHandler {
                     $pd = $c->get(ProblemDetailsResponseFactory::class);

--- a/src/Document/EmptyFileException.php
+++ b/src/Document/EmptyFileException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+use RuntimeException;
+
+final class EmptyFileException extends RuntimeException
+{
+    public function __construct()
+    {
+        parent::__construct('The uploaded file is empty (0 bytes). Upload a document with content.');
+    }
+}

--- a/src/Document/EmptyFileExceptionHandler.php
+++ b/src/Document/EmptyFileExceptionHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneVault\Document;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class EmptyFileExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $e): bool
+    {
+        return $e instanceof EmptyFileException;
+    }
+
+    public function handle(Throwable $e, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'empty-file', 'Empty File', 422, $e->getMessage());
+    }
+}

--- a/src/Document/UploadDocumentUseCase.php
+++ b/src/Document/UploadDocumentUseCase.php
@@ -41,6 +41,13 @@ final readonly class UploadDocumentUseCase implements UploadDocumentUseCaseInter
 
     public function execute(UploadDocumentInput $input): UploadDocumentOutput
     {
+        // 0. Empty file (QA VLT-B7-02): a 0-byte upload is a meaningless record
+        // for a 電子帳簿保存法 archive. Reject it with a clear reason before the
+        // MIME/sniff gates (which would otherwise report it as a content mismatch).
+        if ($input->fileSizeBytes <= 0) {
+            throw new EmptyFileException();
+        }
+
         // 1. MIME allowlist (compliance §2.1, backend-standards §5) — the
         // client-declared media type is a cheap first gate.
         if (!in_array($input->mimeType, self::ALLOWED_MIME_TYPES, true)) {

--- a/tests/Document/UploadDocumentUseCaseTest.php
+++ b/tests/Document/UploadDocumentUseCaseTest.php
@@ -6,6 +6,7 @@ namespace NeneVault\Tests\Document;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use NeneVault\Document\DuplicateFileException;
+use NeneVault\Document\EmptyFileException;
 use NeneVault\Document\FileTooLargeException;
 use NeneVault\Document\MimeTypeNotAllowedException;
 use NeneVault\Document\UploadDocumentInput;
@@ -129,6 +130,17 @@ final class UploadDocumentUseCaseTest extends TestCase
         $output = $useCase->execute($this->input(mimeType: 'image/png'));
 
         $this->assertSame('active', $output->document->status);
+    }
+
+    public function test_rejects_empty_file(): void
+    {
+        // QA VLT-B7-02: a 0-byte upload is a meaningless record and is rejected
+        // with a clear reason before the MIME/sniff gates.
+        $useCase = $this->makeUseCase();
+
+        $this->expectException(EmptyFileException::class);
+
+        $useCase->execute($this->input(fileSizeBytes: 0, content: ''));
     }
 
     public function test_rejects_oversized_file(): void


### PR DESCRIPTION
Closes #296 · QA発見 **優先2🟡**（VLT-B7-02: 0バイト受理）。

## 修正
- `UploadDocumentUseCase`: `fileSizeBytes <= 0` を **MIME/sniff の前段**で拒否（`EmptyFileException`）。空ファイルには content-mismatch でなく「空」の明確な理由
- `EmptyFileException` + `EmptyFileExceptionHandler`（**422 Empty File**・problem details）を両プロバイダに登録（既存ハンドラと同型）

## UT（受入）
- ✅ 0バイト拒否・正規（>0）受理（回帰なし）
- `composer check` 全緑（PHPUnit **406**/PHPStan/CS/conformance 0 error）

## 後続
優先3(amount 範囲)・優先4(RFC5987)・🟢仕様確認(TTL/楽観ロック issue 起票のみ)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)