### PR TITLE
fix(css): W1 で既定のまま残っていたボタンのスロット3つを埋める（#407）

### DIFF
--- a/frontend/src/shared/ui/theme/themes/default.css
+++ b/frontend/src/shared/ui/theme/themes/default.css
@@ -287,6 +287,29 @@
      larger. Deleting this line is what produces that, not the kit's default on its own. */
   --text-x-slot-button-sm-size: var(--text-xs);
 
+  /* 🔴 Three slots the migration left at the kit's defaults, found by comparing computed
+     styles against the production build in a real browser (#404 harness, 2026-08-24). Each
+     was carried by this product's own `Button` before W1 and is in the git history of
+     `shared/ui/primitives/Button.tsx` at `fcb65a6~1`; none of the four checks in
+     `npm run check` looks at a colour or a weight, so all three were green for a day.
+
+       weight   `font-semibold` in BASE            600 → 500   every button on every screen
+       fg       `text-x-ink-deep` on secondary     24% → 31%
+       border   `border-border-strong` on secondary 76% → 89%
+
+     ⚠️ The weight one is the widest: it is in BASE, so it reaches all 39 buttons, and a
+     500 next to a 600 is the kind of difference that reads as "this looks a bit off" rather
+     than as a defect with a name. */
+  --font-weight-x-slot-button: var(--font-weight-semibold);
+  --color-x-slot-button-secondary-fg: var(--color-x-ink-deep);
+  --color-x-slot-button-secondary-border: var(--color-border-strong);
+
+  /* 🔴 NOT set: `--color-x-slot-button-ghost-fg`. The pre-W1 ghost variant was
+     `text-text-muted` against the kit's `text-text-primary`, so the slot would be wrong if
+     the variant were used — measured 2026-08-24, it is used **zero** times. Setting a slot
+     for a variant nothing renders would be a value no one can check. Recorded here so the
+     next person to write `variant="ghost"` finds the number rather than rediscovering it. */
+
   --spacing-x-slot-control-pad-y: var(--spacing-x-2xs);
   --spacing-x-slot-control-pad-x: var(--spacing-x-xs);
 


### PR DESCRIPTION
Closes #407

実ブラウザで**本番と手元の計算済みスタイルを突合**して見つけた回帰3件。
どれも載せ替え前の `Button` が持っていた値で、`fcb65a6~1` の
`frontend/src/shared/ui/primitives/Button.tsx` に現物がある。

## 実測（本番 `vault.ayane.co.jp` vs 手元 nene2-ui 0.14.0・1440×1000・en）

| 対象 | プロパティ | 本番 | 手元（修正前） | 出所 |
|---|---|---|---|---|
| **全ボタン**（4箇所で検出） | `font-weight` | **600** | **500** | BASE の `font-semibold` |
| secondary（Clear） | `color` | `oklch(0.24 …)` | `oklch(0.31 …)` | `text-x-ink-deep` |
| secondary（Clear） | `border-color` | `oklch(0.76 …)` | `oklch(0.89 …)` | `border-border-strong` |

⚠️ **太さが最も広い。** BASE に在るので **39箇所すべて**に及ぶ。
そして **500 と 600 の差は「なんとなく違う」としか見えない**ので、
名前のついた不具合として報告されない類のもの。

## 直したもの

```css
--font-weight-x-slot-button: var(--font-weight-semibold);
--color-x-slot-button-secondary-fg: var(--color-x-ink-deep);
--color-x-slot-button-secondary-border: var(--color-border-strong);
```

## 効果の実測（2026-08-24 08:48 UTC / 17:48 JST）

ハーネス再走で**当該3項目が差分表から消えた**:

| | 修正前 | 修正後 |
|---|---:|---:|
| 一致 | 159 | **165** |
| 差 | 30 | **24** |

`npm run check` 全緑（43ファイル / 248テスト）。

## 🔑 なぜ検査4本を素通りしたか

`source-probe` / `slot-values` / `scale-not-redefined` / `control-touch-floor` は
どれも「**スロットがスケールを参照しているか**」を見る。
**スロットを置かなかった場合は射程の外**で、既定値が使われるだけなので全部通る。

⇒ **不在は違反として表現されない。** 08-15 の drain で学んだ
「正しさが不在で表現されると素直な回帰ガードから漏れる」の**逆向き**。
捕まえたのは静的検査ではなく**実ブラウザの突合**だった。

## 設定しなかったもの（測ったうえで）

`--color-x-slot-button-ghost-fg` は**置かない**。載せ替え前は `text-text-muted`、
キット既定は `text-text-primary` で確かに違うが、**`variant="ghost"` の使用実測は 0箇所**。
**描画されない値は誰も検算できない。** 数字だけテーマのコメントに残したので、
次に `variant="ghost"` を書く人は再発見せずに済む。

## 残る差24件の内訳（この PR の射程外）

| | 件数 | 判断 |
|---|---:|---|
| `padding` 15→16px / `gap` 7→8px / `width` ±1〜4px | 19 | 🟢 段への丸め（施主裁定済み） |
| choice ラベルの `display: inline-flex → flex` | 2 | 🟢 `Stack`（flex コンテナ）の子が blockify される標準挙動。`align="start"` があるので**幅は一致**しており実害なし |
| `field hint` の `line-height` | 1 | 🟢 段への丸め |
| **primary の `box-shadow`（`shadow-sm` → `none`）** | 2 | 🔴 **キット側にスロットが無い**（`shadow-*x-slot*` は 0件）。別 Issue で上流へ |
