### PR TITLE
chore(deps): npm audit 新規 advisory を lockfile 更新で解消＋mh99 allowlist を撤去 (#353)

### DIFF
--- a/frontend/audit-ci.jsonc
+++ b/frontend/audit-ci.jsonc
@@ -23,20 +23,23 @@
     // 期限を過ぎたら PR で再論証する——黙って延長しない。
     "GHSA-qwww-vcr4-c8h2",
 
-    // GHSA-mh99-v99m-4gvg — brace-expansion "DoS via unbounded expansion"（high）。
-    // 脆弱範囲 <=5.0.7・修正は 5.0.8。**採れる場所では採る**: overrides
-    // "brace-expansion@5": "^5.0.8"（本 PR 同梱・従前 5.0.7）。1.x/2.x 系には patched release が
-    // 存在せず、5.0.8 を強制すると minimatch@3 系の消費者が壊れる（named export 化・
-    // フリート実測 2026-07-29）。
+    // ── 撤去済み: GHSA-mh99-v99m-4gvg（brace-expansion DoS・#353 で削除・2026-08-05）──
+    // 「patch が出たから外した」のではない。**エントリの前提が執筆時点で既に誤っていた**。
     //
-    // 残余リスクが許容できる理由（この tree で実測・2026-07-31）:
-    // brace-expansion は本艦で **dev 専用**（package-lock の全コピーが dev:true・
-    // 出荷バンドルに含まれず、リクエスト経路に到達しない）。残る脆弱コピーは
-    // 1.1.16 ×2（minimatch@3 経由）・2.1.2 ×1＝lint/codegen ツーリングが自リポの committed パターンを処理するだけで、
-    // 攻撃者供給の brace パターンが入る口が無い。
+    // 旧エントリの主張:「1.x/2.x 系には patched release が存在せず、5.0.8 を強制すると
+    // minimatch@3 系の消費者が壊れる（named export 化）」。後半は真だが、前半は誤り。
+    // 誤りの正体 = 「brace-expansion@5 を 1.x/2.x 消費者に流し込めない」を
+    // 「1.x/2.x に patch が無い」と取り違えた。各系列は自前の patch 線を持っていた。
     //
-    // 期限: 2026-08-31。eslint 10 / plugin major 波（チェーンが minimatch@10 →
-    // brace-expansion@^5 へ動く）で外れる。期限時に再検証——反射で延長しない。
-    "GHSA-mh99-v99m-4gvg",
+    // npm view brace-expansion time 実測（2026-08-05）— エントリ執筆は 07-31 12:56 UTC:
+    //   2.1.3 = 07-28 10:16Z / 1.1.17 = 07-29 10:45Z / 2.1.4・1.1.18 = 07-30 10:15-10:17Z
+    //   → 全系列の patch が執筆の 1〜3 日前に存在した。例外は当初から不要だった。
+    //
+    // 正解は最初から系列内 bump（親の宣言は ^1.1.7 / ^2.0.1 の caret なので lockfile 更新のみ・
+    // package.json 無変更・export 形も不変＝named export の罠を踏まない）。
+    // 現在値 1.1.18 / 2.1.4 / 5.0.9 で mh99・rgw5 とも解消（本 PR で実測）。
+    //
+    // 教訓: allowlist の条件(2)「当てはまらない理由」は**執筆時点で実測**する。
+    // 「patch が無い」は npm view で1コマンド確認できる——想定で書かない。
   ],
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2837,9 +2837,9 @@
       "license": "MIT"
     },
     "node_modules/@redocly/openapi-core/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6735,9 +6735,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6842,9 +6842,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Closes #353

fleet-tooling #229 / board 行101（due 2026-08-05）の配布分。hub 裁定（`handoff-vault-352-353-ruling-2026-08-05.md`）の **#353 → #352** の順で、先に本件。

## 陽性対照（修正前・2026-08-05 実測 @ 74b4f39）

```
npm run audit → exit 1
Found vulnerable advisory paths: GHSA-rgw5-rvv9-x895|brace-expansion
Failed security audit due to high vulnerabilities.
```

CI が緑だったのは 07-31 の push 以降 push が無かっただけで、**次の push で落ちる**状態でした。

## 🔴 自艦実測が fleet の外部見立てと違った2点（写経しなかった箇所）

fleet #229 は「新規 advisory **2件**」としていましたが、**本艦で生きていたのは1件**でした。

| advisory | fleet の見立て | vault 実測 | 判定 |
| --- | --- | --- | --- |
| GHSA-7p8r-x3mc-p8w7 (fast-uri) | 目標 3.1.5 | 既に 3.1.5・**audit に一切現れない** | 該当なし・bump 不要 |
| GHSA-rgw5-rvv9-x895 (brace-expansion) | 目標 1.1.18/2.1.4/5.0.9 | 該当。ただし赤の実体は **5.x ではなく 1.1.16×2 / 2.1.2×1** | 本件 |

`overrides` の `"brace-expansion@5": "^5.0.8"` は caret なので **5.0.9 へ既に解決済み**でした。fleet の「caret なので package.json 編集は不要」という見立ては正しく、かつ **1.x/2.x にもそのまま当てはまり**ました。

## 対策: lockfile 更新のみ（package.json 無変更・overrides 追加ゼロ）

親の宣言が全て caret（minimatch 経由で `^1.1.7` / `^2.0.1`）なので `npm update brace-expansion` だけで patched 版へ上がります。

```
1.1.16 ×2 → 1.1.18   (eslint-plugin-import / eslint-plugin-jsx-a11y)
2.1.2     → 2.1.4     (@redocly/openapi-core)
5.0.9                 (据置・caret で既に到達済み)
```

差分は **3パッケージの version/resolved/integrity のみ**。実装コードは無変更です。

## allowlist: mh99 撤去・qwww 温存

hub 裁定の判別（「patch が出たから消す」ではなく「そもそも死んだ例外だった可能性」を先に判定）に従い、`npm view` で生死を測りました。

**結論: mh99 はエントリ執筆時点で既に前提が誤っていました。**

旧エントリの主張は「**1.x/2.x 系には patched release が存在せず**、5.0.8 を強制すると minimatch@3 系の消費者が壊れる（named export 化）」。**後半は真ですが、前半は誤り**です。

`npm view brace-expansion time` 実測（2026-08-05）— エントリ執筆は 07-31 12:56 UTC（74b4f39）:

| 版 | 公開 (UTC) | 執筆との前後 |
| --- | --- | --- |
| 2.1.3 | 2026-07-28 10:16 | **3日前に存在** |
| 1.1.17 | 2026-07-29 10:45 | **2日前に存在** |
| 2.1.4 | 2026-07-30 10:15 | **1日前に存在** |
| 1.1.18 | 2026-07-30 10:17 | **1日前に存在** |

誤りの正体は、「`brace-expansion@5` を 1.x/2.x 消費者に流し込めない」を「1.x/2.x に patch が無い」と**取り違えた**ことです。各系列は自前の patch 線を持っており、系列内 bump なら export 形は変わらないので named export の罠も踏みません。**正解は最初から系列内 bump でした。**

`GHSA-qwww-vcr4-c8h2` (react-router) は 7.x 系に fix が無いため**温存**（艦隊解と一致・invoice/serve/field とも react-router 1件のみ残置）。

## 陰性対照（`npm ci` 後に実測）

依存の解決が壊れていないことを実証しました。

```
minimatch('src/a.ts','src/{a,b}.ts') → true   ✅
minimatch('src/c.ts','src/{a,b}.ts') → false  ✅
typeof require('eslint-plugin-import/node_modules/brace-expansion') → function ✅
  （minimatch@3 が呼ぶ v1 の関数 export 形が不変＝named export の罠を踏んでいない）
expand('a{b,c}d') → ["abd","acd"] ✅
```

`brace-expansion@5` のスコープ限定も維持（root のみ 5.0.9・consumer 側は 1.x/2.x のまま）。

## 受入

- [x] `npm run audit` が **exit 0**（残: qwww のみ・意図的温存）
- [x] **allowlist を追加していない**（むしろ mh99 を撤去＝allowlist は2件→1件）
- [x] 🔴 陰性対照を実測（上記4本）
- [x] 差分が**依存の版だけ**（実装コード無変更・package.json 無変更）
- [x] `npm run check` が **exit 0**
- [ ] 結果を fleet-tooling #229 へコメント（マージ後）

## 他艦へ効く一般形

**allowlist エントリの「当てはまらない理由」は執筆時点で実測する。**「patch が無い」は `npm view <pkg> time` で1コマンド確認できます。本件は「override を流し込めない」という**別の真の制約**を「patch が存在しない」と誤読して例外を作った型で、他艦の allowlist にも同じ取り違えがありうると思います。

🤖 Generated with [Claude Code](https://claude.com/claude-code)