### PR TITLE
docs: 死んだ `docs/todo/current.md` 参照6箇所を private の現在地へ向け直す（#380）

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -21,7 +21,7 @@ The following documents exist now and must be read before contributing:
 | Sibling product boundaries | `docs/integrations/sibling-products.md` |
 | Workflow | `docs/workflow.md` |
 | Roadmap | `docs/roadmap.md` |
-| Current work | `docs/todo/current.md` |
+| Current work | private `nene-origin/internal-docs/vault/todo/current.md` |
 
 The following documents are also available:
 
@@ -48,7 +48,8 @@ Follow [`docs/workflow.md`](workflow.md) — inherited from [NENE2](https://gith
 4. Push, open PR with `Closes #number`, merge after checks — **do not push directly to `main`**.
 
 - Use one branch and one PR per focused work unit.
-- Keep `docs/milestones/`, `docs/roadmap.md`, and `docs/todo/current.md` updated when direction changes.
+- Keep `docs/milestones/` and `docs/roadmap.md` updated when direction changes, and the
+  current work board in the private `nene-origin/internal-docs/vault/todo/current.md`.
 - Explain intent, impact, verification, and remaining risk in PRs.
 - Prefer documentation that helps the next developer or AI agent decide what to do without rereading chat history.
 

--- a/docs/review/docs-policy.md
+++ b/docs/review/docs-policy.md
@@ -30,7 +30,8 @@ Use for: workflow changes, ADR additions, roadmap updates, Cursor rules, AGENTS.
 
 - [ ] `docs/roadmap.md` is updated if the change affects phases.
 - [ ] `docs/milestones/` is updated if an acceptance criterion changes.
-- [ ] `docs/todo/current.md` reflects current in-progress and next items.
+- [ ] The current work board (private `nene-origin/internal-docs/vault/todo/current.md`)
+      reflects current in-progress and next items.
 
 ## Language policy (ADR 0008)
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -7,7 +7,8 @@ See also: `docs/inheritance-from-nene2.md`.
 ## Standard Flow
 
 1. Create or reuse a focused GitHub Issue.
-2. Confirm context in `docs/roadmap.md`, `docs/milestones/`, and `docs/todo/current.md`.
+2. Confirm context in `docs/roadmap.md`, `docs/milestones/`, and the current work board
+   (private `nene-origin/internal-docs/vault/todo/current.md`).
 3. Create a branch from `main` named like `type/issue-number-summary`.
 4. Implement the smallest useful change.
 5. Update docs, roadmap, milestone, or TODO files when the decision or state changes.
@@ -45,7 +46,10 @@ Do not commit directly to `main`.
 
 - `docs/roadmap.md`: long-lived direction and phases
 - `docs/milestones/`: medium-sized goals and acceptance criteria
-- `docs/todo/current.md`: current task board and handoff notes
+- private `nene-origin/internal-docs/vault/todo/current.md`: current task board and handoff
+  notes. 🔴 Not in this repo — the operational logs (todo, daily) moved to the private
+  receptacle in #267 (P3), and this line pointed at the empty path for 37 days afterwards
+  (#380). If a path here does not resolve, that is the bug, not your checkout.
 - `docs/adr/`: major architecture decisions
 - `docs/inheritance-from-nene2.md`: NENE2 governance inheritance map
 
@@ -72,4 +76,5 @@ If a user explicitly says investigation only, no commit, no PR, or another narro
 
 ## Initial Issues Backlog
 
-Use GitHub Issues for all work. Current work board: `docs/todo/current.md`. No direct `main` commits.
+Use GitHub Issues for all work. Current work board: private
+`nene-origin/internal-docs/vault/todo/current.md`. No direct `main` commits.


### PR DESCRIPTION
Closes #380

`docs/todo/` は #267（P3）で private 受け皿へ移設され、**この repo には存在しない**。
それでも**導線文書3ファイル・6箇所**が指し続けていた。

## 実測（2026-08-24 17:0x JST）

**修正前**（`grep -rn 'docs/todo/current.md' --include='*.md' .`）:

| ファイル | 行 |
|---|---|
| `docs/CONTRIBUTING.md` | 24（「どこを読むか」の表）・51 |
| `docs/workflow.md` | 10・48・75 |
| `docs/review/docs-policy.md` | 33 |
| `docs/security/2026-07-14-redteam-assessment.md` | 26 ← **歴史記述・対象外** |

**修正後**: 残るのは **歴史記述1件のみ**（受入条件③を満たす）。

`frontend/stylelint.config.js:5` は **#356 の射程**なので触っていない（`--include='*.md'` の外）。

## 言い回しは既存に揃えた

`CLAUDE.md` / `AGENTS.md` / `README.md:155` は既に repoint 済みなので、
その形（**private** `nene-origin/internal-docs/vault/todo/current.md`）をそのまま使った。
新しい書き方を発明していない。

## なぜ37日間残ったか — 判断ではなく出口が無かった

#267 は**誤っていない**。clickable link を先に潰したのは正しい優先順位で
（`README.md:155` と `2026-review-3-preprod-package.md:141` は正しく repoint されている）、
prose 言及を「follow-up 可」と置いたのも妥当。

🔴 **欠けたのは出口。** 「follow-up 可」に対して follow-up issue が**一度も立たず**、
#267 のクローズと同時に消えた。

🔑 **先送りは検出より始末が悪い。** 検出は未処理として目に付くが、
**先送りは処理済みの Issue の中に埋まる**。

## 検査は足していない

`docs/workflow.md` の「Local Project Memory」節に、**次に読む人が自分のチェックアウトを
疑わずに済むよう**「パスが解決しないならそれがバグ」と書き添えるところまで。

CI の grep 等は足していません（**08-15 施主方針＝検査を増やして足かせにしない**）。
🟡 **ただしこれは「次も37日気づかない」を許す選択**でもあるので、
検知器が要ると施主が判断するなら別 Issue で。この PR では方針に従っています。
