### PR TITLE
ci(frontend): check に本番 build を配線する — 射程はバンドル解決性であって CSS ではない (#352)

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -31,8 +31,18 @@ jobs:
 
       # npm run check = type-check + lint + format + coverage:check
       # (vitest --coverage + shrink-only ratchet) + knip + stylelint
-      # + build-storybook.
-      - name: Check (type-check, lint, format, coverage:check, knip, storybook build)
+      # + registries:check + build（本番バンドル・#352）+ build-storybook。
+      #
+      # 🔴 build の射程を誤読しないこと（#352 で実測・2026-08-05 @ 2c725d5）:
+      # build は **CSS を守らない**。base.css に不正 CSS（`color: ;`・閉じない @media）を
+      # 注入した実測では stylelint rc=2 に対し build rc=0・build-storybook rc=0 だった。
+      # CSS の守りは stylelint 側で、build を足しても増えない（invoice #742 と同型）。
+      #
+      # build が実際に塞ぐのは **本番バンドル経路の解決性**。main.tsx から到達する
+      # .ts/.tsx 78 本のうち 71 本は storybook のどの story からも到達せず、
+      # そこに解決不能な import があっても type-check / lint / stylelint / knip /
+      # build-storybook は全て rc=0 で素通りする（負テスト実測・#352 参照）。
+      - name: Check (type-check, lint, format, coverage:check, knip, build, storybook build)
         run: npm run check
 
       # audit-ci = npm audit ＋ advisory 単位の allowlist（理由・期限つき例外）。

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,7 @@
     "build-storybook": "storybook build",
     "knip": "knip",
     "stylelint": "stylelint \"src/**/*.css\"",
-    "check": "npm run type-check && npm run lint && npm run format && npm run coverage:check && npm run knip && npm run stylelint && npm run registries:check && npm run build-storybook",
+    "check": "npm run type-check && npm run lint && npm run format && npm run coverage:check && npm run knip && npm run stylelint && npm run registries:check && npm run build && npm run build-storybook",
     "e2e:live": "NODE_PATH=./node_modules playwright test --config playwright.live.config.ts",
     "registries:check": "nene2-check init --check",
     "audit": "audit-ci --config audit-ci.jsonc"


### PR DESCRIPTION
Closes #352

fleet-tooling #210 / board 行78（due 2026-08-05）の配布分。hub 裁定（`handoff-vault-352-353-ruling-2026-08-05.md` Q3）に従い **check へ集約**。#353（PR #354・マージ済み 2c725d5）の後に着手しています。

## 追認

fleet の指摘を自艦で追認しました（実測 2026-08-05 @ 2c725d5）。check の全ステップと CI workflow の全ステップに `npm run build` を実行する行は **0本**。

なお `type-check` = `tsc -b` なので **build の TS 半分は既に check にあり**、純増は **`vite build`（本番バンドル）のみ**です。

---

## 🔴 ① CSS — 「build を足せば CSS が守られる」は vault でも成り立ちません

`vite.config.ts` に `cssMinify` / `lightningcss` の設定なし（既定 esbuild）。`base.css` に不正 CSS（`color: ;` と閉じない `@media (min-width {`）を注入した実測:

| ゲート | rc |
| --- | --- |
| `stylelint` | **2** ✅ 捕まえる |
| `npm run build` | **0** 🔴 素通り |
| `build-storybook` | **0** 🔴 素通り |

**board 行78 の但し書き（invoice 実測の一般化禁止）は vault にもそのまま当たりました。** CSS の守りは stylelint 側で、build を足しても増えません。

この PR は「CSS を守るために build を足す」ものでは**ありません**。誤読防止の注記を workflow のコメントに実測値つきで残しています。

## ② storybook の射程 — main 経路 78本のうち 71本が到達不能

| 集合 | 本数 |
| --- | --- |
| stories | 7（+ `.storybook/preview.ts` / `main.ts`） |
| `src` の `.ts`/`.tsx`（stories/test 除く） | 80 |
| `main.tsx` から到達 | **78** |
| いずれかの story から到達 | **9** |
| 🔴 main 経路で story 未到達 | **71** |

未到達 71本は pages 全9・features 全17・entities 全16・`shared/api`・`shared/i18n` ほか。**アプリ本体はほぼ全部** storybook のバンドル対象外です。

<details>
<summary>⚠️ CSS の測定に訂正があります（自己申告）</summary>

当初「CSS 5本は story 到達 0」と測りましたが**誤りでした**。`.storybook/preview.ts` が `index.css` を import しており、そこから `active.css` → `themes/default.css` → `default.components.css` / `base.css` まで `@import` 連鎖が通っています。**CSS 5本は storybook も全部コンパイルしています。**

原因は走査を `src/**/*.stories.tsx` からしか辿っておらず `.storybook/` のエントリを入れ忘れたこと。①の結論（storybook も CSS の破壊を捕まえない）は連鎖を通した上でも rc=0 なので**変わりません**。
</details>

## ③ 負テスト — 壊して exit 1 の実証

main 専用ファイル `src/app/providers.tsx` に解決不能 import（`'@/shared/ui/theme/DOES-NOT-EXIST.css'`）を注入。

**【配線前】現行 check の全ステップが緑のまま素通りします**

```
type-check       rc=0
lint             rc=0
stylelint        rc=0
knip             rc=0
build-storybook  rc=0
npm run build    rc=1   ← ここだけが落ちる
```

**【配線後】**

```
壊した状態:  npm run check → rc=1
             [UNLOADABLE_DEPENDENCY] Could not load src/shared/ui/theme/DOES-NOT-EXIST.css
               5 │ import "@/shared/ui/theme/DOES-NOT-EXIST.css";
                 │                    ╰──── No such file or directory (os error 2)
             ※ storybook build に到達していない = 新設の build ステップで停止した証拠

直した状態:  npm run check → rc=0（storybook build まで完走）
```

📌 **射程の正体は CSS ではなく「本番バンドル経路の解決性」** ＝ storybook が見ない 71本です。注入は全て測定後に復旧済み（`git checkout` で復元・tracked diff なし）。

---

## 変更

- **`frontend/package.json`** — check の `registries:check` と `build-storybook` の間に `npm run build` を挿入。参照実装を実読した結果、**deal #180 も invoice #742 も check 末尾が `… && npm run build && npm run build-storybook`** で一致していたので同じ形にしました。
- **`.github/workflows/frontend-ci.yml`** — ステップ名とコメントを更新。**build の射程を誤読させないための注記**を実測値つきで残しました（「build は CSS を守らない」を次に読む人が測り直さずに済むように）。

CI 側に独立ステップは足していません（hub 裁定: 出荷ゲートの正体は CI だが、**どこに書くか**は check に集約するのがフリート標準＝艦の開発者が手元で同じ結果を得られる）。required checks への追加も不要です（check の一部になるため `frontend-check` に含まれる）。

## 受入

- [x] ①②③ を実測（対策より先に測定）
- [x] 測定結果に基づいて射程を塞いだ（`check` への build 追加＝ただし**正解は「CSS が守られるから」ではない**）
- [x] **負テストを1本**（壊して exit 1 → 直して exit 0 の一巡）
- [x] `npm run check` が exit 0
- [ ] 結果を fleet-tooling #210 へコメント（マージ後）

## 他艦へ効く一般形

**「build を足す」対策は、足す前に「その build が何を検査しているか」を負テストで測る。** vault では CSS は守られず、守られたのはバンドル解決性でした。invoice も同型です。**共有できるのは対策ではなく測り方**という board 行78 の但し書きが、3艦目でも正しかったことになります。

あわせて、**storybook build を「フロントの網羅ゲート」と見なすのは危険**です。vault では main 経路の 91%（71/78）が storybook の外にありました。同じ比率を他艦でも測る価値があると思います（測り方: `main.tsx` と stories 群から独立に import グラフを辿って差集合を取る）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)