### PR TITLE
fix(document): amount_cents をアプリ層で範囲検証する（0..INT32・#298）

### DIFF
--- a/src/Document/UpdateDocumentMetadataHandler.php
+++ b/src/Document/UpdateDocumentMetadataHandler.php
@@ -18,6 +18,9 @@ final readonly class UpdateDocumentMetadataHandler
     /** @var list<string> */
     private const VALID_CATEGORIES = ['invoice_received', 'contract', 'receipt', 'delivery_note', 'other'];
 
+    /** amount_cents is a signed 32-bit DB column; app-layer range guard (QA VLT-B1-02). */
+    private const MAX_AMOUNT_CENTS = 2147483647;
+
     public function __construct(
         private UpdateDocumentMetadataUseCaseInterface $useCase,
         private JsonResponseFactory $response,
@@ -59,6 +62,11 @@ final readonly class UpdateDocumentMetadataHandler
         if (isset($body['amount_cents']) && $body['amount_cents'] !== '') {
             if (!is_numeric($body['amount_cents']) || (int) $body['amount_cents'] != $body['amount_cents']) {
                 $errors[] = new ValidationError('amount_cents', 'Please enter a valid integer amount.', 'invalid_amount');
+            } elseif ((int) $body['amount_cents'] < 0 || (int) $body['amount_cents'] > self::MAX_AMOUNT_CENTS) {
+                // Range-check at the app layer so an out-of-range value returns a
+                // friendly 422 instead of overflowing the signed-32-bit DB column
+                // and surfacing as a raw server error (QA VLT-B1-02).
+                $errors[] = new ValidationError('amount_cents', 'Amount must be between 0 and 2,147,483,647.', 'amount_out_of_range');
             } else {
                 $amountCents = (int) $body['amount_cents'];
             }

--- a/src/Document/UploadDocumentHandler.php
+++ b/src/Document/UploadDocumentHandler.php
@@ -18,6 +18,9 @@ final readonly class UploadDocumentHandler
     /** @var list<string> */
     private const VALID_CATEGORIES = ['invoice_received', 'contract', 'receipt', 'delivery_note', 'other'];
 
+    /** amount_cents is a signed 32-bit DB column; app-layer range guard (QA VLT-B1-02). */
+    private const MAX_AMOUNT_CENTS = 2147483647;
+
     public function __construct(
         private UploadDocumentUseCaseInterface $useCase,
         private JsonResponseFactory $response,
@@ -63,6 +66,11 @@ final readonly class UploadDocumentHandler
         if (isset($body['amount_cents']) && $body['amount_cents'] !== '') {
             if (!is_numeric($body['amount_cents']) || (int) $body['amount_cents'] != $body['amount_cents']) {
                 $errors[] = new ValidationError('amount_cents', 'Please enter a valid integer amount.', 'invalid_amount');
+            } elseif ((int) $body['amount_cents'] < 0 || (int) $body['amount_cents'] > self::MAX_AMOUNT_CENTS) {
+                // Range-check at the app layer so an out-of-range value returns a
+                // friendly 422 instead of overflowing the signed-32-bit DB column
+                // and surfacing as a raw server error (QA VLT-B1-02).
+                $errors[] = new ValidationError('amount_cents', 'Amount must be between 0 and 2,147,483,647.', 'amount_out_of_range');
             } else {
                 $amountCents = (int) $body['amount_cents'];
             }

--- a/tests/Document/DocumentMetadataBoundaryTest.php
+++ b/tests/Document/DocumentMetadataBoundaryTest.php
@@ -149,6 +149,20 @@ final class DocumentMetadataBoundaryTest extends ApiTestCase
         $this->assertSame(422, $resp->getStatusCode());
     }
 
+    public function test_metadata_edit_amount_above_int32_max_returns_422(): void
+    {
+        // QA VLT-B1-02: app-layer range guard on the metadata edit path too.
+        $id   = $this->uploadDoc($this->handler(), self::$adminToken, 'AmountRange', '2026-01-01', '1');
+        $resp = $this->handler()->handle(
+            $this->request('PATCH', "/admin/vault/documents/{$id}/metadata", self::$adminToken, [
+                'counterparty_name' => 'AmountRange',
+                'category'          => 'invoice_received',
+                'amount_cents'      => 2147483648,
+            ]),
+        );
+        $this->assertSame(422, $resp->getStatusCode());
+    }
+
     public function test_metadata_edit_nonexistent_document_returns_404(): void
     {
         $resp = $this->handler()->handle(

--- a/tests/Document/DocumentUploadBoundaryTest.php
+++ b/tests/Document/DocumentUploadBoundaryTest.php
@@ -171,6 +171,37 @@ final class DocumentUploadBoundaryTest extends ApiTestCase
         @unlink($tmp);
     }
 
+    // ── amount_cents range (QA VLT-B1-02) ─────────────────────────────────────
+
+    public function test_upload_amount_at_int32_max_accepted(): void
+    {
+        $tmp = $this->makeTempPdf('amount-max');
+        $req = $this->buildUploadRequest(self::$adminToken, $tmp, 'invoice.pdf', 'application/pdf', 'Max Amount Co', '2026-01-01', '2147483647');
+        $resp = $this->handler()->handle($req);
+        $this->assertSame(201, $resp->getStatusCode(), (string) $resp->getBody());
+        @unlink($tmp);
+    }
+
+    public function test_upload_amount_above_int32_max_returns_422(): void
+    {
+        // App-layer range guard returns a friendly 422 instead of overflowing the
+        // signed-32-bit DB column and surfacing as a raw server error.
+        $tmp = $this->makeTempPdf('amount-over');
+        $req = $this->buildUploadRequest(self::$adminToken, $tmp, 'invoice.pdf', 'application/pdf', 'Over Amount Co', '2026-01-01', '2147483648');
+        $resp = $this->handler()->handle($req);
+        $this->assertSame(422, $resp->getStatusCode());
+        @unlink($tmp);
+    }
+
+    public function test_upload_negative_amount_returns_422(): void
+    {
+        $tmp = $this->makeTempPdf('amount-neg');
+        $req = $this->buildUploadRequest(self::$adminToken, $tmp, 'invoice.pdf', 'application/pdf', 'Negative Amount Co', '2026-01-01', '-1');
+        $resp = $this->handler()->handle($req);
+        $this->assertSame(422, $resp->getStatusCode());
+        @unlink($tmp);
+    }
+
     // ── Duplicate detection ───────────────────────────────────────────────────
 
     public function test_duplicate_sha256_rejected_unless_confirmed(): void


### PR DESCRIPTION
Closes #298 · QA発見 **優先3🟡**（VLT-B1-02: amount 範囲検証欠落）。

## 修正
- `UploadDocumentHandler` / `UpdateDocumentMetadataHandler`: 整数チェックの後に **0..2147483647**（`MAX_AMOUNT_CENTS`）の範囲検証。範囲外は `ValidationError`→`ValidationException`（**422**）＝DB 挿入オーバーフロー前に friendly なエラー

## UT（受入）
- ✅ 上限(2147483647)受理・上限+1(2147483648)拒否・負数拒否（upload）＋上限+1 拒否（metadata edit）
- `composer check` 全緑（PHPUnit **410**/PHPStan/CS/conformance 0 error）

## 後続
優先4(RFC5987)・🟢仕様確認(TTL/楽観ロック issue 起票のみ)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)