### PR TITLE
fix(css): nene2-ui 0.8.0 — 角丸を載せ替え前の値へ戻す（#395・ズレ0）

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@hideyukimori/nene2-client": "^1.1.0",
-        "@hideyukimori/nene2-ui": "^0.8.0",
+        "@hideyukimori/nene2-ui": "^0.11.0",
         "@hookform/resolvers": "^3.10.0",
         "@tanstack/react-query": "^5.62.11",
         "react": "^19.2.6",
@@ -1711,9 +1711,9 @@
       }
     },
     "node_modules/@hideyukimori/nene2-ui": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@hideyukimori/nene2-ui/-/nene2-ui-0.8.0.tgz",
-      "integrity": "sha512-5NkG+Jnjm0BiZnnDjlRsKu2KChBS379dTyamfguvbLBF7v6NsJ/XjDnp6jmKy1qQLzPJFGuAP+BcDDzm3zMrBw==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@hideyukimori/nene2-ui/-/nene2-ui-0.11.0.tgz",
+      "integrity": "sha512-r3he6cJhtN7fQY0eBhSY/m2mEUWUfi0/2hWaQ/T+8EIvEs+h3dz029EzrfOt0Dx8A4I+SnCTDM9GND1YssUyJg==",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@hideyukimori/nene2-client": "^1.1.0",
-        "@hideyukimori/nene2-ui": "^0.7.0",
+        "@hideyukimori/nene2-ui": "^0.8.0",
         "@hookform/resolvers": "^3.10.0",
         "@tanstack/react-query": "^5.62.11",
         "react": "^19.2.6",
@@ -1711,9 +1711,9 @@
       }
     },
     "node_modules/@hideyukimori/nene2-ui": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@hideyukimori/nene2-ui/-/nene2-ui-0.7.0.tgz",
-      "integrity": "sha512-UwU80aElMk2U1e/5Sq6qdEYRzmSVJiH/G4/8doF5ZP9uSU1aZ3uDJdtkwVjFWVwB+gDKwVeR4JwhFYcrJmeX6g==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@hideyukimori/nene2-ui/-/nene2-ui-0.8.0.tgz",
+      "integrity": "sha512-5NkG+Jnjm0BiZnnDjlRsKu2KChBS379dTyamfguvbLBF7v6NsJ/XjDnp6jmKy1qQLzPJFGuAP+BcDDzm3zMrBw==",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@hideyukimori/nene2-client": "^1.1.0",
-    "@hideyukimori/nene2-ui": "^0.7.0",
+    "@hideyukimori/nene2-ui": "^0.8.0",
     "@hookform/resolvers": "^3.10.0",
     "@tanstack/react-query": "^5.62.11",
     "react": "^19.2.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@hideyukimori/nene2-client": "^1.1.0",
-    "@hideyukimori/nene2-ui": "^0.8.0",
+    "@hideyukimori/nene2-ui": "^0.11.0",
     "@hookform/resolvers": "^3.10.0",
     "@tanstack/react-query": "^5.62.11",
     "react": "^19.2.6",

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -1,4 +1,4 @@
-import { Button, EmptyState, InlineAlert, Stack } from '@hideyukimori/nene2-ui';
+import { Button, EmptyState, Icon, InlineAlert, Stack } from '@hideyukimori/nene2-ui';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useDocumentSearch, DocumentSearchForm, DocumentTable } from '@/features/document-search';
@@ -36,23 +36,23 @@ export function DocumentsPage() {
             {t('document.list.title')}
           </h1>
         </Stack>
+        {/* 🔴 `inline-flex items-center` and the gap are on the call site because the kit's
+            Button does not lay out its own children — it sets no display, so an icon and a
+            label sit on the text baseline with nothing between them. vault's own Button
+            carried `inline-flex items-center justify-center gap-1.75`. Raised as #398; this
+            className goes away when the kit takes it on. */}
         <Button
           variant="primary"
+          className="inline-flex items-center gap-x-2xs"
           onClick={() => {
             setShowUpload(true);
           }}
         >
-          <svg
-            viewBox="0 0 24 24"
-            fill="none"
-            strokeWidth="1.8"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
+          <Icon decorative size="sm" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round">
             <path d="M12 19V6" />
             <path d="m6 11 6-6 6 6" />
             <path d="M5 20h14" />
-          </svg>
+          </Icon>
           {t('document.list.upload_button')}
         </Button>
       </div>

--- a/frontend/src/pages/ExportPage.tsx
+++ b/frontend/src/pages/ExportPage.tsx
@@ -145,7 +145,7 @@ export function ExportPage() {
           {exportError !== null && <p className="text-2xs text-danger">{exportError}</p>}
           {exportSuccess && <p className="success body-sm">{t('export.messages.downloaded')}</p>}
 
-          <Stack>
+          <div>
             <Button
               variant="primary"
               onClick={() => {
@@ -155,7 +155,7 @@ export function ExportPage() {
             >
               {isExporting ? t('common.status.processing') : t('export.form.submit')}
             </Button>
-          </Stack>
+          </div>
         </Stack>
       </Box>
     </AppChrome>

--- a/frontend/src/pages/ExportPage.tsx
+++ b/frontend/src/pages/ExportPage.tsx
@@ -118,7 +118,10 @@ export function ExportPage() {
           </FormField>
 
           <FormField id="export-format" label={t('export.form.format_label')}>
-            <Stack gap="2xs">
+            {/* `align="start"` so the labels keep their own width. A Stack blockifies its
+                children, and a choice label that spans the full row moves the click target
+                somewhere the eye does not expect it. */}
+            <Stack align="start" gap="2xs">
               {(['zip', 'csv'] as const).map((f) => (
                 <Radio
                   key={f}
@@ -134,13 +137,20 @@ export function ExportPage() {
             </Stack>
           </FormField>
 
-          <Checkbox
-            label={t('export.form.include_voided_label')}
-            checked={includeVoided}
-            onChange={(e) => {
-              setIncludeVoided(e.target.checked);
-            }}
-          />
+          {/* Wrapped so the label keeps its own width. The kit's Checkbox hardcodes the
+              `<label>`'s className and forwards the caller's to the `<input>`, so there is
+              no way to say `self-start` from here; a block wrapper is the only place left
+              to say it. As a flex item the label would otherwise span the whole card, and
+              the click target would sit where nothing is drawn. */}
+          <div>
+            <Checkbox
+              label={t('export.form.include_voided_label')}
+              checked={includeVoided}
+              onChange={(e) => {
+                setIncludeVoided(e.target.checked);
+              }}
+            />
+          </div>
 
           {exportError !== null && <p className="text-2xs text-danger">{exportError}</p>}
           {exportSuccess && <p className="success body-sm">{t('export.messages.downloaded')}</p>}

--- a/frontend/src/pages/ExportPage.tsx
+++ b/frontend/src/pages/ExportPage.tsx
@@ -137,20 +137,18 @@ export function ExportPage() {
             </Stack>
           </FormField>
 
-          {/* Wrapped so the label keeps its own width. The kit's Checkbox hardcodes the
-              `<label>`'s className and forwards the caller's to the `<input>`, so there is
-              no way to say `self-start` from here; a block wrapper is the only place left
-              to say it. As a flex item the label would otherwise span the whole card, and
-              the click target would sit where nothing is drawn. */}
-          <div>
-            <Checkbox
-              label={t('export.form.include_voided_label')}
-              checked={includeVoided}
-              onChange={(e) => {
-                setIncludeVoided(e.target.checked);
-              }}
-            />
-          </div>
+          {/* `self-start` so the label keeps its own width — as a flex item it would
+              otherwise span the whole card and put the click target where nothing is drawn.
+              Said directly on the control since 0.11.0: `className` lands on the `<label>`
+              now, and the box takes `inputClassName`. Until then this needed a wrapper. */}
+          <Checkbox
+            className="self-start"
+            label={t('export.form.include_voided_label')}
+            checked={includeVoided}
+            onChange={(e) => {
+              setIncludeVoided(e.target.checked);
+            }}
+          />
 
           {exportError !== null && <p className="text-2xs text-danger">{exportError}</p>}
           {exportSuccess && <p className="success body-sm">{t('export.messages.downloaded')}</p>}

--- a/frontend/src/pages/SettingsPage.test.tsx
+++ b/frontend/src/pages/SettingsPage.test.tsx
@@ -28,7 +28,48 @@ describe('SettingsPage retention warning', () => {
     await userEvent.type(input, '8');
 
     await waitFor(() => {
-      expect(input).toHaveAttribute('aria-invalid', 'true');
+      // 🔴 The paint, not the attribute. This used to assert `aria-invalid="true"` as a proxy
+      // for the amber outline, because vault's own Input drew it from that attribute (FC-1.8).
+      // The kit's Input does not, so the outline vanished in the migration while the assertion
+      // kept passing — the attribute survived, the CSS behind it did not. Assert what is drawn.
+      expect(input).toHaveClass('border-warn', 'ring-warn-soft');
     });
+  });
+
+  /**
+   * Closing the last of #385 in the one place that is not an error.
+   *
+   * 🔴 The field used to set `aria-invalid` for the under-ten-years notice. Eight years is
+   * over the `min` of seven, so the value is valid — `aria-invalid` said it was not, and the
+   * reason was never linked. Both halves were wrong, and neither is visible in a render.
+   */
+  it('links the retention notice to the field without calling the value invalid', async () => {
+    renderWithProviders(
+      <MemoryRouter>
+        <SettingsPage />
+      </MemoryRouter>,
+    );
+
+    const input = await screen.findByRole('spinbutton');
+    await waitFor(() => {
+      expect(input).toHaveValue(10);
+    });
+
+    await userEvent.clear(input);
+    await userEvent.type(input, '8');
+
+    // Scoped to the alert itself: the hint under the field says "10 years or more" too, and
+    // the point of this test is which of the two the field points at.
+    await screen.findByRole('status');
+
+    // The value passes validation, so it must not be announced as invalid.
+    expect(input).not.toHaveAttribute('aria-invalid', 'true');
+
+    // …and the reason it is flagged has to be reachable from the field. Compared by id
+    // rather than by walking the DOM: what matters is that the field points at the element
+    // holding the notice, which is exactly what a screen reader follows.
+    const describedBy = input.getAttribute('aria-describedby');
+    expect(describedBy).not.toBeNull();
+    expect(screen.getByRole('status').parentElement?.id).toBe(describedBy);
   });
 });

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -185,11 +185,11 @@ export function SettingsPage() {
             )}
             {submitError !== null && <p className="text-2xs text-danger">{t(submitError)}</p>}
 
-            <Stack>
+            <div>
               <Button type="submit" variant="primary" disabled={mutation.isPending}>
                 {mutation.isPending ? t('common.status.saving') : t('vault_settings.save_button')}
               </Button>
-            </Stack>
+            </div>
           </Stack>
         </form>
       )}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -12,6 +12,9 @@ import { formatDateTime } from '@/shared/lib/format';
 import { AppChrome } from '@/features/app-chrome';
 import { useNavigate } from 'react-router-dom';
 
+/** Referenced by the retention input's `aria-describedby`, so it lives next to both. */
+const RETENTION_WARNING_ID = 'settings-retention-warning';
+
 const settingsSchema = z.object({
   retention_years: z.coerce
     .number()
@@ -123,19 +126,41 @@ export function SettingsPage() {
                 type="number"
                 min={7}
                 max={99}
-                // The live under-10-years notice is a *warning*, not a validation error, so it
-                // sets aria-invalid directly. FormField's own wiring covers the error case and
-                // an explicit prop wins over it (see the kit's useFieldWiring).
-                aria-invalid={retentionWarn || undefined}
+                /* 🔴 No `aria-invalid` here. Eight years is under the recommended ten and over
+                   the `min` of seven — the value passes validation, and `aria-invalid` says it
+                   did not. It used to be set, which told assistive technology the field was
+                   wrong while the reason went unlinked: the exact shape #385 was opened for,
+                   surviving in the one place that is not an error at all.
+
+                   The notice is linked instead. Only when there is no real validation error —
+                   an explicit `aria-describedby` wins over FormField's own wiring, and an
+                   error outranks a recommendation. */
+                aria-describedby={
+                  retentionWarn && errors.retention_years === undefined
+                    ? RETENTION_WARNING_ID
+                    : undefined
+                }
+                /* 🔴 The amber outline the notice used to draw. Before the migration it came
+                   from vault's own Input, which carried `aria-invalid:border-warn` and friends
+                   — attribute and paint from one source (FC-1.8). The kit's Input reads
+                   `aria-invalid` for wiring and paints nothing from it, so the outline went
+                   away in W1 and nothing noticed: the test asserted the attribute, and the
+                   attribute was still there. Restored here until the kit has a warning state
+                   for controls (#399). */
+                className={retentionWarn ? 'border-warn ring-3 ring-warn-soft' : undefined}
                 // valueAsNumber so the watched value is numeric *while typing* — the
                 // under-10-years compliance warning must render live, not only after
                 // save → re-fetch coerces the value server-side.
                 {...register('retention_years', { valueAsNumber: true })}
               />
               {retentionWarn && (
-                <InlineAlert tone="warn">
-                  {t('vault_settings.fields.retention_warning')}
-                </InlineAlert>
+                /* Wrapped to carry the id: the kit's InlineAlert takes neither `id` nor
+                   `className`, so there is nowhere else to put one (#399). */
+                <div id={RETENTION_WARNING_ID}>
+                  <InlineAlert tone="warn">
+                    {t('vault_settings.fields.retention_warning')}
+                  </InlineAlert>
+                </div>
               )}
             </FormField>
 

--- a/frontend/src/shared/ui/theme/scale-not-redefined.test.ts
+++ b/frontend/src/shared/ui/theme/scale-not-redefined.test.ts
@@ -1,0 +1,55 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * A product redefines slots, never the scale they choose from.
+ *
+ * 🔴 The distinction is the whole mechanism. Redefining a slot changes one ship; redefining
+ * a step changes what the name means for every ship that reads the kit's scale — and it does
+ * it silently, because the name still resolves. A product whose design has no rounded
+ * corners points its slots at `--radius-x-none`; it does not set `--radius-x-pill: 0`.
+ *
+ * 🔴 `npm run slot-values` does not catch this. That rule reads `--*-x-slot-*` declarations
+ * and checks their values; a redefined *step* is not a slot declaration at all, so it never
+ * reaches the check. Two different failures, two different guards (#395).
+ *
+ * 🔴 The step names are read from the kit's own theme rather than matched by pattern. The
+ * first version of this test used `--(spacing|radius|text|…)-x-` and failed on a clean tree:
+ * `x-` is also this product's extension namespace (`--color-x-brass`, `--color-x-ink-deep`),
+ * so the pattern claimed every one of those was a redefined step. Reading the kit's file
+ * means the list cannot drift from what the kit actually ships, either.
+ */
+const require = createRequire(import.meta.url);
+const KIT_THEME = join(
+  dirname(require.resolve('@hideyukimori/nene2-ui/package.json')),
+  'themes',
+  'default.css',
+);
+
+/** Declarations only — a token named inside a comment is prose. */
+const declarations = (css: string): string[] =>
+  [...css.replace(/\/\*[\s\S]*?\*\//g, '').matchAll(/(--[a-z0-9-]+)\s*:/g)].map((m) => m[1] ?? '');
+
+/** Every `--…-x-…` the kit declares that is not a slot: the scale itself. */
+const KIT_STEPS = new Set(
+  declarations(readFileSync(KIT_THEME, 'utf8')).filter(
+    (name) => /-x-/.test(name) && !name.includes('-x-slot-'),
+  ),
+);
+
+const THEME_DIR = join(import.meta.dirname, 'themes');
+const files = readdirSync(THEME_DIR).filter((f) => f.endsWith('.css'));
+
+describe('kit scale', () => {
+  it('reads a non-empty set of steps from the kit, so an empty result is not a pass', () => {
+    expect(KIT_STEPS.size).toBeGreaterThan(10);
+  });
+
+  it.each(files)('%s redefines no step of the kit scale', (file) => {
+    const ours = declarations(readFileSync(join(THEME_DIR, file), 'utf8'));
+
+    expect(ours.filter((name) => KIT_STEPS.has(name))).toEqual([]);
+  });
+});

--- a/frontend/src/shared/ui/theme/themes/default.css
+++ b/frontend/src/shared/ui/theme/themes/default.css
@@ -201,6 +201,22 @@
 
      All three are slots, so all three are ours to choose. Each is the nearest step to the
      old value: 8px is `2xs` exactly, 11px lands on `xs` (12px, +1px). */
+  /* Corners. Set only for the three kit components this product actually renders; `card`,
+     `modal` and `badge` are still its own, so their slots are left at the kit default rather
+     than given values nothing reads.
+
+     All three land on a step exactly — 0.8.0 chose the scale from the fleet's own
+     distribution (10 ships, 25 values, 266 uses) rather than promoting one ship's, so the
+     values that were already here are in it (#395).
+
+     🔴 The scale itself, `--radius-x-pill` included, is not redefined. A product whose
+     design has no rounded corners points its slots at `--radius-x-none`; it does not set
+     `--radius-x-pill: 0`. Redefining a step changes what the name means for the whole fleet;
+     redefining a slot changes one ship. Only the second is the mechanism. */
+  --radius-x-slot-control: var(--radius-x-xs); /* 4px — was `rounded-sm` */
+  --radius-x-slot-button: var(--radius-x-xs); /* 4px — was `rounded-sm` */
+  --radius-x-slot-alert: var(--radius-x-sm); /* 6px — was `rounded-md` */
+
   --spacing-x-slot-control-pad-y: var(--spacing-x-2xs);
   --spacing-x-slot-control-pad-x: var(--spacing-x-xs);
 

--- a/frontend/src/shared/ui/theme/themes/default.css
+++ b/frontend/src/shared/ui/theme/themes/default.css
@@ -213,6 +213,22 @@
      design has no rounded corners points its slots at `--radius-x-none`; it does not set
      `--radius-x-pill: 0`. Redefining a step changes what the name means for the whole fleet;
      redefining a slot changes one ship. Only the second is the mechanism. */
+  /* Button padding. The kit's default y is one step up from what this product used, which
+     made every button 4px taller — 39 of them. `2xs` is the old value exactly. The x default
+     is already the nearest step (16px against the old 15px), so it is left alone.
+
+     🔴 This drops the touch-device height below 44px, and there is no way to hold it here.
+     Before the migration this product carried `max-md:min-h-11.5` (46px) alongside a larger
+     mobile padding; the kit has no equivalent, and its 12px default cleared 44px only by
+     arithmetic accident — an accident that cannot survive the slot being overridden, which
+     is what the slot is for. Raised as #397, in the shape that #393 settled for the font
+     floor: a second slot the product does not get to lower. */
+  --spacing-x-slot-button-pad-y: var(--spacing-x-2xs);
+
+  /* Alert padding, composed — the old rule was 13px vertical and 15px horizontal, and one
+     value for all four sides cannot say that. Each lands within 1px of a step. */
+  --spacing-x-slot-alert-pad: var(--spacing-x-xs) var(--spacing-x-sm);
+
   --radius-x-slot-control: var(--radius-x-xs); /* 4px — was `rounded-sm` */
   --radius-x-slot-button: var(--radius-x-xs); /* 4px — was `rounded-sm` */
   --radius-x-slot-alert: var(--radius-x-sm); /* 6px — was `rounded-md` */

--- a/frontend/src/shared/ui/theme/themes/default.css
+++ b/frontend/src/shared/ui/theme/themes/default.css
@@ -233,6 +233,27 @@
   --radius-x-slot-button: var(--radius-x-xs); /* 4px — was `rounded-sm` */
   --radius-x-slot-alert: var(--radius-x-sm); /* 6px — was `rounded-md` */
 
+  /* Control colours. Three of the four differ from the kit's defaults — measured against
+     the pre-migration `FIELD_BASE` and confirmed in a real browser against production
+     (#399). `bg` already matches, so it is not restated. */
+  --color-x-slot-control-fg: var(--color-x-ink-deep); /* 24% vs the kit's 31% */
+  --color-x-slot-control-border: var(--color-x-line-mid); /* 84% vs 89% */
+  --color-x-slot-control-placeholder: var(--color-text-faint); /* 60% vs 49% */
+
+  /* 🔴 Font sizes for Button and the choice controls. Both default to `inherit` in the kit
+     — deliberately, because those two components never carried a size, so choosing a step
+     upstream would move every ship's rendering. This product's did carry one: `text-sm`,
+     which here is 0.8125rem.
+
+     ⚠️ 13px is not a step in the kit's type scale (0.6875 / 0.75 / 0.875 / 1 / 1.125 /
+     1.5rem). It is referenced from this product's own scale, the same way the alert colours
+     are referenced from its palette. The kit's scale was measured from what ships write as
+     Tailwind classes, so a value that only ever existed as a token was invisible to it —
+     the same shape as the radius scale missing everything but 8px (#395). Whether the scale
+     should grow a step is upstream's call; measuring it wants computed styles, not classes. */
+  --text-x-slot-button-size: var(--text-sm);
+  --text-x-slot-choice-size: var(--text-sm);
+
   --spacing-x-slot-control-pad-y: var(--spacing-x-2xs);
   --spacing-x-slot-control-pad-x: var(--spacing-x-xs);
 


### PR DESCRIPTION
Closes #395

施主の目視での指摘（2回）:

> 角丸の数値が違うように見えるよ
> 角丸は **2px が絶対必要**って言われると思う。あと、**ピル型の指定も必要**だよね？

0.8.0 で radius スケールが **1段 → 9段＋pill** になったので、**スロットで戻す**。

| 部品 | 載せ替え前 | 0.6/0.7 | 本 PR | ズレ |
|---|---|---|---|---:|
| `Input` / `Select` / `Textarea` | 4px | 8px | `var(--radius-x-xs)` | **0** |
| `Button` | 4px | 8px | `var(--radius-x-xs)` | **0** |
| `InlineAlert` | 6px | 8px | `var(--radius-x-sm)` | **0** |

**3つとも段に完全一致。** スケールがフリートの実分布から選ばれたので、**元からあった値がその中にある** — 1艦から verbatim 昇格していた頃には無かった性質。

`card` / `modal` / `badge` は本リポ自前の部品なので、**何も読まない値を置かない**ためにスロットは既定のまま。

## 🔴 スケールの段は再定義しない

`--radius-x-pill` を含め、**段そのものは1つも上書きしていない**。角丸を持たない艦は `--radius-x-pill: 0` にするのではなく、**スロットを `--radius-x-none` へ向ける**。

> **段を書き換えると名前の意味がフリート全体で変わり、スロットを書き換えると1艦が変わる。機構なのは後者だけ。**

（fleet-tooling の裁定。当初 hub の案は「pill の値は製品が決める」だったが、それは前者にあたるとして却下された。alert 色スロットの喩えを正しく適用すると、上書き先はスロットになる。）

## 検査を1本足した — `slot-values` が届かない失敗

`src/shared/ui/theme/scale-not-redefined.test.ts`

**段の再定義は `--*-x-slot-*` の宣言ではないので、`slot-values` には最初から届かない。** 別の失敗には別の検査が要る。

```
変異                          slot-values   この test
--radius-x-pill: 0;           🔴 素通り      🟢 検知
--spacing-x-md: 1.375rem;     🔴 素通り      🟢 検知
--text-x-ios-floor: 12px;     🔴 素通り      🟢 検知
```

⚠️ **最初の版は clean な状態で落ちた。** `--(spacing|radius|text|color)-x-` のパターンで書いたら、**本リポ自身の拡張トークン（`--color-x-brass` 等）を「再定義された段」と報告した** — **フィルタが意図より広い**、今日4件目。

⇒ **キットのテーマから段名を読んで突合する形**へ変更（キットが段を増やしても追随する）。**段の集合が空なら何でも通ってしまう**ので、**空でないことを確かめる検査も併置**した。

## 分母の訂正

#395 で出した「実在11値」は**トークン定義だけを数えたもの**で、**`border-radius` の直書きが入っていなかった**（fleet-tooling が実測）。正しくは **10艦・25種・のべ266件**、最頻値は **2px（56件・21%）**、次いで 0px（39件）。

🔑 **施主が挙げた2点が、分布の1位と2位だった。**

## 検証

- **配布境界の陽性対照を 0.8.0 で再取得**: `@source` 無し → exit 1 ／ 有り → exit 0
- `npm run check` 全12ステップ緑・テスト **247件** ／ `composer check` 全項目グリーン（411 tests / conformance 0 errors）

## 目視について

**変わるのは角丸だけ**（コントロールとボタンが 8px → 4px、アラートが 8px → 6px）。いずれも**載せ替え前とズレ 0** なので、W1 以前の見た目に戻る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LUxwSZwgsVqnZcpFzkdTYr