### PR TITLE
chore(css): C5 W3 波(a) — card flush を shadow-none へ（67→66）

### DIFF
--- a/frontend/registries.jsonc
+++ b/frontend/registries.jsonc
@@ -36,7 +36,6 @@
         ".env",
         ".field-label",
         ".file-input",
-        ".flush",
         ".head",
         ".ic",
         ".input",

--- a/frontend/src/pages/AuditPage.tsx
+++ b/frontend/src/pages/AuditPage.tsx
@@ -384,7 +384,7 @@ export function AuditPage() {
       {isLoading ? (
         <EmptyState>{t('common.status.loading')}</EmptyState>
       ) : (
-        <div className="card flush">
+        <div className="card shadow-none">
           {events.length === 0 ? (
             <EmptyState>{t('audit_event.list.empty')}</EmptyState>
           ) : (

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -66,7 +66,7 @@ export function DocumentsPage() {
       {isLoading ? (
         <EmptyState>{t('common.status.loading')}</EmptyState>
       ) : (
-        <div className="card flush">
+        <div className="card shadow-none">
           <DocumentTable
             documents={documents}
             onSelectDocument={(id) => {

--- a/frontend/src/pages/UsersPage.tsx
+++ b/frontend/src/pages/UsersPage.tsx
@@ -202,7 +202,7 @@ export function UsersPage() {
       {isLoading ? (
         <EmptyState>{t('common.status.loading')}</EmptyState>
       ) : (
-        <div className="card flush">
+        <div className="card shadow-none">
           {users.length === 0 ? (
             <EmptyState>{t('user.list.empty')}</EmptyState>
           ) : (

--- a/frontend/src/shared/ui/theme/themes/default.components.css
+++ b/frontend/src/shared/ui/theme/themes/default.components.css
@@ -263,9 +263,6 @@
       border-radius: var(--radius-md);
       box-shadow: var(--shadow-sm);
     }
-    .card.flush {
-      box-shadow: none;
-    }
 
     /* ---- buttons ---- */
 


### PR DESCRIPTION
Closes #343 · umbrella #307 · 台帳 #333 · 純 (a)

## (a) — 単一 utility（判例#35 ガード①）
`.card.flush { box-shadow: none }` は単一プロパティ＝Tailwind `shadow-none`（utilities 層が components 層に勝つ）。**単一 utility で足りるので data-属性でなく (a)**。`.card` base 温存・`.flush` のみ drain。

- `card flush`（3 usages: Documents/Audit/UsersPage）→ `card shadow-none`

## 受入
- **EXACT**（box-shadow none）・**init --check** unregistered 0 / 回帰 0 ・ **npm run check** 全 gate green ＋ **@smoke** green ・ 判例 **#313 4形態 sweep** 済（`flush` はこの3 site のみ）

## registries
components-allowlist **67 → 66**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)