### PR TITLE
chore(css): C5 W3 波(a) — pagination を utility 化（65→64）

### DIFF
--- a/frontend/registries.jsonc
+++ b/frontend/registries.jsonc
@@ -52,7 +52,6 @@
         ".link",
         ".no-dot",
         ".out",
-        ".pagination",
         ".params-head",
         ".pri",
         ".qlink",

--- a/frontend/src/shared/ui/components/Pagination.tsx
+++ b/frontend/src/shared/ui/components/Pagination.tsx
@@ -32,7 +32,7 @@ export function Pagination({
   }
 
   return (
-    <div className="pagination">
+    <div className="flex items-center justify-between px-4 py-3 border-t border-border text-xs text-text-muted max-md:flex-col max-md:gap-3 max-md:items-stretch max-md:text-center">
       <span>{showingLabel}</span>
       <div className="flex items-center gap-2 max-md:justify-center">
         {/* max-md:flex-1 preserves the retired `.pagination .btn { flex: 1 }`

--- a/frontend/src/shared/ui/theme/themes/default.components.css
+++ b/frontend/src/shared/ui/theme/themes/default.components.css
@@ -443,15 +443,6 @@
     /* ---- callouts ---- */
 
     /* ---- pagination ---- */
-    .pagination {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      padding: 12px 16px;
-      border-top: 1px solid var(--color-border);
-      font-size: var(--text-xs);
-      color: var(--color-text-muted);
-    }
 
     /* ---- quick links (home) ---- */
     .qlink {
@@ -939,12 +930,6 @@
       /* a form's action row spans full width, primary on its own line & reachable */
 
       /* pagination stacks */
-      .pagination {
-        flex-direction: column;
-        gap: 12px;
-        align-items: stretch;
-        text-align: center;
-      }
 
       /* modals sit near the bottom, full width, thumb-reachable */
 


### PR DESCRIPTION
Closes #346 · umbrella #307 · 台帳 #333 · 純 (a)

## (a) utility — clean single-class
btn 波で `.pagination .btn` が除去され、`.pagination` は single-class（base＋1 responsive・children なし）になったので clean に utility 化。新トークン0。

- `.pagination` → `flex items-center justify-between px-4 py-3 border-t border-border text-xs text-text-muted max-md:flex-col max-md:gap-3 max-md:items-stretch max-md:text-center`（12px 16px=py-3 px-4・mobile: flex-col/gap-3/items-stretch/text-center）

## 受入
- **EXACT** ・ **init --check** unregistered 0 / 回帰 0 ・ **npm run check** 全 gate green ＋ **@smoke** green ・ 判例 **#313 4形態 sweep** 済（className 使用は Pagination.tsx 1箇所・DocumentsPage の `pagination.*` は JS 変数で無関係）

## registries
components-allowlist **65 → 64**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)