### PR TITLE
feat(frontend): nene2-ui 0.14.0 へ上げ、呼び出し側の暫定対応3件を外す（#402）

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@hideyukimori/nene2-client": "^1.1.0",
-        "@hideyukimori/nene2-ui": "^0.11.0",
+        "@hideyukimori/nene2-ui": "^0.14.0",
         "@hookform/resolvers": "^3.10.0",
         "@tanstack/react-query": "^5.62.11",
         "react": "^19.2.6",
@@ -1711,9 +1711,9 @@
       }
     },
     "node_modules/@hideyukimori/nene2-ui": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@hideyukimori/nene2-ui/-/nene2-ui-0.11.0.tgz",
-      "integrity": "sha512-r3he6cJhtN7fQY0eBhSY/m2mEUWUfi0/2hWaQ/T+8EIvEs+h3dz029EzrfOt0Dx8A4I+SnCTDM9GND1YssUyJg==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@hideyukimori/nene2-ui/-/nene2-ui-0.14.0.tgz",
+      "integrity": "sha512-phfgrzYkCVzct9+4ufUyj/7gRYgIz/f2e2nd/rtXpwrhXPJ5kQUrXasrZMhR/VGmBtyoA4QAWEhzVzSwrm+cWw==",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@hideyukimori/nene2-client": "^1.1.0",
-    "@hideyukimori/nene2-ui": "^0.11.0",
+    "@hideyukimori/nene2-ui": "^0.14.0",
     "@hookform/resolvers": "^3.10.0",
     "@tanstack/react-query": "^5.62.11",
     "react": "^19.2.6",

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -36,14 +36,12 @@ export function DocumentsPage() {
             {t('document.list.title')}
           </h1>
         </Stack>
-        {/* 🔴 `inline-flex items-center` and the gap are on the call site because the kit's
-            Button does not lay out its own children — it sets no display, so an icon and a
-            label sit on the text baseline with nothing between them. vault's own Button
-            carried `inline-flex items-center justify-center gap-1.75`. Raised as #398; this
-            className goes away when the kit takes it on. */}
+        {/* No layout className here. Until 0.13.0 the kit's Button set no display, so an icon
+            and a label sat on the text baseline with nothing between them and this call site
+            carried `inline-flex items-center gap-x-2xs` itself (#398). The kit lays out its
+            own children now; the gap is `--spacing-x-slot-button-gap` in the theme. */}
         <Button
           variant="primary"
-          className="inline-flex items-center gap-x-2xs"
           onClick={() => {
             setShowUpload(true);
           }}

--- a/frontend/src/pages/SettingsPage.test.tsx
+++ b/frontend/src/pages/SettingsPage.test.tsx
@@ -28,12 +28,29 @@ describe('SettingsPage retention warning', () => {
     await userEvent.type(input, '8');
 
     await waitFor(() => {
-      // 🔴 The paint, not the attribute. This used to assert `aria-invalid="true"` as a proxy
-      // for the amber outline, because vault's own Input drew it from that attribute (FC-1.8).
-      // The kit's Input does not, so the outline vanished in the migration while the assertion
-      // kept passing — the attribute survived, the CSS behind it did not. Assert what is drawn.
-      expect(input).toHaveClass('border-warn', 'ring-warn-soft');
+      // 🔴 Two assertions, and they have to fail for different reasons.
+      //
+      //   1. this page marks the field   — `data-warn` is on the input
+      //   2. the kit paints that mark    — the classes keyed off it are on the input
+      //
+      // Asserting only (1) is the shape that already got through here once: the attribute
+      // survived the migration, the paint did not, and the test stayed green because it was
+      // checking a stand-in that lived in the same component as the thing it stood for. The
+      // moment the implementation moved upstream, the stand-in stayed behind.
+      //
+      // Asserting only (2) would pass on a field that is never marked at all.
+      //
+      // ⚠️ Neither reaches computed style — jsdom has no compiled CSS. What they do reach is
+      // the two edits that actually removed the signal last time: dropping `data-warn` here,
+      // and the kit dropping `VALIDITY_CLASS` upstream. Verified by making each of those
+      // edits and watching this go red (2026-08-24).
+      expect(input).toHaveAttribute('data-warn');
     });
+
+    // Outside the `waitFor`: the class list is fixed at render, so there is nothing to wait
+    // for here — and one assertion per callback is the lint rule.
+    expect(input.className).toContain('data-[warn]:border-x-slot-control-warn-border');
+    expect(input.className).toContain('data-[warn]:bg-x-slot-control-warn-bg');
   });
 
   /**
@@ -68,8 +85,11 @@ describe('SettingsPage retention warning', () => {
     // …and the reason it is flagged has to be reachable from the field. Compared by id
     // rather than by walking the DOM: what matters is that the field points at the element
     // holding the notice, which is exactly what a screen reader follows.
+    //
+    // The id sits on the alert itself since 0.12.0 — `InlineAlert` takes an `id` now, so the
+    // wrapper this used to read through (`.parentElement`) is gone.
     const describedBy = input.getAttribute('aria-describedby');
     expect(describedBy).not.toBeNull();
-    expect(screen.getByRole('status').parentElement?.id).toBe(describedBy);
+    expect(screen.getByRole('status').id).toBe(describedBy);
   });
 });

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -140,27 +140,30 @@ export function SettingsPage() {
                     ? RETENTION_WARNING_ID
                     : undefined
                 }
-                /* 🔴 The amber outline the notice used to draw. Before the migration it came
-                   from vault's own Input, which carried `aria-invalid:border-warn` and friends
-                   — attribute and paint from one source (FC-1.8). The kit's Input reads
-                   `aria-invalid` for wiring and paints nothing from it, so the outline went
-                   away in W1 and nothing noticed: the test asserted the attribute, and the
-                   attribute was still there. Restored here until the kit has a warning state
-                   for controls (#399). */
-                className={retentionWarn ? 'border-warn ring-3 ring-warn-soft' : undefined}
+                /* 🔴 The amber paint, back where it belongs. Before the migration it came
+                   from vault's own Input (`aria-invalid:border-warn` and friends — attribute
+                   and paint from one source, FC-1.8); W1 moved the Input upstream and the
+                   paint did not come along, which nothing noticed because the test asserted
+                   the attribute and the attribute was still there.
+
+                   0.12.0 gave the kit a warning state that is deliberately NOT `aria-invalid`
+                   (#399): `data-warn` carries no ARIA meaning, so a legal value is painted
+                   without being announced as an error. Presence is what the selector matches,
+                   so the value is the empty string — `data-warn={false}` would still render
+                   the attribute. The two assertions in
+                   `SettingsPage.test.tsx` are what hold this — the mark and the paint, separately. */
+                data-warn={retentionWarn ? '' : undefined}
                 // valueAsNumber so the watched value is numeric *while typing* — the
                 // under-10-years compliance warning must render live, not only after
                 // save → re-fetch coerces the value server-side.
                 {...register('retention_years', { valueAsNumber: true })}
               />
               {retentionWarn && (
-                /* Wrapped to carry the id: the kit's InlineAlert takes neither `id` nor
-                   `className`, so there is nowhere else to put one (#399). */
-                <div id={RETENTION_WARNING_ID}>
-                  <InlineAlert tone="warn">
-                    {t('vault_settings.fields.retention_warning')}
-                  </InlineAlert>
-                </div>
+                /* The id goes on the alert itself since 0.12.0 (#399); before that the kit's
+                   InlineAlert took neither `id` nor `className` and this needed a wrapper. */
+                <InlineAlert id={RETENTION_WARNING_ID} tone="warn">
+                  {t('vault_settings.fields.retention_warning')}
+                </InlineAlert>
               )}
             </FormField>
 

--- a/frontend/src/shared/ui/theme/themes/default.css
+++ b/frontend/src/shared/ui/theme/themes/default.css
@@ -217,13 +217,30 @@
      made every button 4px taller — 39 of them. `2xs` is the old value exactly. The x default
      is already the nearest step (16px against the old 15px), so it is left alone.
 
-     🔴 This drops the touch-device height below 44px, and there is no way to hold it here.
-     Before the migration this product carried `max-md:min-h-11.5` (46px) alongside a larger
-     mobile padding; the kit has no equivalent, and its 12px default cleared 44px only by
-     arithmetic accident — an accident that cannot survive the slot being overridden, which
-     is what the slot is for. Raised as #397, in the shape that #393 settled for the font
-     floor: a second slot the product does not get to lower. */
+     🟢 Lowering the padding used to drop the touch-device height below 44px, with no way to
+     hold it from here — the kit's 12px default cleared 44px only by arithmetic accident, and
+     an accident cannot survive the slot being overridden, which is what the slot is for.
+     Settled upstream in 0.14.0 (#397): `--spacing-x-slot-control-touch-min` is a second slot
+     the product does not get to lower, applied under `pointer-coarse:`. Same shape as the
+     font floor (#393). The padding here is free to be the old value again. */
   --spacing-x-slot-button-pad-y: var(--spacing-x-2xs);
+
+  /* 🔴 DO NOT override `--spacing-x-slot-control-touch-min`. 44px is WCAG 2.5.5 and the
+     Apple HIG minimum — a device constraint, not a design value, and the same class of
+     number as `--text-x-slot-control-touch-size`. `slot-values` will NOT catch a lower
+     value here either: a smaller step is still a `var()` into the scale.
+     `control-touch-floor.test.ts` is what holds the line.
+
+     ⚠️ On touch devices this moves two things, both deliberately left at the kit's default:
+       · `md` buttons 46px → 44px. The old 46 came from `max-md:min-h-11.5`, an ad-hoc value,
+         not a step of any scale.
+       · `sm` buttons 38px → 44px. 38 was below the floor — this is a fix, not a regression.
+     Desktop rendering is unchanged. */
+
+  /* Button gap. 0.13.0 gave `Button` `inline-flex` and a gap of its own, which is what the
+     upload button was writing at its call site (#398). The old value was 7px; `2xs` is 8px,
+     the nearest step, and it is what that call site already used. */
+  --spacing-x-slot-button-gap: var(--spacing-x-2xs);
 
   /* Alert padding, composed — the old rule was 13px vertical and 15px horizontal, and one
      value for all four sides cannot say that. Each lands within 1px of a step. */
@@ -253,6 +270,12 @@
      should grow a step is upstream's call; measuring it wants computed styles, not classes. */
   --text-x-slot-button-size: var(--text-sm);
   --text-x-slot-choice-size: var(--text-sm);
+
+  /* `sm` buttons shipped one step below `md` here — `text-xs`, 0.75rem. Until 0.13.0 the kit
+     had one font slot against two padding slots, so both sizes rendered alike; the slot pair
+     is symmetric now (#398). The kit's default is `inherit`, which would put `sm` at body
+     size — larger than `md`. */
+  --text-x-slot-button-sm-size: var(--text-xs);
 
   --spacing-x-slot-control-pad-y: var(--spacing-x-2xs);
   --spacing-x-slot-control-pad-x: var(--spacing-x-xs);

--- a/frontend/src/shared/ui/theme/themes/default.css
+++ b/frontend/src/shared/ui/theme/themes/default.css
@@ -239,7 +239,12 @@
 
   /* Button gap. 0.13.0 gave `Button` `inline-flex` and a gap of its own, which is what the
      upload button was writing at its call site (#398). The old value was 7px; `2xs` is 8px,
-     the nearest step, and it is what that call site already used. */
+     the nearest step, and it is what that call site already used.
+
+     🟢 A preference, not a repair. The kit ships a default of `3xs` (4px) — this line is an
+     override, and removing it renders at 4px rather than at nothing. Stated because the
+     slot below it is the opposite case, and a reader skimming two adjacent overrides will
+     otherwise read them as the same kind of thing. */
   --spacing-x-slot-button-gap: var(--spacing-x-2xs);
 
   /* Alert padding, composed — the old rule was 13px vertical and 15px horizontal, and one
@@ -273,8 +278,13 @@
 
   /* `sm` buttons shipped one step below `md` here — `text-xs`, 0.75rem. Until 0.13.0 the kit
      had one font slot against two padding slots, so both sizes rendered alike; the slot pair
-     is symmetric now (#398). The kit's default is `inherit`, which would put `sm` at body
-     size — larger than `md`. */
+     is symmetric now (#398).
+
+     🔴 Required here, and the reason is conditional. Both slots default to `inherit`, so a
+     product that overrides neither gets one size for both and nothing is wrong. The
+     inversion needs a product that overrides `md` and not `sm` — which is this one, three
+     lines up. Then `md` is 13px and `sm` inherits the 14px body: the smaller button renders
+     larger. Deleting this line is what produces that, not the kit's default on its own. */
   --text-x-slot-button-sm-size: var(--text-xs);
 
   --spacing-x-slot-control-pad-y: var(--spacing-x-2xs);


### PR DESCRIPTION
Closes #402

`@hideyukimori/nene2-ui` の floor を `^0.11.0` → **`^0.14.0`**。
フリート baseline と npm latest がともに 0.14.0 で、**本リポだけ3マイナー遅れていた**。

⚠️ **0.12.0 と 0.13.0 は npm 欠番**（3本連続マージ→publish 1回）。publish の失敗ではない。

## 実測（2026-08-24 16:4x JST）

| 測ったもの | 値 |
|---|---|
| `npm view @hideyukimori/nene2-ui version` | **0.14.0** |
| 公開されている版 | `0.2.0 / 0.3.0 / 0.4.0 / 0.6.0 / 0.7.0 / 0.8.0 / 0.11.0 / 0.14.0` |
| 変更前の floor（HEAD `04f2c63`） | `^0.11.0` |
| フリート baseline の floor | `^0.14.0` |
| `npm run check` | **全緑**（43ファイル / 248テスト） |

## 外した暫定対応3件

いずれも「キットが持つべきものを呼び出し側で書いていた」箇所。

| 場所 | 書いていたもの | 代わりに |
|---|---|---|
| `SettingsPage` | `className={retentionWarn ? 'border-warn ring-3 ring-warn-soft' : undefined}` | キットの `data-warn`（0.12.0） |
| `SettingsPage` | `id` を持たせるためだけの `<div>` で `InlineAlert` を包む | `InlineAlert` の `id`（0.12.0） |
| `DocumentsPage` | `className="inline-flex items-center gap-x-2xs"` | BASE の `inline-flex` ＋ gap スロット（0.13.0） |

## 置いたスロット2本 — ただし性質が違う（2026-08-24 17:0x 追記で分離）

**初版はこの2本を「どちらも置かないと描画が動く」と1つの表にまとめていた。**
どちらの行も個別には正しい（既定値も両方書いてある）が、**片方はキット側の欠陥で、
もう片方はこちらの好み**なので、束ねると読み手が同じ重さで受け取る。分ける。

### ① `--text-x-slot-button-sm-size` — 🔴 置かないと反転する

| | md | sm | |
|---|---|---|---|
| どちらも既定（`inherit`） | 継承 | 継承 | 🟢 同じ大きさ。反転しない |
| **md だけ上書き** | 13px | 継承 **14px** | 🔴 **sm が md より大きい** |
| **両方上書き** | 13px | **12px** | 🟢 ← この PR |

🔑 **既定だけでは壊れない。壊れるのは `md` を上書きした艦で、本リポはそれに当たる**
（`--text-x-slot-button-size: var(--text-sm)` を持っている）。だから本リポでは必須。
**キット側の論点としては「将来の消費者」の話**で、この PR で直すものではない。

### ② `--spacing-x-slot-button-gap` — 🟢 欠陥ではなく好みの差

| | 値 |
|---|---|
| キット既定 | `var(--spacing-x-3xs)` = **4px**（欠落ではない・実在する） |
| 本リポ | `var(--spacing-x-2xs)` = **8px** |
| 載せ替え前の実値 | 7px（`gap-1.75`） |

置かなくても 4px で描画される。8px にしているのは**呼び出し側が書いていた値に合わせるため**で、
**キット側に直すものは無い。**

🔴 **`--spacing-x-slot-control-touch-min` は上書きしていない。** 44px は WCAG 2.5.5 と
Apple HIG の下限＝**端末の制約であって意匠ではない**。`--text-x-slot-control-touch-size`
と同じ種類の数字。

## 🔴 施主に見てほしい1点 — タッチ端末でボタンの高さが動く

**デスクトップは不変。** タッチ端末（スマホ・タブレット）でのみ:

| | 変更前 | 変更後 | |
|---|---:|---:|---|
| `md` ボタン | 46px | **44px** | 旧 46 は `max-md:min-h-11.5` というその場の値で、どの段でもない |
| `sm` ボタン | 38px | **44px** | 🔴 **38px は下限割れだった**。これは是正 |

`md` が 2px 縮むので、意図どおりか確認してください。**44 は規格を満たす最小値**で、
キットが 48（profile / deal の先例）を焼き込まずに 44 を選んだのは
「大きさを押し付けない」ためです。48 が要るならスロットを上げれば済みます。

## 🔴 検知器を壊して確かめた

前回この箇所は **`aria-invalid` という代理を検査していたため、実装が上流へ移って
塗りが消えても緑のままだった**（キット側リリースノートにも同じ指摘がある）。
今回は2つを**別々に**主張する:

1. **本リポが印を付ける** — `data-warn` が input に在る
2. **キットがその印を塗る** — `data-[warn]:` のクラスが input に在る

| 変異 | 結果 |
|---|---|
| 本リポが `data-warn` を出さなくなる | 🔴 **赤**（1 failed） |
| キットが `VALIDITY_CLASS` の塗りを落とす | 🔴 **赤**（`expected '…' to contain 'data-[warn]:border-…'`） |
| 復元 | 🟢 緑（2 passed） |

⚠️ どちらも computed style には届かない（jsdom に CSS は無い）。届くのは
**前回実際に signal を消した2つの編集**で、そこは押さえた。

## この PR が閉じないもの

#397 / #398 / #399 / #390 の可否判定は**この PR とは別**に、実ブラウザ突合を
やってから行います（0.14.0 は計算済みスタイルを変えるので、上げてから測るのが正しい順序）。

## 手順の記録

- `.mcp.json` は作業ツリーで modified のまま。**明示パスで stage** した（過去に事故1件・#374）。

