### PR TITLE
chore(deps): security lockfile sweep — nanoid + js-yaml (GHSA-2v37-7h3g-55p8, GHSA-5p4m-2wfm-xmqj)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2808,9 +2808,9 @@
       "license": "MIT"
     },
     "node_modules/@redocly/openapi-core": {
-      "version": "1.34.17",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.17.tgz",
-      "integrity": "sha512-wsV2keCt6B806XpSdezbWZ9aFJYf14YVh+XQf0ESt7M90yqVuxH9//PxvtC70sgj9OCkRM3nRaLfu4MsGQZRig==",
+      "version": "1.34.19",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.19.tgz",
+      "integrity": "sha512-o/0VgsBXgwcY1lyeqcVtSGdTQAPnVggo0fbFVPlxl5XVDKUcVH0OLRqt3CbkwByT5FU305E0iE0O7MzThjDblw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2819,7 +2819,7 @@
         "colorette": "1.4.0",
         "https-proxy-agent": "7.0.6",
         "js-levenshtein": "1.1.6",
-        "js-yaml": "4.2.0",
+        "js-yaml": "4.3.1",
         "minimatch": "5.1.9",
         "pluralize": "8.0.0",
         "yaml-ast-parser": "0.0.43"
@@ -8626,9 +8626,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9505,9 +9505,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary
- nanoid <3.3.17 has a HIGH severity infinite-loop vulnerability (GHSA-2v37-7h3g-55p8) when `size=0`.
  - Dependency path is dev-only: `nene2-standards -> postcss -> nanoid`. Not part of the prod bundle.
  - Lockfile-only bump via `npm update nanoid --package-lock-only` in `frontend/`: `3.3.16 -> 3.3.18`. `package.json` is unchanged.
- js-yaml 4.0.0-4.3.0 has a HIGH severity quadratic CPU consumption in `!!omap` resolution (GHSA-5p4m-2wfm-xmqj / CVE-2026-59870, fix not backported).
  - Dependency path is dev-only: `@redocly/openapi-core -> js-yaml` (used by `openapi-typescript`). Not part of the prod bundle.
  - This was the actual advisory keeping the audit gate red on this PR (unrelated to nanoid).
  - Lockfile-only bump via `npm update @redocly/openapi-core js-yaml --package-lock-only` in `frontend/`: `@redocly/openapi-core` `1.34.17 -> 1.34.19` (out of vulnerable range `1.34.8 - 1.34.18`), `js-yaml` `4.3.0 -> 4.3.1`. `package.json` is unchanged (existing `overrides["js-yaml"]: "^4.3.0"` still satisfied).
  - Resolved via lockfile bump, not by adding to `audit-ci.jsonc` allowlist.
- `react-router` GHSA-qwww-vcr4-c8h2 is untouched by this PR — it is already allowlisted in `frontend/audit-ci.jsonc` (expires 2026-08-31, separate lane).

## Test plan
- [x] `git diff --name-only` confirms only `frontend/package-lock.json` changed
- [x] `package.json` has no diff
- [x] nanoid resolved version is now 3.3.18 (>= 3.3.17 patch floor)
- [x] `@redocly/openapi-core` resolved version is now 1.34.19 (out of vulnerable range)
- [x] local `npx audit-ci --config audit-ci.jsonc` passes (only allowlisted GHSA-qwww-vcr4-c8h2 remains)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)