### PR TITLE
docs(operator): backup 手順に検証4点セット②③を適用する (#376)

### DIFF
--- a/docs/operator/backup.md
+++ b/docs/operator/backup.md
@@ -60,25 +60,118 @@ rsync -av --progress \
 
 ## MySQL
 
-Use `mysqldump` or `mysqlpump`:
+Dump to a **temporary file, verify it, and only then promote it** to its final
+name. Writing straight to the final name lets a dump that died halfway take the
+place of "the latest backup" — and nothing downstream would notice.
 
 ```sh
+set -euo pipefail
+
+out="/backups/nene_vault_$(date +%Y%m%d).sql"
+tmp="$out.part"
+
 mysqldump \
   --single-transaction \
   --routines \
   --triggers \
+  --no-tablespaces \
   -h "$DB_HOST" -u "$DB_USER" -p"$DB_PASSWORD" \
   "$DB_NAME" \
-  > /backups/nene_vault_$(date +%Y%m%d).sql
+  > "$tmp"
+
+[ -s "$tmp" ] || { echo "backup FAILED: $tmp is empty" >&2; rm -f "$tmp"; exit 1; }
+case "$(tail -1 "$tmp")" in
+  '-- Dump completed'*) : ;;
+  *) echo "backup FAILED: no completion marker in $tmp (truncated dump)" >&2
+     rm -f "$tmp"; exit 1 ;;
+esac
+
+mv "$tmp" "$out"
+echo "backup OK: $out ($(du -h "$out" | cut -f1))"
 ```
 
 For Docker Compose:
 
 ```sh
-docker compose exec mysql \
-  mysqldump --single-transaction -u nene_vault -pnene_vault nene_vault \
-  > /backups/nene_vault_$(date +%Y%m%d).sql
+set -euo pipefail
+
+out="/backups/nene_vault_$(date +%Y%m%d).sql"
+tmp="$out.part"
+
+docker compose exec -T mysql \
+  mysqldump --single-transaction --routines --triggers --no-tablespaces \
+  -u nene_vault -pnene_vault nene_vault \
+  > "$tmp"
+
+[ -s "$tmp" ] || { echo "backup FAILED: $tmp is empty" >&2; rm -f "$tmp"; exit 1; }
+case "$(tail -1 "$tmp")" in
+  '-- Dump completed'*) : ;;
+  *) echo "backup FAILED: no completion marker in $tmp (truncated dump)" >&2
+     rm -f "$tmp"; exit 1 ;;
+esac
+
+mv "$tmp" "$out"
+echo "backup OK: $out ($(du -h "$out" | cut -f1))"
 ```
+
+`-T` is required: without it `docker compose exec` allocates a TTY and mangles
+the dump on its way to the redirect.
+
+### Verifying a dump
+
+`mysqldump` writes `-- Dump completed on <timestamp>` as the last line when — and
+only when — it finished. That single line is what makes a dump verifiable, at two
+different moments.
+
+**1. Immediately after taking it.** Shown in both commands above: the dump lands
+on `$tmp`, the marker is asserted, and only a dump that passes gets `mv`'d into
+place. A failure leaves the previous backup untouched and removes the partial
+file.
+
+**2. After the fact, across dumps you already hold.** This is the marker's real
+value — it lets you audit backups taken before anyone thought to check them:
+
+```sh
+set -euo pipefail
+
+for f in /backups/nene_vault_*.sql; do
+  case "$(tail -1 "$f")" in
+    '-- Dump completed'*) echo "OK        $f" ;;
+    *)                    echo "TRUNCATED $f" >&2 ;;
+  esac
+done
+```
+
+For gzipped dumps, read the last line through `gunzip` instead:
+
+```sh
+case "$(gunzip -c "$f" | tail -1)" in
+```
+
+### Why these three things
+
+**`--no-tablespaces`** — MySQL 8's `mysqldump` issues `SHOW CREATE TABLESPACE`,
+which requires the `PROCESS` privilege. On shared hosting, or with a
+deliberately scoped application user, the dump fails outright with
+`Access denied ... PROCESS privilege ... tablespaces`. Vault needs no tablespace
+DDL in its dumps, so the flag costs nothing and removes the failure mode.
+
+**The completion marker, not a size check** — 🔑 **a truncated dump is not an
+empty file.** `[ -s "$file" ]` passes happily on a dump that died at 40 %, so
+size alone will hand you a backup that only fails when you try to restore it.
+The `-s` test above is kept as a cheap first gate, but the marker is what decides.
+
+**`set -euo pipefail`** — the commands above redirect with `>` rather than piping,
+so nothing is currently hidden by a pipe. The moment you add one — compressing
+with `mysqldump ... | gzip > "$tmp"` is the obvious next step — the exit status
+becomes **gzip's**, and a failed `mysqldump` disappears into a successful-looking
+pipeline. `pipefail` is what keeps that failure visible.
+
+> ⚠️ **Never write `... || true` in a backup script.** It converts "the command
+> was not found" and "the container is not running" into exit 0, so cron reports
+> success every night while producing nothing at all. A backup that fails loudly
+> is recoverable; a backup that does nothing and calls it success is not
+> discovered until a restore. Assert on the **artifact**, not on the exit status.
 
 ---
 


### PR DESCRIPTION
Closes #376

`docs/operator/backup.md` の MySQL 手順に、フリート標準の「backup 検証4点セット」のうち
**②`--no-tablespaces`** と **③`-- Dump completed` マーカーの assert** を適用する。
**ドキュメントのみの変更**（スクリプト・CI は触っていない）。

## 着手前の現物確認

指示書の射程判定（②③のみ）を自艦で測り直し、**一致を確認**した。差し戻しは無い。

| # | 項目 | 実測 | 要否 |
|---|---|---|---|
| ① | `set -euo pipefail` | mysqldump 2例とも**パイプ無し・`>` リダイレクトのみ** | 🟢 非該当 |
| ② | `--no-tablespaces` | **両例とも無し** | 🔴 要対応 |
| ③ | 完了マーカーの assert | **検証手順が存在しない** | 🔴 要対応 |
| ④ | 定期実行と保持世代 | `### Recommended schedule` に表あり | 🟢 充足済み・**未変更** |

`|| true` の点検も指示どおり実施: `docs/operator/backup.md` には**該当なし**。
`tools/build-release.sh:94` に1件あるが phpstan 設定のコピーで backup 射程外。
ただし「**生成物の存在を確かめていない**」は該当し、それが③そのものなので本 PR で塞がる。

## 変更点

- mysqldump 2例に `--no-tablespaces`
- **一時ファイルへ dump →検証→昇格**の形に変更。本番ファイルへ直書きすると、
  途中で切れたゴミが「最新のバックアップ」に化ける
- `### Verifying a dump` を新設し、**「取った直後」と「既存ファイルの事後検証」の両方**を記載
  （マーカーの本当の価値は、**後から既存ファイルを検証できる**こと）
- `docker compose exec` に **`-T`** を追加（TTY 割り当てでダンプが壊れる）。
  合わせて compose 版にも `--routines --triggers` を揃えた ⚠️**射程を少し出ている**ので、
  不要なら落とします
- `### Why these three things` に理由を記載（なぜ空ファイル検査では駄目か、まで）
- `|| true` を書くなという警告

## 🔴 陽性・陰性の両対照で検証済み

**本文のコードブロックを逐語で抽出して実行**した（貼り直しではない）。docker が
起動していなかったため `mysqldump` / `docker` はスタブ化し、`/backups` のみ一時ディレクトリへ置換。

```
── plain mysqldump / MODE=ok            exit 0 ・昇格 ・マーカーが最終行 ・.part 無し ・backup OK
── plain mysqldump / MODE=truncated     exit 1 ・前回のバックアップ不変 ・.part 掃除 ・backup OK 出ず
── plain mysqldump / MODE=empty         exit 1 ・前回のバックアップ不変 ・.part 掃除 ・backup OK 出ず
── docker compose exec / ok|truncated|empty   同上
── 事後スイープ  good→OK ・truncated→TRUNCATED ・empty→TRUNCATED
════ pass=33 fail=0 ════
```

**さらに変異テストで assert に歯があることを確認した。** マーカー assert を外して
`[ -s ]` だけにすると、**切り詰めダンプが昇格して `backup OK` を出す**:

```
── plain mysqldump / MODE=truncated
  ❌ exit code — expected [1] got [0]
  ❌ previous backup INTACT — expected [same] got [changed]
  ❌ no false 'backup OK' — expected [yes] got [no]
```

⇒ 落ちない assert ではないことを、**落ちるはずの場面で実際に落として**確かめた。

マーカー文字列そのものも実バイナリで確認:
`strings /usr/bin/mysqldump | grep 'Dump completed'` → `-- Dump completed on %s`（Ver 8.0.46）。

⚠️ **未検証**: 実 MySQL サーバへの end-to-end ダンプは、docker が起動していなかったため
**行っていない**（スタブ検証まで）。

## 射程外として分離

- **#377** — SQLite／ファイル本体側にも同種の検証が無い。SQLite は**既定ストア**なので、
  MySQL だけ直すと既定構成が未検証で残る。

## 併せて（本 PR 外）

- **#333** に実測コメント: `.is-open` が **dead allowlist entry**（CSS/TSX いずれにも不在）＝
  無改修で 49→48 にできる枠。射程は中央レジストリ側。
