### PR TITLE
docs(operator): 既定ストア（SQLite ＋ ファイル本体）のバックアップに検証を入れる（#377）

### DIFF
--- a/docs/operator/backup.md
+++ b/docs/operator/backup.md
@@ -24,19 +24,110 @@ The SQLite database is a single file at `DB_NAME` (default `var/nene_vault.sqlit
 
 ### Online backup (no downtime)
 
-```sh
-# Atomic copy via SQLite backup API
-sqlite3 var/nene_vault.sqlite ".backup /backups/nene_vault_$(date +%Y%m%d).sqlite"
-```
-
-Or using PHP:
+Take the copy, verify it, and only then move it into place. A backup that is not
+asserted on is not a backup — it is a file that will be found wanting during a
+restore, which is the one moment you cannot afford to find out.
 
 ```sh
-php -r "
-\$src = new PDO('sqlite:var/nene_vault.sqlite');
-\$src->exec(\"VACUUM INTO '/backups/nene_vault_\$(date +%Y%m%d).sqlite'\");
-"
+#!/bin/sh
+set -eu
+
+src=var/nene_vault.sqlite
+out=/backups/nene_vault_$(date +%Y%m%d).sqlite
+tmp=$out.part
+
+rm -f "$tmp"
+
+php -r '
+  $src = $argv[1];
+  $tmp = $argv[2];
+  (new PDO("sqlite:$src"))->exec(sprintf("VACUUM INTO %s", (new PDO("sqlite::memory:"))->quote($tmp)));
+
+  $check = (new PDO("sqlite:$tmp"))->query("PRAGMA integrity_check")->fetchColumn();
+  if ($check !== "ok") {
+      fwrite(STDERR, "integrity_check: $check\n");
+      exit(1);
+  }
+' "$src" "$tmp"
+
+mv "$tmp" "$out"
 ```
+
+The `rm -f` is not tidiness. `VACUUM INTO` refuses a target that already holds
+data — `file is not a database` — so a partial file left by a failed run would
+block every subsequent backup until someone cleared it by hand. Removing it up
+front makes the script re-runnable.
+
+A run that fails the check exits non-zero, leaves the `.part` file behind for
+inspection, and **does not touch the backup already in place** — the same
+guarantee the MySQL commands give.
+
+If the `sqlite3` CLI is installed, the same shape works with it:
+
+```sh
+sqlite3 "$src" ".backup '$tmp'"
+[ "$(sqlite3 "$tmp" 'PRAGMA integrity_check;')" = ok ] || exit 1
+```
+
+> ⚠️ **Prefer the PHP form.** Any host running Vault has PHP — it is the
+> application runtime. The `sqlite3` CLI is a separate package and is frequently
+> absent, including on hosts where Vault itself runs perfectly well.
+
+### Verifying a SQLite backup
+
+`PRAGMA integrity_check` returns the single string `ok` on a sound database, and
+either a list of problems or an error on a damaged one. Like the MySQL dump
+marker, it is useful at two moments.
+
+**1. Immediately after taking it** — shown above.
+
+**2. After the fact, across backups you already hold:**
+
+```sh
+set -eu
+
+for f in /backups/nene_vault_*.sqlite; do
+  php -r '
+    try {
+      $r = (new PDO("sqlite:" . $argv[1]))->query("PRAGMA integrity_check")->fetchColumn();
+      printf("%-9s %s\n", $r === "ok" ? "OK" : "DAMAGED", $argv[1]);
+      exit($r === "ok" ? 0 : 1);
+    } catch (Throwable $e) {
+      printf("%-9s %s (%s)\n", "UNREADABLE", $argv[1], $e->getMessage());
+      exit(1);
+    }
+  ' "$f" || true   # keep auditing the remaining files
+done
+```
+
+> ⚠️ The `|| true` above is deliberate and is the **only** place this guide
+> permits it: this loop audits a set and must not stop at the first bad file. Never
+> use it in the backup itself — see the warning at the end of the MySQL section.
+
+#### Why `integrity_check` and not a size check
+
+🔑 **A truncated SQLite file is not an empty file.** A copy that died at 40 %
+still opens as far as the filesystem is concerned, and `[ -s "$f" ]` passes on it
+without complaint. `integrity_check` refuses it — SQLite's header records the
+database size in pages, so a short file is detected even when the truncation
+lands exactly on a page boundary.
+
+#### What `integrity_check` cannot tell you
+
+It answers *"is this file a sound database?"*, not *"is this the data you meant to
+back up?"*. A backup that is structurally perfect but taken from the wrong
+generation — or taken while writes were still landing — returns `ok` with rows
+missing.
+
+🔑 **An empty file is a sound database.** A zero-byte `.sqlite` passes
+`integrity_check` with `ok`, because that is exactly what a database with no
+tables looks like on disk. So the check cannot, on its own, distinguish a good
+backup from a step that ran and produced nothing.
+
+Structure and contents are two different questions. The second one is answered in
+the next section, by reconciling the database against the files — which is also
+what catches the empty-backup case, since zero rows cannot account for the files
+on disk.
 
 ### File backup
 
@@ -47,6 +138,96 @@ rsync -av --progress \
   /var/nene-vault/files/ \
   /backups/nene-vault-files-$(date +%Y%m%d)/
 ```
+
+### Verifying a file backup
+
+🔑 **Vault verifies SHA-256 on every download.** Backups of those same files are
+held to the same standard, or the guarantee stops at the edge of the running
+system.
+
+`document_versions` carries `file_path` (relative to `NENE_VAULT_STORAGE_PATH`)
+and `file_sha256` for every stored file. That is enough to reconcile a backup
+against itself, with no access to the live system:
+
+```php
+<?php
+// verify-backup.php <backup.sqlite> <backup files root>
+[$db, $root] = [$argv[1], rtrim($argv[2], '/')];
+
+$pdo = new PDO("sqlite:$db");
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$rows = $pdo->query(
+    'SELECT file_path, file_sha256 FROM document_versions'
+)->fetchAll(PDO::FETCH_ASSOC);
+
+$ok = $missing = $mismatch = 0;
+$seen = [];
+
+foreach ($rows as $r) {
+    $abs = $root . '/' . $r['file_path'];
+    $seen[$r['file_path']] = true;
+
+    if (!is_file($abs)) {
+        fwrite(STDERR, "MISSING   {$r['file_path']}\n");
+        $missing++;
+    } elseif (hash_file('sha256', $abs) !== $r['file_sha256']) {
+        fwrite(STDERR, "MISMATCH  {$r['file_path']}\n");
+        $mismatch++;
+    } else {
+        $ok++;
+    }
+}
+
+$orphan = 0;
+$walk = new RecursiveIteratorIterator(
+    new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS)
+);
+
+foreach ($walk as $f) {
+    if (!$f->isFile()) {
+        continue;
+    }
+    $rel = substr($f->getPathname(), strlen($root) + 1);
+    if (!isset($seen[$rel])) {
+        fwrite(STDERR, "ORPHAN    $rel\n");
+        $orphan++;
+    }
+}
+
+printf(
+    "rows=%d ok=%d missing=%d mismatch=%d orphan=%d\n",
+    count($rows), $ok, $missing, $mismatch, $orphan
+);
+
+exit(($missing || $mismatch) ? 1 : 0);
+```
+
+```sh
+php verify-backup.php \
+  /backups/nene_vault_20260823.sqlite \
+  /backups/nene-vault-files-20260823
+```
+
+**Why SHA-256 and not size or count.** A file that is corrupted in transit is
+usually the *same length* as the original — a flipped byte changes the content
+and nothing else. Counting files, or comparing sizes, passes such a backup. The
+hash is the only check that does not.
+
+**MISSING and ORPHAN are not the same failure.** They are the two directions of
+the same skew, and the guide's rule that the database and the files must be taken
+together is what they enforce:
+
+| Reading | Means | Severity |
+|---|---|---|
+| `missing > 0` | The database references a file the backup does not hold | 🔴 **Data loss.** Exits non-zero |
+| `mismatch > 0` | The file is there but its bytes are not the ones Vault recorded | 🔴 **Silent corruption.** Exits non-zero |
+| `orphan > 0` | Files present that no row references | 🟡 Exits **zero** |
+
+An orphan count that is small and stable is normal — deleted-then-restored
+versions and stray temporary files both land there. An orphan count that *jumps*
+between runs means the database is older than the files: the copies were not
+taken together. The opposite skew — files older than the database — appears as
+`missing`, which is why that one is fatal and this one is not.
 
 ### Recommended schedule
 


### PR DESCRIPTION
Closes #377

`#376` で MySQL 側に検証4点セット②③を入れた際、**既定構成だけが未検証で残る**ことが分かり射程を分けて起票していた分。`DB_ADAPTER=sqlite` / `DB_NAME=var/nene_vault.sqlite` が既定なので、**実際に多くの設置で使われる経路**が「取ったが確かめていない」状態だった。

🔑 Vault は **SHA-256 をダウンロード毎に検証する製品**なのに、そのファイル群のバックアップは件数でも SHA でも突合していなかった。保証が動作中のシステムの縁で切れていた。

## 入れたもの

| 節 | 内容 |
|---|---|
| `Online backup` | `$tmp` へ取り、`PRAGMA integrity_check` が `ok` の時だけ `mv` |
| `Verifying a SQLite backup` | 取得直後の assert ＋ **既に持っている世代を後から監査する**ループ |
| `Verifying a file backup` | `document_versions` の `file_path` / `file_sha256` と実体を突合する PHP スクリプト |

## 検知器を壊して確かめた

fixture（4000行のDB／12件のファイル）を作り、**壊して赤にできること**まで確認している。

| 検査 | 壊し方 | 結果 |
|---|---|---|
| `integrity_check` | 40% で切り詰め | 🟢 検知 |
| `integrity_check` | ページ境界ちょうど（25/50/75/90/99%） | 🟢 全て検知 |
| **`[ -s "$f" ]`** | 40% で切り詰め | 🔴 **通す** |
| SHA-256 突合 | ファイル1件を削除 | 🟢 `MISSING` / exit 1 |
| SHA-256 突合 | **1バイト反転（サイズ同一）** | 🟢 `MISMATCH` / exit 1 |
| 取得スクリプト | `integrity_check` を強制的に落とす | 🟢 exit 1・**既存バックアップは温存** |

**文書中のコードは出荷物から逐語抽出して実行している**（`` ```php `` / `` ```sh `` ブロックを抜き出してそのまま走らせた）。書いたものと試したものが違う、という事故を防ぐため。

## 実測から分かって文書に反映したこと

- 🔑 **0バイトの `.sqlite` は `integrity_check` を `ok` で通る** — テーブルの無いDBの正しい姿なので。⇒ **構造検査だけでは「走ったが何も作らなかった」を良品と区別できない。** ファイル突合を併置する理由でもある（0行では実体を説明できない）
- 🔑 **`integrity_check` は「健全なDBか」であって「意図したデータか」ではない** — 古い世代を掴むと、行が欠けたまま `ok` を返す（実測: 4000行→3200行でも `ok`）
- **`VACUUM INTO` は中身のあるターゲットを拒否する**（`file is not a database`）ので、失敗の残骸 `.part` が次回以降を全部止める ⇒ 冒頭に `rm -f "$tmp"` を置いて再実行可能にした
- **主経路を `sqlite3` CLI ではなく PHP にした** — Vault が動くホストには PHP が必ずある（アプリのランタイムなので）が、`sqlite3` は別パッケージで頻繁に欠けている

## MISSING と ORPHAN は同じズレの両方向

「DB とファイルは同期して取る」という本ガイド冒頭の規約を、この2つが強制する。

| 読み | 意味 | 終了コード |
|---|---|---|
| `missing > 0` | DBが参照するファイルをバックアップが持っていない | 🔴 データ損失・非ゼロ |
| `mismatch > 0` | ファイルはあるが Vault が記録したバイト列ではない | 🔴 サイレント破損・非ゼロ |
| `orphan > 0` | どの行も参照しないファイルがある | 🟡 **ゼロ**（件数の跳ねが同期ズレの信号） |

片方だけ見ると、どちらの向きのズレも見落とす。

## 射程

- **ドキュメントのみ**。スクリプトの `tools/` 化・CI 配線は行っていない（起票時の方針どおり「手順として書けるところまで」）
- `Recommended schedule` は変更していない
- MySQL 側（`#376` で完済）は変更していない

## 検証

`composer check` 全項目グリーン（411 tests / PHPStan 0 errors / CS clean / locales / OpenAPI / MCP / conformance 0 errors）。`docs/` は `prettier --check .`（`frontend/` 起点）の射程外で、変更前の同ファイルも同じ状態なので回帰なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LUxwSZwgsVqnZcpFzkdTYr