### PR TITLE
test: ダウンロード試験の間欠失敗を直す — フレークではなく「走らせ方」だった（#400）

### DIFF
--- a/frontend/src/pages/DocumentDetailPage.test.tsx
+++ b/frontend/src/pages/DocumentDetailPage.test.tsx
@@ -47,7 +47,13 @@ describe('DocumentDetailPage download', () => {
 
     // The button stays disabled until the history response resolves the
     // current version's ULID (the detail payload only has the ordinal number).
-    const button = await screen.findByRole('button', { name: 'Download' });
+    //
+    // 🔴 Explicit timeout. The default 1000ms is enough for `vitest run` and not always
+    // enough for `vitest run --coverage`, which is what `npm run check` and CI actually
+    // execute: measured 2026-08-24, 0 failures in 13 plain runs and 2 in 3 coverage runs.
+    // The suite was passing on the machine and failing on the gate — the same test, told
+    // apart only by how the gate runs it.
+    const button = await screen.findByRole('button', { name: 'Download' }, { timeout: 5000 });
     await waitFor(() => {
       expect(button).toBeEnabled();
     });


### PR DESCRIPTION
Closes #400

`DocumentDetailPage.test.tsx` の「downloads through the authenticated client (#179)」が**手元では通り、ゲートで落ちる**状態だった。

## 🔴 再現条件を測ったら一発だった

| 走らせ方 | 実測 |
|---|---|
| `vitest run`（単体10回・フル3回） | **13/13 通過** |
| `vitest run --coverage`（3回） | 🔴 **2/3 失敗** |

**`npm run check` と CI が実際に回すのは後者。** ⇒ 同じテストを、**ゲートの回し方だけが分けていた。**

## 原因と対応

`findByRole` の既定タイムアウトは 1000ms。カバレッジ計装で描画が遅くなると、**文書詳細のクエリが解決する前に打ち切られる**（ボタンが「無効で存在する」のではなく、まだ描画されていない）。

⇒ 当該 `findByRole` に `{ timeout: 5000 }` を明示し、**なぜ既定では足りないか**をコメントで残した。

**検証: カバレッジありで 5/5 通過**（修正前 2/3 失敗）。

## 🔑 「間欠」は原因の名前ではない

**1回目に落ちたとき、「単体3回・フル2回で緑だから間欠」と判断してコミットに書いただけで済ませた。** そのとき回していたのは**カバレッジ無し**で、**落ちた時の条件を再現していなかった**。

⇒ **再現条件を測るまでは、まだ何も分かっていないのと同じ。** 今回は「走らせ方」を変数に入れただけで出た。

⚠️ 同族の可能性: `findBy*` の既定タイムアウトに依存するテストは同じことが起きうる。当該ファイルでは `findBy*` は1箇所のみ。

## 検証

`npm run check` 全12ステップ緑・テスト 248件 ／ `composer check` 全項目グリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LUxwSZwgsVqnZcpFzkdTYr