### PR TITLE
ci: add weekly schedule harness to frontend CI (audit-ci)

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -8,6 +8,27 @@ on:
     branches:
       - main
 
+  # 週次 schedule — audit-ci（依存の既知脆弱性）を毎週拾う。
+  # 艦ごとに分をずらしてフリート内同時発火を回避（このリポは 35 分）。
+  # 🔴 制約: public リポの scheduled workflow は 60 日リポジトリ活動が無いと
+  # GitHub 側で自動的に無効化される（公式仕様）。長期休眠すると週次検知も止まる。
+  schedule:
+    - cron: '35 0 * * 1'      # 月曜 00:35 UTC = 09:35 JST
+
+  # 手動トリガー（simulate_failure で失敗通知経路を検証できる）
+  workflow_dispatch:
+    inputs:
+      simulate_failure:
+        description: '意図的に check を失敗させ、失敗通知の経路を検証する'
+        type: boolean
+        default: false
+
+# concurrency: event_name を含めないと schedule/workflow_dispatch の実行が
+# push の実行に cancel される（nene-origin PR #412 で実測）。
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
 jobs:
   frontend-check:
     runs-on: ubuntu-latest
@@ -16,6 +37,10 @@ jobs:
         working-directory: frontend
 
     steps:
+      - name: Simulate failure (validation only)
+        if: inputs.simulate_failure
+        run: exit 1
+
       - name: Checkout
         uses: actions/checkout@v5
 
@@ -49,3 +74,28 @@ jobs:
       # allowlist に無い high/critical は fail。config = frontend/audit-ci.jsonc
       - name: Audit (fail on high/critical)
         run: npm run audit
+
+  notify-failure:
+    name: Open an issue when the scheduled run fails
+    if: failure() && (github.event_name == 'schedule' || inputs.simulate_failure)
+    needs: [frontend-check]
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    env:
+      ISSUE_TITLE: '🔴 nene-vault: 週次 CI（schedule）が失敗しています'
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      - name: Create or update the failure issue
+        run: |
+          set -euo pipefail
+          existing="$(gh issue list --state open --limit 100 --json number,title \
+            | jq -r --arg t "$ISSUE_TITLE" 'map(select(.title == $t)) | .[0].number // empty')"
+          body="週次の schedule 実行が失敗しました。 実行: ${RUN_URL}"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "$ISSUE_TITLE" --body "$body"
+          fi


### PR DESCRIPTION
## Summary

Fleet-wide weekly CI harness rollout (1st wave), applied to nene-vault.
Canonical spec: `_work/handoff-nene2-python-2026-08-12-schedule-rollout-note.md` (hub).

- **Target workflow**: `frontend-ci.yml` (job `frontend-check`) — this is the
  workflow that carries the dependency audit (`npm run audit` → `audit-ci`,
  config `frontend/audit-ci.jsonc`). `backend-ci.yml` (`composer check`) has
  no audit step, so it is left untouched — only one workflow gets `schedule`.
- Added the 3-piece set: `schedule`, `workflow_dispatch` (with
  `simulate_failure` input), and `concurrency` with `github.event_name`
  included in the group (prevents schedule/dispatch runs from being
  cancelled by a concurrent push run — reproduced/fixed upstream in
  nene-origin PR #412).
- Added a `Simulate failure (validation only)` step at the top of
  `frontend-check`, gated on `inputs.simulate_failure`, to let this be
  verified on demand instead of waiting for the first Monday firing.
- Added `notify-failure` job (schedule-only), `needs: [frontend-check]`,
  opens/updates a single GitHub Issue on failure. `GH_REPO` is set
  explicitly (job has no checkout, so `gh` can't infer the repo otherwise).

**Assigned cron slot**: `35 0 * * 1` (Mon 00:35 UTC = 09:35 JST) — offset
from sibling ships in the fleet rollout to avoid simultaneous firing
(00=origin/fleet-tooling, 05=clear, 10=deal, 15=field, 20=payout,
25=records, 30=nene2-python, 40=records-commercial).

**Known limitation (documented in-file)**: GitHub auto-disables scheduled
workflows on public repos after 60 days with no repository activity. A
long-dormant period would silently stop the weekly check; this repo-local
harness can't detect that from the inside (needs an external cross-repo
poller, tracked at the hub level).

## Test plan

- [ ] `gh pr checks --watch` all green
- [ ] Post-merge: `workflow_dispatch` on main (no simulate_failure) → green
- [ ] Post-merge: `workflow_dispatch -f simulate_failure=true` on main →
      fails, opens a new Issue
- [ ] Close the verification Issue with a note that it was intentional

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>