### PR TITLE
fix(document): ダウンロードの Content-Disposition を RFC5987 でエンコードする（#300）

### DIFF
--- a/src/Document/DownloadDocumentVersionHandler.php
+++ b/src/Document/DownloadDocumentVersionHandler.php
@@ -34,14 +34,56 @@ final readonly class DownloadDocumentVersionHandler
 
         return $this->responseFactory->createResponse(200)
             ->withHeader('Content-Type', $result['mime_type'])
-            ->withHeader('Content-Disposition', 'attachment; filename="' . $this->sanitizeFilename($result['filename']) . '"')
+            ->withHeader('Content-Disposition', $this->contentDisposition($result['filename']))
             ->withHeader('X-Content-Type-Options', 'nosniff')
             ->withBody($stream);
     }
 
-    private function sanitizeFilename(string $filename): string
+    /**
+     * Build a Content-Disposition value carrying the original filename safely for
+     * both legacy and modern clients (RFC 6266): a quoted ASCII `filename=` for
+     * old agents plus an RFC 5987 `filename*=UTF-8''…` that preserves non-ASCII
+     * names (e.g. Japanese) instead of emitting raw bytes that garble (QA VLT-B7-03).
+     */
+    private function contentDisposition(string $filename): string
     {
-        // Strip characters that could break the header; keep it simple and safe.
-        return str_replace(['"', "\r", "\n"], '', $filename);
+        // Header-injection guard: never let quotes/CR/LF into the header.
+        $clean = str_replace(['"', "\r", "\n"], '', $filename);
+
+        // ASCII fallback for clients that ignore filename*: non-ASCII → '_'.
+        $ascii = preg_replace('/[^\x20-\x7E]/', '_', $clean);
+        if ($ascii === null || trim($ascii, '_ ') === '') {
+            $ascii = 'download';
+        }
+
+        return sprintf(
+            "attachment; filename=\"%s\"; filename*=UTF-8''%s",
+            $ascii,
+            $this->rfc5987Encode($clean),
+        );
+    }
+
+    /**
+     * Percent-encode a UTF-8 string per RFC 5987 (attr-char stays literal, every
+     * other byte becomes %HH).
+     */
+    private function rfc5987Encode(string $value): string
+    {
+        $out = '';
+        $length = strlen($value);
+        for ($i = 0; $i < $length; $i++) {
+            $char = $value[$i];
+            $ord = ord($char);
+            $isAlnum = ($ord >= 0x30 && $ord <= 0x39)
+                || ($ord >= 0x41 && $ord <= 0x5A)
+                || ($ord >= 0x61 && $ord <= 0x7A);
+            if ($isAlnum || str_contains('!#$&+-.^_`|~', $char)) {
+                $out .= $char;
+            } else {
+                $out .= '%' . strtoupper(str_pad(dechex($ord), 2, '0', STR_PAD_LEFT));
+            }
+        }
+
+        return $out;
     }
 }

--- a/tests/Document/DocumentVersionBoundaryTest.php
+++ b/tests/Document/DocumentVersionBoundaryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneVault\Tests\Document;
 
 use NeneVault\Tests\Support\ApiTestCase;
+use Nyholm\Psr7Server\ServerRequestCreator;
 
 /**
  * Version download and history boundary tests: wrong IDs, tenant isolation,
@@ -55,6 +56,54 @@ final class DocumentVersionBoundaryTest extends ApiTestCase
         );
 
         $this->assertStringContainsString('attachment', $resp->getHeaderLine('Content-Disposition'));
+    }
+
+    public function test_download_content_disposition_rfc5987_for_japanese_filename(): void
+    {
+        // QA VLT-B7-03: a Japanese filename must be carried via RFC 5987
+        // `filename*=UTF-8''…` (percent-encoded), with an ASCII `filename=`
+        // fallback — not emitted as raw bytes that garble in the header.
+        $handler = $this->handler();
+        $psr17   = $this->psr17();
+        $tmp     = $this->makeTempPdf('jp-name');
+
+        $file = $psr17->createUploadedFile(
+            $psr17->createStreamFromFile($tmp),
+            (int) filesize($tmp),
+            UPLOAD_ERR_OK,
+            '請求書_4月.pdf',
+            'application/pdf',
+        );
+        $creator = new ServerRequestCreator($psr17, $psr17, $psr17, $psr17);
+        $up = $handler->handle(
+            $creator->fromArrays(
+                server: ['REQUEST_METHOD' => 'POST', 'REQUEST_URI' => '/admin/vault/documents'],
+                headers: ['Host' => 'localhost', 'Authorization' => 'Bearer ' . self::$adminToken],
+            )
+                ->withUploadedFiles(['file' => $file])
+                ->withParsedBody([
+                    'counterparty_name' => 'JpName',
+                    'category'          => 'invoice_received',
+                    'transaction_date'  => '2026-01-01',
+                ]),
+        );
+        $this->assertSame(201, $up->getStatusCode(), (string) $up->getBody());
+        @unlink($tmp);
+        $docId = (string) json_decode((string) $up->getBody(), true)['id'];
+
+        [$docId, $versionId] = $this->getVersionId($handler, $docId);
+        $resp = $handler->handle(
+            $this->request('GET', "/admin/vault/documents/{$docId}/versions/{$versionId}/download", self::$adminToken),
+        );
+
+        $cd = $resp->getHeaderLine('Content-Disposition');
+        // RFC 5987 percent-encoding of the UTF-8 name (請 = %E8%AB%8B).
+        $this->assertStringContainsString("filename*=UTF-8''", $cd);
+        $this->assertStringContainsString('%E8%AB%8B', $cd);
+        // ASCII fallback present (non-ASCII replaced with '_').
+        $this->assertMatchesRegularExpression('/filename="[^"]*_[^"]*"/', $cd);
+        // Header-injection safety: no raw CR/LF/quote leakage.
+        $this->assertStringNotContainsString("\n", $cd);
     }
 
     public function test_download_unknown_version_returns_404(): void


### PR DESCRIPTION
Closes #300 · QA発見 **優先4🟡**（VLT-B7-03: 日本語DL名 RFC5987 欠落）。

## 修正
- `DownloadDocumentVersionHandler.contentDisposition()`: **RFC 6266** 準拠。ASCII 互換の `filename="..."`（非 ASCII は `_`）＋**RFC 5987** の `filename*=UTF-8''<pct-encoded>` を併記。header-injection ガード（quote/CR/LF 除去）維持

## UT（受入）
- ✅ 日本語名（`請求書_4月.pdf`）で `filename*=UTF-8''` に `%E8%AB%8B`（請）がエンコード・ASCII fallback 付・CR/LF 漏れなし
- ✅ ASCII 名は回帰なし
- `composer check` 全緑（PHPUnit 407/PHPStan/CS/conformance 0 error）

## 残
🟢仕様確認（TTL 無告知・楽観ロック無し）= issue 起票のみ（修正しない）。これで修正レーン完了→『サニタイズ品質サマリ公開』の下書きへ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)