### PR TITLE
ci: backend-ci に失敗通知を新設し dedup の --limit を 1000 へ (#381)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -8,11 +8,37 @@ on:
     branches:
       - main
 
+  # 手動トリガー（simulate_failure で失敗通知経路を検証できる）。
+  # notify-failure を足すなら、これは必須。通知装置は「壊して赤にできること」まで
+  # 確かめて初めて完成で、それを確かめる手段が dispatch だけだから（#381・#379）。
+  workflow_dispatch:
+    inputs:
+      simulate_failure:
+        description: '意図的に check を失敗させ、失敗通知の経路を検証する'
+        type: boolean
+        default: false
+
+  # 🔴 schedule は **意図的に置いていない**（#381 の射程外）。
+  # PHP 監査を週次で再走させる方式は施主判断待ちで、選択肢は
+  # (a) ここに schedule を足す / (b) audit を frontend へ寄せる /
+  # (c) 週次専用 weekly-audit.yml を新設。ここに足すと (a) で確定してしまう。
+
+# concurrency: event_name を含めないと workflow_dispatch の実行が push の実行に
+# cancel される（nene-origin PR #412 で実測・frontend-ci.yml と同じ理由）。
+# dispatch が黙って消えると、上の simulate_failure による検証自体が成立しない。
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Simulate failure (validation only)
+        if: inputs.simulate_failure
+        run: exit 1
+
       - name: Checkout
         uses: actions/checkout@v5
 
@@ -56,3 +82,44 @@ jobs:
       # (force="true", #18) — so runner-level env pollution cannot break it.
       - name: Run checks
         run: composer check
+
+  notify-failure:
+    name: Open an issue when an unattended run fails
+    # 🔴 発火条件は frontend-ci.yml と **意図的に違う**（#381）。
+    #
+    # frontend は `schedule || simulate_failure`。それをそのまま写すと、backend には
+    # schedule が無いので **この job は simulate_failure 以外では永久に発火しない** ——
+    # 「装置はあるが原理的に赤にならない」ものが1つ増えるだけになる（#379 で問題にした形）。
+    #
+    # そこで backend は push（= main への merge 後の実行）を含める。main が赤い状態は、
+    # マージした人が立ち去れば誰も見ていない＝まさに通知が要る「無人の実行」。
+    # pull_request は含めない — PR の赤は作者が見ているので issue にする価値がなく、ノイズになる。
+    # schedule 節は先に書いておく: (a) に決まればそのまま効き、(c) になっても無害に残るだけ。
+    if: >-
+      failure() && (
+        github.event_name == 'schedule' ||
+        github.event_name == 'push' ||
+        inputs.simulate_failure
+      )
+    needs: [check]
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    env:
+      ISSUE_TITLE: '🔴 nene-vault: Backend CI（無人実行）が失敗しています'
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      - name: Create or update the failure issue
+        run: |
+          set -euo pipefail
+          # --limit は open issue の総数より大きく取る（frontend-ci.yml と同じ理由・#381）。
+          existing="$(gh issue list --state open --limit 1000 --json number,title \
+            | jq -r --arg t "$ISSUE_TITLE" 'map(select(.title == $t)) | .[0].number // empty')"
+          body="Backend CI の無人実行（${{ github.event_name }}）が失敗しました。 実行: ${RUN_URL}"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "$ISSUE_TITLE" --body "$body"
+          fi

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -91,7 +91,11 @@ jobs:
       - name: Create or update the failure issue
         run: |
           set -euo pipefail
-          existing="$(gh issue list --state open --limit 100 --json number,title \
+          # --limit は open issue の総数より大きく取る。既定(30)や 100 のままだと
+          # open が上限を超えた瞬間に同名 issue を取りこぼし、dedup が黙って
+          # 重複起票へフォールバックする（#381）。重複こそが「通知が読まれなくなる」
+          # 原因なので、dedup が静かに壊れる形は避ける。参照実装 = nene-serve PR #218。
+          existing="$(gh issue list --state open --limit 1000 --json number,title \
             | jq -r --arg t "$ISSUE_TITLE" 'map(select(.title == $t)) | .[0].number // empty')"
           body="週次の schedule 実行が失敗しました。 実行: ${RUN_URL}"
           if [ -n "$existing" ]; then


### PR DESCRIPTION
Closes #381 / #379 の「併せて検討」分を先行実施。

## 何を直したか

| # | 内容 | ファイル |
|---|---|---|
| ① | dedup 検索の `--limit 100` → `1000` | `frontend-ci.yml:98` |
| ② | `notify-failure` job を新設（dedup 経路つき） | `backend-ci.yml` |
| ②付随 | `workflow_dispatch`（`simulate_failure`）と `concurrency` を追加 | `backend-ci.yml` |

🔴 **`schedule:` は入れていません**（差分で不在を確認できます）。

## なぜ backend の発火条件が frontend と違うのか

ここが本 PR で唯一の設計判断です。

`frontend-ci.yml` は `schedule || simulate_failure`。**これをそのまま写すのは間違い**でした。
backend には `schedule` が無いので、写した job は `simulate_failure` 以外では**永久に発火しません**。
つまり「装置はあるが原理的に赤にならない」ものが1つ増えるだけになる — #379 で問題にしたのと同じ形です。

```yaml
if: >-
  failure() && (
    github.event_name == 'schedule' ||
    github.event_name == 'push' ||
    inputs.simulate_failure
  )
```

- **`push`（`main` への merge 後の実行）を含める** — main が赤い状態は、マージした人が立ち去れば
  誰も見ていない＝まさに通知が要る「無人の実行」。**今日から実際に発火する条件がある。**
- **`pull_request` は含めない** — PR の赤は作者が見ているので issue にする価値がなく、ノイズになる。
- **`schedule` 節は先に書いておく** — 週次方式が (a) に決まればそのまま効き、(c) になっても無害に残るだけ。

## なぜ `schedule` を入れないのか

PHP 監査を週次で再走させる方式は**施主判断待ち**です。選択肢は
(a) `backend-ci` に schedule を足す / (b) audit を frontend へ寄せる / (c) 週次専用 `weekly-audit.yml` を新設（hub 推し）。

🔴 **良かれと思ってここに schedule を入れると、施主が選ぶ前に (a) で確定してしまいます。**
①② は方式と独立なので先行できる、という hub 裁定（2026-08-22）に従っています。

## 背景 — 艦単位で数えると穴が平均に埋もれる

repo-status で vault の片肺（frontend だけ通知あり）を実測 → hub がフリート27艦を
**workflow 単位**で測り直した結果:

- 1本でも notify を持つ 16艦のうち **13艦が片肺**
- 全 workflow に通知があるのは payout / records-commercial / serve の**3艦だけ**（いずれも workflow 1本）
- 🔴 **`backend-ci.yml` を持つ10艦は、10艦とも無通知**（clear / concierge / contact / corpus / deal / field / invoice / profile / records / **vault**）＝ **100%**

🔑 **保有を艦単位で数えると、その艦の中で最も守られていない面が平均に埋もれる。**

## 検証

ローカル実測（2026-08-22 22:1x）:

```
YAML parse            backend OK / frontend OK
backend triggers      pull_request, push, workflow_dispatch   ← schedule 不在 ✅
backend jobs          check, notify-failure
backend notify if     failure() && ( schedule || push || simulate_failure )
--limit 100  完全一致  backend 0 / frontend 0
--limit 1000 完全一致  backend 1 / frontend 1
```

⚠️ 測り方の注意を1つ記録します。`grep -c -- '--limit 100'` は **`--limit 1000` に部分一致**して
「まだ 100 が残っている」と読める出力を返しました。境界つき（`--limit 100([^0-9]|$)`）で測り直して 0 を確認しています。
**部分文字列一致は「直っていないように見える」方向にも「直ったように見える」方向にも転ぶ**ので、
数字を含む文字列の grep には境界を付けます。

## 🔴 マージ後に必要な検収（#381 / #379 の受入条件）

`workflow_dispatch` は**既定ブランチに載って初めて dispatch できる**ため、以下はマージ後になります。

- [ ] `simulate_failure=true` を **2回連続 dispatch**
- [ ] **1回目の issue を open のまま** 2回目を回す
      （closed だと `--state open` に掛からず新規起票が正しい挙動になり、dedup を検証したことにならない）
- [ ] 2回目が**新規起票せず同一 issue へコメント**することを実測する
- [ ] リハーサルで起票された issue は、クローズ前に「何のための赤か」を書く（#359 の先例を踏襲）

これを通して初めて **#379（dedup 分岐が一度も実行されていない）** が閉じられます。
今日 backup assert で確かめたのと同じ理屈で、**通ることは証拠にならず、赤にできることが証拠**です。

## 射程外

- 週次 schedule の方式（(a)/(b)/(c)）— 施主判断待ち
- `timeout-minutes`（board 行111・両 workflow とも 0 件）— フリート横断の別波
