### PR TITLE
chore(css): C5 W3 波(a) — brand-name(wordmark) を utility+token 化（92→91）

### DIFF
--- a/frontend/registries.jsonc
+++ b/frontend/registries.jsonc
@@ -22,7 +22,6 @@
         ".badge-success",
         ".badge-warning",
         ".body",
-        ".brand-name",
         ".btn",
         ".btn-danger",
         ".btn-ghost",

--- a/frontend/src/features/login/ui/LoginForm.tsx
+++ b/frontend/src/features/login/ui/LoginForm.tsx
@@ -33,7 +33,7 @@ export function LoginForm({ onLoggedIn }: LoginFormProps) {
         <div className="head">
           <div className="inline-flex flex-col items-center gap-3">
             <BrandMark size={46} className="text-x-seal" title="NeNe Vault" />
-            <div className="brand-name">
+            <div className="font-serif text-2xl font-semibold text-x-ink-deep leading-brand tracking-wordmark whitespace-nowrap">
               NeNe <span className="text-x-brass">Vault</span>
             </div>
           </div>

--- a/frontend/src/shared/ui/components/AppShell.tsx
+++ b/frontend/src/shared/ui/components/AppShell.tsx
@@ -219,7 +219,9 @@ export function AppShell({
             title="NeNe Vault"
           />
           <div>
-            <div className="brand-name">NeNe Vault</div>
+            <div className="font-serif text-brand font-semibold text-x-rail-ink leading-brand tracking-wordmark whitespace-nowrap">
+              NeNe Vault
+            </div>
             <div className="text-3xs tracking-brand text-x-brass uppercase mt-0.5 font-medium">
               Document Archive
             </div>

--- a/frontend/src/shared/ui/theme/themes/default.components.css
+++ b/frontend/src/shared/ui/theme/themes/default.components.css
@@ -61,15 +61,6 @@
       padding: 20px 18px 18px;
       border-bottom: 1px solid var(--color-x-rail-line);
     }
-    .brand-name {
-      font-family: var(--font-serif);
-      font-size: 1.18rem;
-      font-weight: 600;
-      color: var(--color-x-rail-ink);
-      line-height: 1.05;
-      letter-spacing: 0.01em;
-      white-space: nowrap;
-    }
     .rail-nav {
       padding: 14px 12px;
       display: flex;
@@ -640,10 +631,6 @@
     .center-card .head {
       padding: 30px 30px 4px;
       text-align: center;
-    }
-    :where(.center-card) .head .brand-name {
-      color: var(--color-x-ink-deep);
-      font-size: 1.5rem;
     }
     .center-card .body {
       padding: 24px 30px 30px;

--- a/frontend/src/shared/ui/theme/themes/default.css
+++ b/frontend/src/shared/ui/theme/themes/default.css
@@ -92,6 +92,7 @@
   --text-sm: 0.8125rem;
   --text-xs: 0.75rem;
   --text-3xs: 0.5625rem;
+  --text-brand: 1.18rem;
   --text-2xs: 0.6875rem;
 
   /* ---- geometry ---- */
@@ -136,8 +137,10 @@
   --tracking-title: -0.01em;
   --tracking-label: 0.06em;
   --tracking-brand: 0.22em;
+  --tracking-wordmark: 0.01em;
 
   /* ---- line-height (leading) ---- */
+  --leading-brand: 1.05;
   --leading-diff: 1.55;
   --leading-pre: 1.6;
 


### PR DESCRIPTION
Closes #331 · umbrella #307 · 台帳 #319 · 純 (a)utility+token（最後の純 standalone-(a) 相当）

## 目標パターン: (a) utility + token（express-first・per-usage）
ブランド wordmark `.brand-name`（2セレクタ=rail base ＋ login center-card 上書き）を per-usage で Tailwind utility 化。standards ブロッカー #322 と独立。

| 使用箇所 | 文脈 | 置換後 |
|---|---|---|
| AppShell | rail・base | `font-serif text-brand font-semibold text-x-rail-ink leading-brand tracking-wordmark whitespace-nowrap` |
| LoginForm | center-card .head・base+override | `font-serif text-2xl font-semibold text-x-ink-deep leading-brand tracking-wordmark whitespace-nowrap` |

override `:where(.center-card) .head .brand-name { color: x-ink-deep; font-size: 1.5rem }` を login 側 utility へ反映（1.5rem=`text-2xl`・line-height は `leading-brand`=1.05 が --tw-leading で供給）。

## 追加トークン（旧CSS実測）
- `--text-brand: 1.18rem`（rail font-size）/ `--leading-brand: 1.05` / `--tracking-wordmark: 0.01em`

## 受入（#235 型）
- **computed-parity EXACT 1:1**（built CSS 実測: `--text-2xl:1.5rem` / `--text-brand:1.18rem` / `--leading-brand:1.05` / `--tracking-wordmark:.01em`＝旧 base/override と一致）
- **init --check** unregistered 0 / 回帰 0 ・ **npm run check** 全 gate green ＋ **@smoke** green
- 判例 **#313** 非literal sweep（2 usages・literal-only）

## registries
components-allowlist **92 → 91**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)