### PR TITLE
chore(css): C5 W3 波(a) — drawer-meta を express-first utility 化（63→62）

### DIFF
--- a/frontend/registries.jsonc
+++ b/frontend/registries.jsonc
@@ -32,7 +32,6 @@
         ".diff-single",
         ".dl",
         ".dot",
-        ".drawer-meta",
         ".env",
         ".field-label",
         ".file-input",

--- a/frontend/src/pages/AuditPage.tsx
+++ b/frontend/src/pages/AuditPage.tsx
@@ -191,7 +191,7 @@ function AuditDetailDrawer({ event, open, onClose }: DrawerProps) {
             </div>
 
             <div className="overflow-auto flex-1 pt-5 px-5.5 pb-7">
-              <dl className="drawer-meta">
+              <dl className="grid grid-cols-2 gap-x-5.5 gap-y-3.25 pb-4.5 border-b border-border mb-4.5 max-md:grid-cols-1 max-md:gap-3 [&_dt]:text-2xs [&_dt]:text-text-muted [&_dt]:uppercase [&_dt]:tracking-meta [&_dt]:font-semibold [&_dt]:mb-0.75 [&_dd]:text-sm [&_dd]:text-x-ink-deep">
                 <div>
                   <dt>{t('audit_event.list.table.actor')}</dt>
                   <dd className="font-mono zero-slash">
@@ -204,7 +204,7 @@ function AuditDetailDrawer({ event, open, onClose }: DrawerProps) {
                     {formatDateTime(event.created_at, locale)}
                   </dd>
                 </div>
-                <div className="col2">
+                <div className="col-span-2 max-md:col-auto">
                   <dt>{t('audit_event.detail.entity')}</dt>
                   <dd className="font-mono zero-slash label-xs break-all">
                     {event.entity_type}/{event.entity_id}

--- a/frontend/src/shared/ui/theme/themes/default.components.css
+++ b/frontend/src/shared/ui/theme/themes/default.components.css
@@ -609,29 +609,6 @@
     }
 
     /* ---- audit detail drawer ---- */
-    .drawer-meta {
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      gap: 13px 22px;
-      padding-bottom: 18px;
-      border-bottom: 1px solid var(--color-border);
-      margin-bottom: 18px;
-    }
-    .drawer-meta .col2 {
-      grid-column: span 2;
-    }
-    .drawer-meta dt {
-      font-size: var(--text-2xs);
-      color: var(--color-text-muted);
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-      font-weight: 600;
-      margin-bottom: 3px;
-    }
-    .drawer-meta dd {
-      font-size: var(--text-sm);
-      color: var(--color-x-ink-deep);
-    }
     .params-head {
       display: flex;
       align-items: center;
@@ -1000,13 +977,6 @@
       }
 
       /* audit detail drawer becomes a bottom sheet with a grab handle */
-      .drawer-meta {
-        grid-template-columns: 1fr;
-        gap: 12px;
-      }
-      .drawer-meta .col2 {
-        grid-column: auto;
-      }
       /* diff stacks vertically: before above, arrow turns down, after below */
       .diff-pair {
         grid-template-columns: 1fr;

--- a/frontend/src/shared/ui/theme/themes/default.css
+++ b/frontend/src/shared/ui/theme/themes/default.css
@@ -141,6 +141,7 @@
   --tracking-label: 0.06em;
   --tracking-brand: 0.22em;
   --tracking-wordmark: 0.01em;
+  --tracking-meta: 0.05em;
 
   /* ---- line-height (leading) ---- */
   --leading-brand: 1.05;


### PR DESCRIPTION
umbrella #307 · 台帳 #333 W4→express · 純 (a)（express-first 再挑戦）

## W4 温存候補 → express drain（判例#33 の express-first 側）
`drawer-meta` は当初 W4 温存候補だったが、**express-first 再挑戦で drain**（統合リナ裁定）。rail の4モード変形（font-size:0/env/position 変換）と違い **dt/dd 3対のみ**で、`[&_dt]:` の scope が dl 1箇所に閉じ可読性を損なわない＝判例#33 の「安易な温存 debt を避け express する」側が正。

- `<dl>` → `grid grid-cols-2 gap-x-5.5 gap-y-3.25 pb-4.5 border-b border-border mb-4.5 max-md:grid-cols-1 max-md:gap-3` ＋ `[&_dt]:*`（text-2xs/text-text-muted/uppercase/tracking-meta/font-semibold/mb-0.75）＋ `[&_dd]:*`（text-sm/text-x-ink-deep）（2.1.1 で子 variant 解禁）
- col2 div → `col-span-2 max-md:col-auto`（`.col2` クラスは `.dl .col2` と共有ゆえ**残置**）
- 追加: `--tracking-meta: 0.05em`

## 受入（#235 型）
- **computed-parity EXACT**（built CSS 実測）: `dt{…letter-spacing:.05em;margin-bottom:3px;…}`・`dd{font-size:var(--text-sm);color:var(--color-x-ink-deep)}` ＝ 旧 `.drawer-meta dt/dd` と一致・`gap-y-3.25`=13px
- 判例 **#313 4形態 sweep** 済 ・ **init --check** unregistered 0 / 回帰 0 ・ **npm run check** 全 gate green ＋ **@smoke** green

## 別記録（本 PR では触らない）
`.label-xs`（AuditPage の entity dd が参照）は **CSS 未定義かつ allowlist 外＝dead className 参照**（意図した小フォントが不発）。別 Issue #350 で施主/設計判断へ（意図フォント復元 or 除去）。drawer-meta では inert なので EXACT に無影響。

## registries
components-allowlist **63 → 62**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)