### PR TITLE
docs: `*_cents` の単位定義を development 配下の規約文へ明記する (#374)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,10 +2,21 @@
   "mcpServers": {
     "nene-vault": {
       "command": "php",
-      "args": ["tools/local-mcp-server.php"],
+      "args": [
+        "tools/local-mcp-server.php"
+      ],
       "env": {
         "NENE2_LOCAL_API_BASE_URL": "http://localhost:8600",
         "NENE2_LOCAL_JWT_SECRET": "${NENE2_LOCAL_JWT_SECRET}"
+      }
+    },
+    "cc-vault": {
+      "command": "node",
+      "args": [
+        "/home/xi/docker/_work/tools/chat-relay/ccbridge.mjs"
+      ],
+      "env": {
+        "CC_CHANNEL_PORT": "8814"
       }
     }
   }

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,21 +2,10 @@
   "mcpServers": {
     "nene-vault": {
       "command": "php",
-      "args": [
-        "tools/local-mcp-server.php"
-      ],
+      "args": ["tools/local-mcp-server.php"],
       "env": {
         "NENE2_LOCAL_API_BASE_URL": "http://localhost:8600",
         "NENE2_LOCAL_JWT_SECRET": "${NENE2_LOCAL_JWT_SECRET}"
-      }
-    },
-    "cc-vault": {
-      "command": "node",
-      "args": [
-        "/home/xi/docker/_work/tools/chat-relay/ccbridge.mjs"
-      ],
-      "env": {
-        "CC_CHANNEL_PORT": "8814"
       }
     }
   }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,10 @@ See [ADR 0009](docs/adr/0009-separate-from-billing-and-reconciliation.md).
 - Do **not** add expense approval workflows or journal entries
 - **Follow NENE2 conventions** — `docs/development/nene2-compliance.md`
 - Namespace: `NeneVault\`; money: integer cents; document metadata only
+
+> `cents` = the currency's **minor unit**, not 1/100 of the display amount.
+> **JPY has zero decimal places (ISO 4217), so `*_cents` stores whole yen — never multiply by 100.**
+> Example: ¥1,500 is stored as `1500`. A value like `116480` means ¥116,480, not ¥1,164.80.
 - **Repository docs: English only** (ADR 0008)
 
 ## Framework

--- a/docs/development/backend-standards.md
+++ b/docs/development/backend-standards.md
@@ -105,6 +105,10 @@ Use `final readonly` classes and `declare(strict_types=1);` in every PHP file.
 - `retention_expires_at` = `transaction_date + retention_years` (computed at upload; see ADR 0004).
 - Default `retention_years = 10` (not 7 — see ADR 0004).
 
+> `cents` = the currency's **minor unit**, not 1/100 of the display amount.
+> **JPY has zero decimal places (ISO 4217), so `*_cents` stores whole yen — never multiply by 100.**
+> Example: ¥1,500 is stored as `1500`. A value like `116480` means ¥116,480, not ¥1,164.80.
+
 ---
 
 ## 7. Audit trail

--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -69,6 +69,10 @@ Any change that touches **document storage, file serving, search, metadata editi
 - **Float and DECIMAL for money are prohibited** in DB, API JSON, and tests.
 - Do not require `amount_cents` for document creation.
 
+> `cents` = the currency's **minor unit**, not 1/100 of the display amount.
+> **JPY has zero decimal places (ISO 4217), so `*_cents` stores whole yen — never multiply by 100.**
+> Example: ¥1,500 is stored as `1500`. A value like `116480` means ¥116,480, not ¥1,164.80.
+
 ### Audit trail
 
 - Every mutating use case **MUST** call `AuditRecorder` in the **same DB transaction** as the mutation.

--- a/docs/development/naming-conventions.md
+++ b/docs/development/naming-conventions.md
@@ -120,6 +120,10 @@ Public OpenAPI summaries, descriptions, and examples: **English only**.
 | Status enum | `status` field | `"active"`, `"voided"` |
 | Source enum | `source` field | `"web_upload"`, `"email_inbound"`, `"api"`, `"scan_upload"` |
 | List envelope | `items`, `limit`, `offset` | Same as NENE2 list pattern |
+
+> `cents` = the currency's **minor unit**, not 1/100 of the display amount.
+> **JPY has zero decimal places (ISO 4217), so `*_cents` stores whole yen — never multiply by 100.**
+> Example: ¥1,500 is stored as `1500`. A value like `116480` means ¥116,480, not ¥1,164.80.
 | File hash | `file_sha256` | 64-char hex string |
 
 Do not mix camelCase in public JSON. Do not use floats for money. Do not expose storage paths.
@@ -152,6 +156,10 @@ Problem Details `title` and `detail`: English.
 | Status column | `status` ENUM | `'active'`, `'voided'` |
 | Soft void | `voided_at`, `voided_by`, `void_reason` | — |
 | Retention | `retention_years INT`, `retention_expires_at DATE` | — |
+
+> `cents` = the currency's **minor unit**, not 1/100 of the display amount.
+> **JPY has zero decimal places (ISO 4217), so `*_cents` stores whole yen — never multiply by 100.**
+> Example: ¥1,500 is stored as `1500`. A value like `116480` means ¥116,480, not ¥1,164.80.
 | Index names | `idx_{table}_{columns}` | `idx_vault_documents_org_date` |
 | Unique constraints | `uniq_{table}_{columns}` | `uniq_document_versions_doc_version` |
 | Audit table | `audit_events` | Append-only; no soft delete column |

--- a/docs/inheritance-from-nene2.md
+++ b/docs/inheritance-from-nene2.md
@@ -60,6 +60,10 @@ Install NENE2 as a Composer dependency and treat `vendor/hideyukimori/nene2/docs
 | File integrity | SHA-256 hash verified on every download; no byte overwrites |
 | Audit trail | UseCase-layer `AuditRecorder` with before/after; same DB transaction as mutation (ADR 0014) |
 | Retention | 10-year default from `transaction_date`; no auto-purge (ADR 0004) |
+
+> `cents` = the currency's **minor unit**, not 1/100 of the display amount.
+> **JPY has zero decimal places (ISO 4217), so `*_cents` stores whole yen — never multiply by 100.**
+> Example: ¥1,500 is stored as `1500`. A value like `116480` means ¥116,480, not ¥1,164.80.
 | Coding standards | `docs/development/coding-standards.md` — NENE2 baseline + vault additions |
 | Backend standards | `docs/development/backend-standards.md` — PHP/API strict policy |
 | Naming conventions | `docs/development/naming-conventions.md` — vault-domain identifiers |


### PR DESCRIPTION
Closes #374

## 何をしたか

正典の定義を **development 配下の規約文 6箇所**へ挿入しました。**ドキュメントのみ・コードは1行も触っていません。**

`naming-conventions.md`（§JSON / §Database）・`backend-standards.md`・`coding-standards.md`・
`inheritance-from-nene2.md`・`AGENTS.md`。

文言は正本 `_work/reports/2026-08-20-money-unit-archaeology.md` §9-1 からの**逐語コピー**で、
**一字一句一致を機械照合済み**です。**言い換えていません**——今回の事故は「同じ言葉を別の意味に読んだ」ことで
起きたので、**表現の揺れを増やさない**のが肝だからです。

## 🟢 本リポは艦隊で最も明示的に正しい記述を持っています

| | 状態 |
|---|---|
| コード | 🟢 **1:1（正しい）** |
| `explanation/glossary.md:25` | 🟢 「1 cent = ¥1」＋ 誤用に「**reading `_cents` as 1/100 yen**」を名指し |
| `operator/search.md:61-63` | 🟢 「**integer yen × 100 is NOT used**」「¥110,000 → `amount_cents = 110000`」 |

**「× 100 は使わない」と否定形で書いてある艦は本リポだけ**です。**この2箇所は既に正しいので触っていません。**

## それでも入れる理由

**`development/` 配下の規約文には定義がありませんでした**（`nullable integer in JPY` という**単位の名前**だけ）。
**実装者が最初に読むのはそちら**です。

🔑 本件の艦隊横断調査で分かったのは、**「定義が無かったから間違えた」艦は実質ゼロ**だということです——
`clear` は glossary が「1/100円として読むのは誤用」と**名指ししているのにコードがその誤用をしており**、
`serve` も `billing-and-accounting-compliance.md:151` に「for JPY, ¥1 = 1 unit」と**正しく書いたうえで実装が ×100** でした。
⇒ **決定要因は「実装者が定義を読んだか、コードをコピーしたか」。**

## 射程外

- **本リポは是正対象ではありません**（コードが正しいため）
- `docs/review/*.md` — 「integer であること」の確認であって単位定義ではない
- `docs/openapi/` — 是正波の射程
- **`format-money.ts` 相当は本リポに存在しない**ので、⑤（「コピーするな」の印）は非該当です

🤖 Generated with [Claude Code](https://claude.com/claude-code)