### PR TITLE
chore(css): C5 W3 波(a) — tag-chg family を inline utility 化（70→67）

### DIFF
--- a/frontend/registries.jsonc
+++ b/frontend/registries.jsonc
@@ -9,7 +9,6 @@
       "repo": "nene-vault",
       "classes": [
         ".a",
-        ".add",
         ".ar",
         ".arr",
         ".audit-row",
@@ -53,7 +52,6 @@
         ".lang",
         ".layout",
         ".link",
-        ".mod",
         ".no-dot",
         ".out",
         ".pagination",
@@ -71,7 +69,6 @@
         ".row-chev",
         ".seg",
         ".select",
-        ".tag-chg",
         ".tbl",
         ".tbl-cards",
         ".tbl-wrap",

--- a/frontend/src/pages/AuditPage.tsx
+++ b/frontend/src/pages/AuditPage.tsx
@@ -86,9 +86,13 @@ function DiffView({ fields, isCreate }: { fields: AuditDiffField[]; isCreate: bo
       {fields.map((f) => {
         const tag =
           f.kind === 'add' ? (
-            <span className="tag-chg add">{t('audit_event.detail.tag_added')}</span>
+            <span className="font-sans text-3xs tracking-label font-bold uppercase px-1.5 py-px rounded-full bg-success-soft text-success">
+              {t('audit_event.detail.tag_added')}
+            </span>
           ) : (
-            <span className="tag-chg mod">{t('audit_event.detail.tag_changed')}</span>
+            <span className="font-sans text-3xs tracking-label font-bold uppercase px-1.5 py-px rounded-full bg-x-brass-soft text-x-brass-deep">
+              {t('audit_event.detail.tag_changed')}
+            </span>
           );
         return (
           <div key={f.key} className={isCreate ? 'diff-field diff-single' : 'diff-field'}>

--- a/frontend/src/shared/ui/theme/themes/default.components.css
+++ b/frontend/src/shared/ui/theme/themes/default.components.css
@@ -682,23 +682,6 @@
     .diff-field + .diff-field {
       margin-top: 13px;
     }
-    .tag-chg {
-      font-family: var(--font-sans);
-      font-size: 9px;
-      letter-spacing: 0.06em;
-      font-weight: 700;
-      text-transform: uppercase;
-      padding: 1px 6px;
-      border-radius: var(--radius-full);
-    }
-    .tag-chg.add {
-      background: var(--color-success-soft);
-      color: var(--color-success);
-    }
-    .tag-chg.mod {
-      background: var(--color-x-brass-soft);
-      color: var(--color-x-brass-deep);
-    }
     .diff-pair {
       display: grid;
       grid-template-columns: 1fr 22px 1fr;


### PR DESCRIPTION
Closes #341 · umbrella #307 · 台帳 #333 · 純 (a)utility+token

## 目標パターン: (a) inline utilities（判例#35）
audit の変更タグ `.tag-chg` ＋ `.add`/`.mod` を Tailwind utility 化。**判例#35**: `add`/`mod` は AuditPage の **2つの静的 JSX**（`tag-chg add`/`tag-chg mod`・`isCreate` 分岐の別要素＝同一要素が runtime データで変わるのでない）なので data-属性でなく **(a) inline utilities**（badge 静的 warning/muted と同型・型見本 #339 の `doc.status` 三項とはここが違う）。新トークン不要。

| 原子 | 置換後 |
|---|---|
| `.tag-chg` | `font-sans text-3xs tracking-label font-bold uppercase px-1.5 py-px rounded-full`（9px=text-3xs / 0.06em=tracking-label / 1px 6px=py-px px-1.5） |
| `.add`（`.tag-chg.add`） | `bg-success-soft text-success` |
| `.mod`（`.tag-chg.mod`） | `bg-x-brass-soft text-x-brass-deep` |

## 受入（#235 型）
- **computed-parity EXACT 1:1** ・ **init --check** unregistered 0 / 回帰 0 ・ **npm run check** 全 gate green ＋ **@smoke** green
- 判例 **#313 の 4形態 sweep** 済（`add`/`mod` は exact-token でこの2 site のみ）

## registries
components-allowlist **70 → 67**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)