### PR TITLE
fix(css): nene2-ui 0.7.0 — タッチ端末の 16px フロアを取り戻す（#393）

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@hideyukimori/nene2-client": "^1.1.0",
-        "@hideyukimori/nene2-ui": "^0.6.0",
+        "@hideyukimori/nene2-ui": "^0.7.0",
         "@hookform/resolvers": "^3.10.0",
         "@tanstack/react-query": "^5.62.11",
         "react": "^19.2.6",
@@ -1711,9 +1711,9 @@
       }
     },
     "node_modules/@hideyukimori/nene2-ui": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@hideyukimori/nene2-ui/-/nene2-ui-0.6.0.tgz",
-      "integrity": "sha512-GPocH0cFmVupmWEvsgWUq8Nv9Jh0Kjl2zHd9jNxkZ9xOvMgO/pUaFZse4dFBOg/8Zn7bGHJ2zmDJr2vkuDRa2w==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@hideyukimori/nene2-ui/-/nene2-ui-0.7.0.tgz",
+      "integrity": "sha512-UwU80aElMk2U1e/5Sq6qdEYRzmSVJiH/G4/8doF5ZP9uSU1aZ3uDJdtkwVjFWVwB+gDKwVeR4JwhFYcrJmeX6g==",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@hideyukimori/nene2-client": "^1.1.0",
-    "@hideyukimori/nene2-ui": "^0.6.0",
+    "@hideyukimori/nene2-ui": "^0.7.0",
     "@hookform/resolvers": "^3.10.0",
     "@tanstack/react-query": "^5.62.11",
     "react": "^19.2.6",

--- a/frontend/src/shared/ui/theme/base.css
+++ b/frontend/src/shared/ui/theme/base.css
@@ -32,18 +32,19 @@
   a {
     color: inherit;
   }
-  /* 🔴 The mobile iOS floor is NOT here, and cannot be.
-     `themes/default.css` sets `--text-x-slot-control-size` to this product's 0.875rem so
-     inputs read the same size as the text around them. That is under the 16px at which iOS
-     Safari zooms on focus, so the floor is wanted on phones and not on desktop — a token
-     that varies by width.
+  /* 🔴 The touch-device font floor is not here, and does not need to be.
+     From #393 the kit carries it as its own slot, applied under `pointer-coarse:` — so the
+     product picks the pointer-fine size in `themes/default.css` and the floor comes along
+     for touch devices on its own.
 
-     This file may hold `@media` but not custom properties (ST-08); `themes/*.css` may hold
-     custom properties but not `@media` (AM-9). The two are deliberately exclusive and
-     exhaustive, so a width-conditional token has no home here — and an element rule cannot
-     stand in for one, because the kit's control utility lives in `@layer utilities`, which
-     wins over `@layer base` whatever the specificity.
+     Recorded because the first attempt cost two round trips: a width-conditional token has
+     no home in this repo. `themes/*.css` may hold custom properties but not `@media`
+     (AM-9); this file may hold `@media` but not custom properties (ST-08). The two are
+     deliberately exclusive and exhaustive, and an element rule cannot stand in — the kit's
+     control utility is in `@layer utilities`, which wins over `@layer base` at any
+     specificity. The answer was upstream, not a way around the rules.
 
-     ⇒ Raised with the kit instead: `max(var(--text-x-md), var(--text-x-ios-floor))` cannot
-     ask how wide the window is, so the floor lands at every width. Tracked as #393. */
+     🔑 And the kit's answer was better than the one asked for: it splits on `pointer-coarse`
+     rather than width, because the zoom is a property of touch input, not of narrow
+     windows — a landscape iPad is wide and still needs the floor. */
 }

--- a/frontend/src/shared/ui/theme/control-touch-floor.test.ts
+++ b/frontend/src/shared/ui/theme/control-touch-floor.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * The touch-device font floor must not be lowered.
+ *
+ * 🔴 iOS Safari zooms the page when a focused control's font-size is under 16px. The kit
+ * carries that as `--text-x-slot-control-touch-size`, applied under `pointer-coarse:` so it
+ * reaches phones and landscape tablets without touching the desktop size this product
+ * chooses in `--text-x-slot-control-size`.
+ *
+ * 🔴 Why a test and not the `slot-values` rule. Lowering the floor to a smaller step is
+ * still `var()` into the scale, so it is *legal* by that rule and passes silently. The rule
+ * guards against inventing values; this guards against choosing the wrong one. They are
+ * different failures and only one of them is about syntax.
+ *
+ * 🔑 The floor is a device constraint, not a design value — the one number in the theme that
+ * is not the product's to pick. vault is the kit's first consumer, so what happens here is
+ * what the next ship copies (#393).
+ */
+const THEME = readFileSync(join(import.meta.dirname, 'themes', 'default.css'), 'utf8');
+
+/** Declarations only — a slot named inside a comment is prose, not a value. */
+const CSS = THEME.replace(/\/\*[\s\S]*?\*\//g, '');
+
+const override = (slot: string): string | null =>
+  new RegExp(`--${slot}\\s*:\\s*([^;]+);`).exec(CSS)?.[1]?.trim() ?? null;
+
+describe('control touch floor', () => {
+  it('does not lower the touch size below the kit floor', () => {
+    const value = override('text-x-slot-control-touch-size');
+
+    // Not overriding at all is the expected state: the kit's default is the floor itself.
+    if (value === null) {
+      return;
+    }
+
+    // If it is overridden, the only defensible value is the floor.
+    expect(value).toBe('var(--text-x-ios-floor)');
+  });
+
+  it('still chooses its own pointer-fine size, so the two are not conflated', () => {
+    expect(override('text-x-slot-control-size')).toBe('var(--text-x-sm)');
+  });
+});

--- a/frontend/src/shared/ui/theme/themes/default.css
+++ b/frontend/src/shared/ui/theme/themes/default.css
@@ -204,16 +204,23 @@
   --spacing-x-slot-control-pad-y: var(--spacing-x-2xs);
   --spacing-x-slot-control-pad-x: var(--spacing-x-xs);
 
-  /* 🔴 14px, not the kit's `max(--text-x-md, --text-x-ios-floor)`.
-     The floor exists because iOS Safari zooms when a focused control is under 16px, and the
-     kit applies it at every width because `max()` cannot ask how wide the window is. This
-     product's body text is 0.875rem, so a 16px input reads as a different size from
-     everything around it — which is what the owner saw.
+  /* 0.875rem, matching this product's body text — a control that reads as a different size
+     from the words around it is what the owner saw at the 0.6.0 default of 1rem.
 
-     The floor is not dropped: it moves to the media query below, which is the only place
-     that can distinguish "on a phone" from "not". It stays in the slot rather than becoming
-     an element rule, because the kit's controls now set a font-size themselves — a rule in
-     `@layer base` would lose to their utility. */
+     🔴 This is the *pointer-fine* size only. The 16px that stops iOS Safari zooming on focus
+     lives in a second slot, `--text-x-slot-control-touch-size`, which the kit applies under
+     `pointer-coarse:` — so a phone and a landscape iPad get the floor while a desktop keeps
+     this. Until 0.7.0 the kit had one slot holding `max(--text-x-md, --text-x-ios-floor)`,
+     which could not tell the two apart; overriding it here dropped the floor everywhere
+     (#393, reported and fixed upstream).
+
+     🔴 DO NOT override `--text-x-slot-control-touch-size`. Lowering it silently reinstates
+     the zoom on every touch device, and `npm run slot-values` will NOT catch it — a lower
+     step is still a `var()` into the scale, so the rule that guards this file is blind to
+     it. `control-touch-floor.test.ts` is what actually holds the line.
+
+     🔑 The floor is a device constraint, not a design value. It is the one number here that
+     is not ours to choose. */
   --text-x-slot-control-size: var(--text-x-sm);
 
   /* Field hint sat one step lighter than the label before the migration (#389); the kit's


### PR DESCRIPTION
Closes #393

#392 波3 の暫定対応で `--text-x-slot-control-size` を `var(--text-x-sm)` にした結果、**iOS Safari のフォーカス時ズーム対策が全端末で外れていた**。0.7.0 がスロットを2つに割ったので回帰を閉じる。

| | 0.6.0 | 0.7.0 |
|---|---|---|
| pointer-fine | `--text-x-slot-control-size: max(--text-x-md, --text-x-ios-floor)`<br>（幅を問えないので**全幅 16px**） | `--text-x-slot-control-size: var(--text-x-md)`<br>🟢 **艦が選ぶ** |
| touch | — | `--text-x-slot-control-touch-size: var(--text-x-ios-floor)`<br>🔴 **下げない** |

部品側は `pointer-coarse:text-x-slot-control-touch-size`。

⇒ **本リポの上書きは `--text-x-slot-control-size: var(--text-x-sm)` のみ。施主が承認したデスクトップの見た目はそのままで、タッチ端末にはフロアが戻る。**

## 🔑 キットの答えは、こちらが依頼した形より良かった

**幅（`max-sm`）ではなくポインタ（`pointer-coarse`）で分けている。** ズームは**タッチ入力の性質**であって狭い窓の性質ではない——**横向きの iPad は広く、それでもフロアが要る**。#393 では「幅で」と書いて依頼したが、そちらが正しい。

## 🔴 検査を1本足した — 規則では止まらない失敗だから

`src/shared/ui/theme/control-touch-floor.test.ts`

**`--text-x-slot-control-touch-size` を下げても `npm run slot-values` は通す。** 小さい段も `var()` 参照なので**構文としては合法**だから。実際に変異させて確かめた:

```
変異: --text-x-slot-control-touch-size: var(--text-x-sm)
  slot-values : 🔴 通す（規則では止まらない）
  この test   : 🟢 検知
```

**規則は「値を発明していないか」を守り、この test は「正しい値を選んでいるか」を守る。別の失敗で、片方は構文の話ですらない。**

🔑 **フロアは端末の制約であって意匠ではない** — このテーマで**唯一、製品が選んでよくない数字**。vault はキットの最初の消費者なので、ここでの扱いが次の艦の型になる。

## 記録として残したこと

- **`themes/default.css`** — 2つのスロットの役割の違いと、**touch 側を下げるなという禁止**（`slot-values` が捕まえないことも明記）
- **`base.css`** — **幅で変わるトークンには本リポに置き場所が無い**経緯。`themes/*.css` は custom property を持てるが `@media` 不可（AM-9）、`base.css` は `@media` を持てるが custom property 不可（ST-08）。`nene2-standards` の実装に「AM-9 token-only の双対」と明記された**意図的に排他かつ網羅**な設計で、element 規則での代替も不可（キットの utility は `@layer utilities`＝`base` は詳細度に関係なく負ける）。**規約の抜け道を探すのではなく上流へ回すのが正解だった**

## 検証

- **配布境界の陽性対照を 0.7.0 で再取得**: `@source` 無し → exit 1 ／ 有り → exit 0
- ビルド後 CSS に実ルールを確認:
  `pointer-coarse\:text-x-slot-control-touch-size{font-size:var(--text-x-slot-control-touch-size)}`
- `npm run check` 全12ステップ緑・テスト **244件** ／ `composer check` 全項目グリーン（411 tests / conformance 0 errors）

## 目視について

**デスクトップの見た目は #392 の施主確認時から変わらない**（`--text-x-slot-control-size` の上書きは維持）。変わるのは**タッチ端末でのみ**入力欄が 16px になる点で、これは載せ替え前の挙動に戻すもの。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LUxwSZwgsVqnZcpFzkdTYr