### PR TITLE
chore(css): C5 W3 波W3 — input-warn を aria-invalid variant へ（66→65・FC-1.8 初適用）

### DIFF
--- a/frontend/registries.jsonc
+++ b/frontend/registries.jsonc
@@ -39,7 +39,6 @@
         ".head",
         ".ic",
         ".input",
-        ".input-warn",
         ".is-active",
         ".is-danger",
         ".is-mid",

--- a/frontend/src/pages/SettingsPage.test.tsx
+++ b/frontend/src/pages/SettingsPage.test.tsx
@@ -18,14 +18,17 @@ describe('SettingsPage retention warning', () => {
     await waitFor(() => {
       expect(input).toHaveValue(10);
     });
-    expect(input).not.toHaveClass('input-warn');
+    // The under-10 warning now hangs off `aria-invalid` (C5 W3 波W3, FC-1.8) —
+    // the styling regenerated from `.input-warn` follows this attribute, so
+    // assert the attribute (a11y + paint source) rather than the retired class.
+    expect(input).not.toHaveAttribute('aria-invalid');
 
     // Typing a value below 10 must flag the field immediately — no save required.
     await userEvent.clear(input);
     await userEvent.type(input, '8');
 
     await waitFor(() => {
-      expect(input).toHaveClass('input-warn');
+      expect(input).toHaveAttribute('aria-invalid', 'true');
     });
   });
 });

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -120,7 +120,7 @@ export function SettingsPage() {
               type="number"
               min={7}
               max={99}
-              className={retentionWarn ? 'input-warn' : ''}
+              aria-invalid={retentionWarn || undefined}
               // valueAsNumber so the watched value is numeric *while typing* — the
               // under-10-years compliance warning must render live, not only after
               // save → re-fetch coerces the value server-side.

--- a/frontend/src/shared/ui/primitives/Input.tsx
+++ b/frontend/src/shared/ui/primitives/Input.tsx
@@ -9,5 +9,14 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
   { className, ...rest },
   ref,
 ) {
-  return <input ref={ref} className={`input ${className ?? ''}`} {...rest} />;
+  // Invalid state (regenerated from the retired `.input-warn` class, C5 W3 波W3):
+  // the styling hangs off the `aria-invalid` attribute so accessibility and paint
+  // come from the same source (FC-1.8). Callers just set `aria-invalid`.
+  return (
+    <input
+      ref={ref}
+      className={`input aria-invalid:border-warn aria-invalid:ring-3 aria-invalid:ring-warn-soft ${className ?? ''}`}
+      {...rest}
+    />
+  );
 });

--- a/frontend/src/shared/ui/theme/themes/default.components.css
+++ b/frontend/src/shared/ui/theme/themes/default.components.css
@@ -310,10 +310,6 @@
       background-position: right 11px center;
       padding-right: 30px;
     }
-    .input-warn {
-      border-color: var(--color-warn);
-      box-shadow: 0 0 0 3px var(--color-warn-soft);
-    }
     .checkbox,
     .radio {
       display: inline-flex;


### PR DESCRIPTION
umbrella #307 · 台帳 #333 W3 · **FC-1.8 aria variant の初適用**（#143 で解禁）

## 目標パターン: (b) aria-* 属性 + aria-[…]: utility variant（FC-1.8）
`.input-warn`（検証警告 state）を **`aria-invalid`** へ再生成。統合リナ裁定: **Input primitive が `aria-invalid` 属性を受け、`aria-invalid:` variant で styling** — a11y とスタイルが同じ属性から出る FC-1.8 の理想形（呼び出し側に撒かない）。

- **Input.tsx** base に `aria-invalid:border-warn aria-invalid:ring-3 aria-invalid:ring-warn-soft`（`.input` base 温存）。任意の input が `aria-invalid="true"` で invalid 表示。
- **SettingsPage**: `className={retentionWarn ? 'input-warn' : ''}` → `aria-invalid={retentionWarn || undefined}`。
- **SettingsPage.test**: `toHaveClass('input-warn')` → `toHaveAttribute('aria-invalid', 'true')`（class 名でなく a11y 属性＝paint 源を張る）。

## 受入（#235 型）
- **computed-parity EXACT 1:1**（built CSS 実測）: `aria-invalid:border-warn` → `[aria-invalid=true]{border-color:var(--color-warn)}`・`ring-3` → `box-shadow 0 0 0 calc(3px + offset=0)` = `0 0 0 3px`・`ring-warn-soft` → `--tw-ring-color:var(--color-warn-soft)` ＝ 旧 `.input-warn`（`border-color: warn` ＋ `box-shadow: 0 0 0 3px warn-soft`）と一致。
- `aria-invalid:` は TW4 built-in variant（`[aria-invalid=true]`）・`ring-3` は dynamic ring-width・eslint⑤ 非該当（実測）。
- 判例 **#313 4形態 sweep** 済 ・ **init --check** unregistered 0 / 回帰 0 ・ **npm run check** 全 gate green ＋ **@smoke** green

## registries
components-allowlist **66 → 65**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)