### PR TITLE
chore(css): C5 W3 波(a) — .center を min-h-screen/flex + gradient @utility 化（93→92）

### DIFF
--- a/frontend/registries.jsonc
+++ b/frontend/registries.jsonc
@@ -32,7 +32,6 @@
         ".callout",
         ".card",
         ".cell-title",
-        ".center",
         ".center-card",
         ".checkbox",
         ".chev-cell",

--- a/frontend/src/features/login/ui/LoginForm.tsx
+++ b/frontend/src/features/login/ui/LoginForm.tsx
@@ -18,7 +18,7 @@ export function LoginForm({ onLoggedIn }: LoginFormProps) {
     useLoginPage();
 
   return (
-    <div className="center">
+    <div className="min-h-screen flex flex-col page-glow">
       <div className="flex justify-end px-6 py-4.5">
         <LanguageSwitcher
           label={t('navigation.language')}

--- a/frontend/src/pages/ForbiddenPage.tsx
+++ b/frontend/src/pages/ForbiddenPage.tsx
@@ -7,7 +7,7 @@ export function ForbiddenPage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   return (
-    <div className="center">
+    <div className="min-h-screen flex flex-col page-glow">
       <div className="center-card">
         <div className="head">
           <div className="inline-flex flex-col items-center gap-3">

--- a/frontend/src/shared/ui/theme/index.css
+++ b/frontend/src/shared/ui/theme/index.css
@@ -7,6 +7,17 @@
   font-feature-settings: 'zero' 1;
 }
 
+/* Custom utility: the app's page-background glow (exact parity with the retired
+   `.center` block — a radial glow over the base surface). arbitrary gradient は
+   規約⑤で components 禁止 → @utility 化が正道。 */
+@utility page-glow {
+  background: radial-gradient(
+    120% 80% at 50% -10%,
+    var(--color-x-page-glow) 0%,
+    var(--color-surface) 60%
+  );
+}
+
 @import './active.css';
 /* NOTE: imported WITHOUT `layer(base)` — this is the canonical form, not a
    deviation. base.css already wraps its rules in `@layer base { … }`, and layer

--- a/frontend/src/shared/ui/theme/themes/default.components.css
+++ b/frontend/src/shared/ui/theme/themes/default.components.css
@@ -627,16 +627,6 @@
     }
 
     /* ---- centered screens (login / forbidden) ---- */
-    .center {
-      min-height: 100vh;
-      display: flex;
-      flex-direction: column;
-      background: radial-gradient(
-        120% 80% at 50% -10%,
-        oklch(95% 0.012 83) 0%,
-        var(--color-surface) 60%
-      );
-    }
     .center-card {
       margin: auto;
       width: 100%;

--- a/frontend/src/shared/ui/theme/themes/default.css
+++ b/frontend/src/shared/ui/theme/themes/default.css
@@ -23,6 +23,7 @@
 @theme {
   /* ---- paper / surfaces — warm, never sterile white ---- */
   --color-surface: oklch(97.2% 0.007 83);
+  --color-x-page-glow: oklch(95% 0.012 83);
   --color-surface-raised: oklch(99.4% 0.004 83);
   --color-surface-overlay: oklch(98% 0.006 83);
   --color-surface-sunken: oklch(95.4% 0.008 83);


### PR DESCRIPTION
Closes #329 · umbrella #307 · 台帳 #319 · 純 (a)utility+token

## 目標パターン: (a) utility + @utility（arbitrary gradient のトークン化）
login/forbidden の全画面ラッパ `.center` を Tailwind utility 化。**radial-gradient は arbitrary なので `@utility` 化＝規約⑤どおりの正道**（`zero-slash`/`--radius-px` と同型）。standards ブロッカー #322 と独立。

- `.center` → `min-h-screen flex flex-col page-glow`
  - `min-height:100vh`→`min-h-screen` / `display:flex`→`flex` / `flex-direction:column`→`flex-col`

## 追加
- `--color-x-page-glow: oklch(95% 0.012 83)`（@theme・gradient の top 色をトークン化）
- `@utility page-glow { background: radial-gradient(120% 80% at 50% -10%, var(--color-x-page-glow) 0%, var(--color-surface) 60%); }`（index.css・zero-slash と同配置）

## 受入（#235 型）
- **computed-parity EXACT 1:1**: built CSS 実測 `radial-gradient(120% 80% at 50% -10%, var(--color-x-page-glow) 0%, var(--color-surface) 60%)`＝旧 `.center` と一致（top 色トークンは同 oklch・position/stops/surface 不変・min-h-screen=100vh）
- **init --check** unregistered 0 / 回帰 0 ・ **npm run check** 全 gate green ＋ **@smoke** green
- 判例 **#313** 非literal sweep（2 usages・literal-only）・`.center-card` 温存

## registries
components-allowlist **93 → 92**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)