### PR TITLE
fix(css): C5 W3 — callout 回帰修正＋drain（Callout の tone 色を復元・#316 template-literal 盲点）

### DIFF
--- a/frontend/registries.jsonc
+++ b/frontend/registries.jsonc
@@ -28,7 +28,6 @@
         ".btn-primary",
         ".btn-secondary",
         ".btn-sm",
-        ".callout",
         ".card",
         ".cell-title",
         ".center-card",

--- a/frontend/src/shared/ui/components/Callout.test.tsx
+++ b/frontend/src/shared/ui/components/Callout.test.tsx
@@ -8,8 +8,22 @@ describe('Callout', () => {
     expect(screen.getByText('Something failed')).toBeInTheDocument();
   });
 
-  it.each(['danger', 'warn'] as const)('applies the %s tone class', (tone) => {
-    render(<Callout tone={tone}>Message</Callout>);
-    expect(screen.getByText('Message')).toHaveClass('callout', `callout-${tone}`);
+  // Regression (#337): the tone colours lived in `.callout-${tone}` component
+  // classes that drain #4 (#316) removed while this component still referenced
+  // them via a template literal — asserting the tone *colour utilities* (not the
+  // class name) now guards the paint, which the old `toHaveClass('callout-…')`
+  // assertion could not (className present, CSS absent = silent regression).
+  it('applies the danger tone colours', () => {
+    render(<Callout tone="danger">Message</Callout>);
+    expect(screen.getByText('Message')).toHaveClass(
+      'bg-danger-soft',
+      'border-danger',
+      'text-x-danger-hover',
+    );
+  });
+
+  it('applies the warn tone colours', () => {
+    render(<Callout tone="warn">Message</Callout>);
+    expect(screen.getByText('Message')).toHaveClass('bg-warn-soft', 'border-warn', 'text-on-warn');
   });
 });

--- a/frontend/src/shared/ui/components/Callout.tsx
+++ b/frontend/src/shared/ui/components/Callout.tsx
@@ -6,10 +6,27 @@ export interface CalloutProps {
   children: ReactNode;
 }
 
+// Tone colours regenerated from the retired `.callout-danger`/`.callout-warn`
+// blocks (C5 W3). NOTE: those component classes were dropped in drain #4 (#316)
+// while this file still referenced them via a `callout-${tone}` template literal
+// — the tone colours had silently regressed since #316 (same template-literal
+// blind spot as 判例 #313). Keeping the tone as a variant map restores them and
+// removes the dead component-class reference.
+const TONE_CLASS: Record<CalloutProps['tone'], string> = {
+  danger: 'bg-danger-soft border-danger text-x-danger-hover',
+  warn: 'bg-warn-soft border-warn text-on-warn',
+};
+
 /**
- * Inline message block (error / warning) styled by the design-system `.callout`
- * block. Replaces hand-written `callout callout-*` divs across pages and modals.
+ * Inline message block (error / warning). Base layout is utility-first; the tone
+ * supplies the border/background/text colour.
  */
 export function Callout({ tone, children }: CalloutProps) {
-  return <div className={`callout callout-${tone}`}>{children}</div>;
+  return (
+    <div
+      className={`flex gap-2.75 rounded-md px-3.75 py-3.25 text-sm leading-diff border ${TONE_CLASS[tone]}`}
+    >
+      {children}
+    </div>
+  );
 }

--- a/frontend/src/shared/ui/theme/themes/default.components.css
+++ b/frontend/src/shared/ui/theme/themes/default.components.css
@@ -535,22 +535,6 @@
     }
 
     /* ---- callouts ---- */
-    .callout {
-      display: flex;
-      gap: 11px;
-      border-radius: var(--radius-md);
-      padding: 13px 15px;
-      font-size: var(--text-sm);
-      line-height: 1.55;
-      border: 1px solid;
-    }
-    .callout svg {
-      width: 18px;
-      height: 18px;
-      flex: none;
-      margin-top: 1px;
-      stroke: currentColor;
-    }
 
     /* ---- pagination ---- */
     .pagination {


### PR DESCRIPTION
Closes #337 · umbrella #307 · 台帳 #333 W1 · **#313 型 live 回帰の第2件（drain #4/#316 起因）の修正 ＋ .callout drain**

## 回帰
`Callout.tsx` は `className={\`callout callout-${tone}\`}`（tone=danger|warn）で tone 色を **template-literal 動的構築**。`.callout-danger`/`.callout-warn` は drain #4(#316) で dead 判定・削除済（当時の 0-usage check は literal grep で `callout-${tone}` を漏らした＝判例 #313 と同盲点）。→ **#316 以降、全 callout の tone 色（border-color/bg/text）が消失**（`.callout` base の `border: 1px solid` が色未指定）。

## EXACT 復元の根拠＝git 履歴（削除済コードが正・記憶でない）
#316（`0ea5bb9`）が削除した実体を `git show` で取得:

| 旧CSS（#316前・git 確定） | → 新 utility |
|---|---|
| `.callout-danger { background: var(--color-danger-soft); border-color: var(--color-danger); color: var(--color-x-danger-hover) }` | `bg-danger-soft border-danger text-x-danger-hover` |
| `.callout-warn { background: var(--color-warn-soft); border-color: var(--color-warn); color: var(--color-on-warn) }` | `bg-warn-soft border-warn text-on-warn` |
| `.callout { display:flex; gap:11px; border-radius:radius-md; padding:13px 15px; font-size:text-sm; line-height:1.55; border:1px solid }` | `flex gap-2.75 rounded-md px-3.75 py-3.25 text-sm leading-diff border` |

`.callout svg`（w18/h18/flex-none/mt1/stroke-current）は callout に svg 子が無く **dead** → 除去。`line-height:1.55` は既存 `--leading-diff` 再利用（**新トークン0**）。

## 回帰ガード
`Callout.test` を tone 色 utility の `toHaveClass`（danger=`bg-danger-soft`/`border-danger`/`text-x-danger-hover`・warn=`bg-warn-soft`/`border-warn`/`text-on-warn`）へ更新。旧 `toHaveClass('callout-…')` は className 文字列のみで CSS 不在の退行を捕捉できなかった（class あり/CSS なし＝silent regression）。※computed border-color/bg/text の paint ロックは @smoke/実ブラウザ側（jsdom は Tailwind CSS を適用しない）。

## 再発防止＝型に昇格（統合リナ指示）
drain 前 sweep を **4形態必須**（**literal ＋ object-map ＋ 三項 ＋ template-literal**）に昇格し台帳 #333 に明記。#313 の初例（AppShell の map・Text の map）→ 本件（Callout の template-literal）再発で **「sweep は4形態必須」を確定判例化**。加えて Button/Select/Input/Textarea は btn/select/input/textarea を template-literal 参照するが**参照先未 drain＝現状安全・将来 drain 波で該当 primitive 更新必須**（学びとして記録）。

## ⚠ デプロイ確認（要 hub/施主）
`#316` は main に merge 済（現 HEAD は #316 以降）。**公開デモ vault.ayane.co.jp の deploy 済みコミットは repo から判定不可** — もし #316 以降がデモに乗っていれば callout が無色で見えている期間があるため、本 PR の priority 最上げ＋デプロイ手配を要検討。

## 受入
- computed-parity EXACT（git 確定の旧 tone 色と一致）・init --check unregistered 0 / 回帰 0 ・ npm run check 全 gate green ＋ @smoke green
- registries **81 → 80**

🤖 Generated with [Claude Code](https://claude.com/claude-code)