### PR TITLE
chore(css): C5 W3 波(a) 型見本 — .diff-arrow を express-first で utility 化（53→52・#371）

### DIFF
--- a/frontend/registries.jsonc
+++ b/frontend/registries.jsonc
@@ -24,7 +24,6 @@
         ".col2",
         ".content",
         ".crumbs",
-        ".diff-arrow",
         ".diff-field",
         ".diff-pair",
         ".diff-single",

--- a/frontend/src/pages/AuditPage.test.tsx
+++ b/frontend/src/pages/AuditPage.test.tsx
@@ -63,6 +63,55 @@ describe('AuditPage', () => {
     expect(within(dialog).getByText(/Sample Inc\./)).toBeInTheDocument();
   });
 
+  // Regression guard for the `.diff-arrow` drain (#371) — asserts the
+  // replacement utilities rather than the retired class name (判例#34). The
+  // seeded fixture is a creation event, so the arrow never rendered in any test
+  // before this one: deleting its CSS would have gone unnoticed.
+  it('carries the regenerated diff-arrow utilities on a change event', async () => {
+    server.use(
+      http.get('/admin/audit-events', () =>
+        HttpResponse.json({
+          ...mockAuditEventList,
+          items: [
+            {
+              ...mockAuditEventList.items[0],
+              action: 'document.metadata_updated',
+              before_json: { counterparty_name: 'Old Inc.' },
+              after_json: { counterparty_name: 'New Inc.' },
+            },
+          ],
+        }),
+      ),
+    );
+    renderPage();
+
+    const row = await screen.findByRole('button', {
+      name: (name) => name.replace(/\s/g, '').includes(ENTITY_TEXT),
+    });
+    await userEvent.click(row);
+    const dialog = await screen.findByRole('dialog');
+    // `formatAuditValue` quotes strings, so the before box reads `"Old Inc."`.
+    expect(within(dialog).getByText('"Old Inc."')).toBeInTheDocument();
+
+    // A function matcher reaches the arrow the same way the entity cell above is
+    // matched: on structure, not on the classes under test (which would make the
+    // assertion circular). It also keeps this inside
+    // testing-library/no-node-access rather than buying a lint override.
+    const arrow = within(dialog).getByText(
+      (_content, el) =>
+        el?.tagName === 'DIV' && el.children.length === 1 && el.children[0]?.tagName === 'svg',
+    );
+    expect(arrow).toHaveClass('flex', 'items-center', 'justify-center', 'text-text-faint');
+    // The old `@media (max-width: 767px)` half of the rule.
+    expect(arrow).toHaveClass('max-md:justify-start', 'max-md:py-px', 'max-md:pl-0.75');
+    expect(arrow).not.toHaveClass('diff-arrow');
+
+    // Scoped with `within(arrow)` rather than walking to `parentElement`, which
+    // testing-library/no-node-access forbids.
+    const icon = within(arrow).getByText((_content, el) => el?.tagName === 'svg');
+    expect(icon).toHaveClass('w-3.75', 'h-3.75', 'stroke-current', 'max-md:rotate-90');
+  });
+
   it('shows the empty state and no table when there are no events', async () => {
     server.use(
       http.get('/admin/audit-events', () =>

--- a/frontend/src/pages/AuditPage.tsx
+++ b/frontend/src/pages/AuditPage.tsx
@@ -21,8 +21,18 @@ const ChevronIcon = (
     <path d="m9 6 6 6-6 6" />
   </svg>
 );
+// `w-3.75 h-3.75 stroke-current` is the old `.diff-arrow svg` rule, and
+// `max-md:rotate-90` its `@media (max-width: 767px)` half — expressed on the
+// element because this icon has exactly one call site (#371).
 const ArrowIcon = (
-  <svg viewBox="0 0 24 24" fill="none" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className="w-3.75 h-3.75 stroke-current max-md:rotate-90"
+  >
     <path d="M5 12h14M13 6l6 6-6 6" />
   </svg>
 );
@@ -105,7 +115,11 @@ function DiffView({ fields, isCreate }: { fields: AuditDiffField[]; isCreate: bo
                   {formatAuditValue(f.before)}
                 </div>
               )}
-              {!isCreate && <div className="diff-arrow">{ArrowIcon}</div>}
+              {!isCreate && (
+                <div className="flex items-center justify-center text-text-faint max-md:justify-start max-md:py-px max-md:pl-0.75">
+                  {ArrowIcon}
+                </div>
+              )}
               <div className="font-mono text-2xs leading-diff rounded-sm py-2 px-2.5 break-all whitespace-pre-wrap bg-x-brass-soft border border-x-brass-line text-x-brass-deep">
                 {formatAuditValue(f.after)}
               </div>

--- a/frontend/src/shared/ui/theme/themes/default.components.css
+++ b/frontend/src/shared/ui/theme/themes/default.components.css
@@ -560,17 +560,9 @@
       align-items: stretch;
       gap: 8px;
     }
-    .diff-arrow {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      color: var(--color-text-faint);
-    }
-    .diff-arrow svg {
-      width: 15px;
-      height: 15px;
-      stroke: currentColor;
-    }
+    /* `.diff-arrow` and its `svg` child were regenerated as utilities on the
+       AuditPage markup — the icon is used at that one call site, so the child
+       selector became element utilities (express-first, #371). */
     .diff-single .diff-pair {
       grid-template-columns: 1fr;
     }
@@ -886,13 +878,8 @@
         grid-template-columns: 1fr;
         gap: 6px;
       }
-      .diff-arrow {
-        justify-content: flex-start;
-        padding: 1px 0 1px 3px;
-      }
-      .diff-arrow svg {
-        transform: rotate(90deg);
-      }
+      /* the `.diff-arrow` half of this block moved to `max-md:` utilities at the
+         call site (#371); `.diff-pair` above still carries its own. */
 
       /* audit table reflows into tappable cards */
       .audit-table,


### PR DESCRIPTION
Refs #371 / #333 — `.diff-*` family（4件）の**型見本**。残り3件（`.diff-pair` / `.diff-field` / `.diff-single`）は後続 PR で束ねる（判例24①「着手済み family は 0 まで drain」の対象なので同一作業デー内に 0 まで落とす）。

## 判例44① 全数表

| クラス | before | after | 根拠 |
|---|---|---|---|
| `.diff-arrow` | 射程31 | **drain 済み（allowlist から除去）** | express-first で call site の utility へ |

**検算**: allowlist 53 → **52**（射程 31 → 30 ／ W4本体6 ／ W4子10 ／ 温存確定6 ＝ 52）。

## EXACT 実測 — built CSS の全ルール集合の差分

```
削除 4: .diff-arrow ×2（base / mobile）・.diff-arrow svg ×2（base / mobile）
追加 6: .max-md:justify-start / .max-md:py-px / .max-md:pl-0.75 / .max-md:rotate-90 /
        .stroke-current / .w-3.75
:root トークン块は無変更（新トークン不要）
他は完全一致
```

`h-3.75` / `flex` / `items-center` / `justify-center` / `text-text-faint` は**既に出力されていたので追加すら発生していない**。

### 宣言ごとの等価（`--spacing: .25rem` 実測）

| 旧宣言 | 置換先 | 等価の根拠 |
|---|---|---|
| `display:flex` / `align-items:center` / `justify-content:center` | `flex items-center justify-center` | 同一宣言 |
| `color:var(--color-text-faint)` | `text-text-faint` | 同一宣言 |
| `svg { width/height: 15px }` | `w-3.75 h-3.75`（svg 要素へ） | `calc(.25rem * 3.75)` = 15px |
| `svg { stroke: currentColor }` | `stroke-current` | `.stroke-current{stroke:currentColor}` ＝ **EXACT** |
| mobile `justify-content:flex-start` | `max-md:justify-start` | 同一宣言 |
| mobile `padding: 1px 0 1px 3px` | `max-md:py-px` `max-md:pl-0.75` | 1px / 3px。**右は基底で未設定＝0 のまま**なので shorthand の `0` は再現不要 |

### 🔴 1点だけ機構が変わる — `transform` → `rotate` プロパティ

`transform: rotate(90deg)` に対し、TW4 の `rotate-90` は **`rotate: 90deg`（独立変形プロパティ）** を出力する。

- この svg には**他の transform / rotate 宣言が無い**ので、合成行列は `transform: rotate(90deg)` と一致する
- `transform-box` / `transform-origin` の解決は両者で共通（プロパティが違うだけで参照ボックスは同じ）
- サポート下限も上がらない: `rotate` プロパティは Chrome 104、このテーマが**既に使っている** `oklch()` / `:has()` / `@property` は Chrome 111 相当

### カスケード順も実測（「はず」で通していない）

`max-md:` 群は `@media not all and (width>=48rem)` 内に、base utility より**後方**へ出力される（pos 40346+ vs 24675）＝上書きが効く。
なお `max-md:` ≡ 旧 `@media (max-width: 767px)` は **#362 で確立した先例**（`fieldBase.ts` に明記）。境界は 767px と 768px 未満で厳密には別だが、その差は端数幅のみで、family の先例に合わせている。

## 🔴 回帰ガード（判例#34）— ここが今回いちばん重要

**既存 fixture は creation event（`before_json: null`）なので、矢印はどのテストでも描画されていませんでした。** つまり CSS を消しても**誰も気づかない**状態でした。

- msw で change event を差し込むテストを追加し、置換先 utility を**全数**アサート
- 要素の掴み方は既存の entity cell と同じ **function matcher（構造で掴む）**。**アサート対象のクラスでは掴まない**＝循環回避
- svg は `within(arrow)` でスコープし `parentElement` を避けた（`testing-library/no-node-access` の override を買わない）
- 副産物として、**`!isCreate` 分岐（before/after 2カラム表示）が初めてテストで通る**ようになった

4形態 sweep（literal / object-map / 三項 / template-literal）実施済み — `.diff-arrow` の className 実参照 **0**。

## 検証

`npm run check` **全 gate green**: type-check / lint / format / **274 tests・46 files** / coverage-ratchet OK / knip / stylelint / `init --check` 未分類0・回帰0 / build / build-storybook