### PR TITLE
fix(css): C5 drain 回帰 — map/三項の className 値が drained クラスを空振り（stack-lg/muted）

### DIFF
--- a/frontend/src/shared/ui/components/AppShell.test.tsx
+++ b/frontend/src/shared/ui/components/AppShell.test.tsx
@@ -146,4 +146,16 @@ describe('AppShell interactions', () => {
 
     expect(screen.getByText('admin@example.com')).toBeInTheDocument();
   });
+
+  // Regression (#313): the content wrapper's vertical rhythm lived in the map
+  // string, which the drain codemod (className literals only) never rewrote —
+  // so `.stack-lg` was dropped from CSS while the reference lingered. Assert the
+  // wrapper now carries the utility form and no drained component class survives.
+  it('wraps content in the space-y utility, not the drained .stack-lg', () => {
+    renderShell({ role: 'admin' });
+
+    const content = screen.getByRole('main');
+    expect(content).toHaveClass('content', 'space-y-5.5');
+    expect(content).not.toHaveClass('stack-lg');
+  });
 });

--- a/frontend/src/shared/ui/components/AppShell.tsx
+++ b/frontend/src/shared/ui/components/AppShell.tsx
@@ -131,9 +131,9 @@ interface AppShellProps {
 }
 
 const WIDTH_CLASS: Record<NonNullable<AppShellProps['width']>, string> = {
-  default: 'content stack-lg',
-  mid: 'content is-mid stack-lg',
-  narrow: 'content is-narrow stack-lg',
+  default: 'content space-y-5.5 max-md:space-y-4.5',
+  mid: 'content is-mid space-y-5.5 max-md:space-y-4.5',
+  narrow: 'content is-narrow space-y-5.5 max-md:space-y-4.5',
 };
 
 export function AppShell({

--- a/frontend/src/shared/ui/primitives/Text.test.tsx
+++ b/frontend/src/shared/ui/primitives/Text.test.tsx
@@ -29,4 +29,13 @@ describe('Text', () => {
     render(<Text className="text-heading-md">Title</Text>);
     expect(screen.getByText('Title')).toHaveClass('text-heading-md');
   });
+
+  // Regression (#313): the muted tone mapped to the drained `.muted` component
+  // class (removed in drain #2) — assert it now carries the utility form.
+  it('maps the muted tone to the text-text-muted utility, not the drained .muted', () => {
+    render(<Text tone="muted">Quiet</Text>);
+    const el = screen.getByText('Quiet');
+    expect(el).toHaveClass('text-text-muted');
+    expect(el).not.toHaveClass('muted');
+  });
 });

--- a/frontend/src/shared/ui/primitives/Text.tsx
+++ b/frontend/src/shared/ui/primitives/Text.tsx
@@ -9,7 +9,7 @@ export interface TextProps {
 
 const TONE_CLASS: Record<NonNullable<TextProps['tone']>, string> = {
   primary: '',
-  muted: 'muted',
+  muted: 'text-text-muted',
   danger: 'danger',
   success: 'success',
 };


### PR DESCRIPTION
Closes #313

## 何が起きていたか
C5 drain の codemod と `nene2-check init --check` scanner は、いずれも **`className="..."` の literal 属性しか見ない**。このため drained クラスを **object-map / 三項 / テンプレート内の className 値**で参照していた2箇所が、CSS 除去後に無言で空振りしていた（`@smoke`・computed-parity も捕捉できず）。

| 箇所 | 参照 | 除去元 | 影響 |
|---|---|---|---|
| `AppShell.tsx` WIDTH_CLASS | `'content stack-lg'` ×3 | drain #1 (#308) | **全ページ**の最上位コンテンツ間の縦リズム（22px / ≤767px 18px）が #308 以降消失 |
| `Text.tsx` TONE_CLASS | `muted: 'muted'` | drain #2 (#310) | `<Text>` は本番未使用（`Modal.stories` のみ）＝低影響 |

## 修正
- AppShell: `stack-lg` → `space-y-5.5 max-md:space-y-4.5`（`.stack-lg > *+*` の 22px / `@media(max-width:767px)` の 18px を完全一致で復元）
- Text: `muted: 'muted'` → `muted: 'text-text-muted'`（drain #2 の再生成先）

## 回帰ガード
- `AppShell.test`: `getByRole('main')` が `content space-y-5.5` を持ち `stack-lg` を持たない
- `Text.test`: `tone="muted"` が `text-text-muted` を持ち `muted` を持たない

## 別件（drain 起因ではない・記録のみ）
`Text.tsx` の `danger: 'danger'` / `success: 'success'` は元々 CSS 未定義のクラスを指しており drain 前から dead。設計色の確定が要るため本 PR では触らず #313 に記録。

## 再発防止
以降の drain は className の literal 属性に加え、object-map / 三項 / テンプレート内の className **値**も sweep する（手順を運用メモに追記）。

## 検証
`npm run check` 全 gate green ＋ `@smoke` green ＋ 追加 2 テスト green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)