### PR TITLE
ci: backend CI に composer audit を追加（追加前 0件を実測） (#363)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -37,6 +37,13 @@ jobs:
       - name: Install dependencies
         run: composer install --no-interaction --prefer-dist --optimize-autoloader
 
+      # Dependency-vulnerability gate. Kept as its own step rather than folded into
+      # `composer check`, so the job log (and any cross-repo tooling that reads it)
+      # can tell whether the audit ran at all. A check that leaves no trace cannot be
+      # distinguished from a check that is missing.
+      - name: composer audit
+        run: composer audit --no-interaction
+
       - name: Prepare environment
         run: cp .env.example .env
 


### PR DESCRIPTION
## 目的

backend の依存に対する脆弱性ゲートを CI に置く。追加前に検出ゼロであることを実測してから配線している。

Closes #363

## 変更点

- `.github/workflows/backend-ci.yml`: `composer install` の直後に `composer audit --no-interaction` を**独立ステップ**で追加。
- 既存ステップの順序・内容は変更なし。

## 検証結果（実測）

| 項目 | 結果 |
|---|---|
| `composer audit --locked`（追加前・`origin/main` の lock） | **No security vulnerability advisories found.** |
| 変更後 YAML のパース | ✅ 成功（job 構造の破壊なし・`composer audit` ステップは 1 つ） |

## 設計上の判断

`composer check` の中に入れず独立ステップにしてある。埋めてしまうと、ログの上で
**「監査が無い」と「監査したが何も出なかった」が区別できなくなる**ため。

## 残リスク

- 今後 advisory が公開された時点でこのジョブが赤くなる。それがこのゲートの目的だが、
  例外が必要な場合は理由・期限・解除条件を添える運用が要る（フロント側の監査設定と同じ作法）。
