### PR TITLE
test(e2e): DOM から外れた要素を差分ではなく「測れなかった」として扱う（#413）

### DIFF
--- a/docs/qa/kit-parity-latest.json
+++ b/docs/qa/kit-parity-latest.json
@@ -1,18 +1,13 @@
 {
-  "measuredAt": "2026-08-24T09:36:40.420Z",
+  "measuredAt": "2026-08-24T09:48:16.298Z",
   "productionKitClasses": 0,
   "localKitClasses": 71,
-  "matched": 186,
-  "differing": 53,
-  "unresolved": [],
+  "matched": 192,
+  "differing": 32,
+  "unresolved": [
+    "audit / sm button (Previous) — local did not yield a measurement"
+  ],
   "rows": [
-    {
-      "screen": "documents",
-      "element": "primary button (Upload)",
-      "property": "font-weight",
-      "production": "600",
-      "local": "500"
-    },
     {
       "screen": "documents",
       "element": "primary button (Upload)",
@@ -32,7 +27,7 @@
       "element": "primary button (Upload)",
       "property": "width",
       "production": "163px",
-      "local": "166px"
+      "local": "167px"
     },
     {
       "screen": "documents",
@@ -40,27 +35,6 @@
       "property": "padding",
       "production": "8px 15px",
       "local": "8px 16px"
-    },
-    {
-      "screen": "documents",
-      "element": "secondary button (Clear)",
-      "property": "font-weight",
-      "production": "600",
-      "local": "500"
-    },
-    {
-      "screen": "documents",
-      "element": "secondary button (Clear)",
-      "property": "color",
-      "production": "oklch(0.24 0.02 256)",
-      "local": "oklch(0.31 0.02 256)"
-    },
-    {
-      "screen": "documents",
-      "element": "secondary button (Clear)",
-      "property": "border-color",
-      "production": "oklch(0.76 0.013 78)",
-      "local": "oklch(0.89 0.009 83)"
     },
     {
       "screen": "documents",
@@ -82,13 +56,6 @@
       "property": "padding",
       "production": "8px 15px",
       "local": "8px 16px"
-    },
-    {
-      "screen": "documents",
-      "element": "submit button (Search)",
-      "property": "font-weight",
-      "production": "600",
-      "local": "500"
     },
     {
       "screen": "documents",
@@ -134,87 +101,10 @@
     },
     {
       "screen": "audit",
-      "element": "sm button (Previous)",
-      "property": "font-weight",
-      "production": "600",
-      "local": "500"
-    },
-    {
-      "screen": "audit",
-      "element": "sm button (Previous)",
-      "property": "line-height",
-      "production": "18.6px",
-      "local": "16px"
-    },
-    {
-      "screen": "audit",
-      "element": "sm button (Previous)",
-      "property": "color",
-      "production": "oklch(0.24 0.02 256)",
-      "local": "oklch(0.31 0.02 256)"
-    },
-    {
-      "screen": "audit",
-      "element": "sm button (Previous)",
-      "property": "border-color",
-      "production": "oklch(0.76 0.013 78)",
-      "local": "oklch(0.89 0.009 83)"
-    },
-    {
-      "screen": "audit",
-      "element": "sm button (Previous)",
-      "property": "gap",
-      "production": "7px",
-      "local": "8px"
-    },
-    {
-      "screen": "audit",
-      "element": "sm button (Previous)",
-      "property": "width",
-      "production": "73px",
-      "local": "75px"
-    },
-    {
-      "screen": "audit",
-      "element": "sm button (Previous)",
-      "property": "height",
-      "production": "30.5938px",
-      "local": "26px"
-    },
-    {
-      "screen": "audit",
-      "element": "sm button (Previous)",
-      "property": "padding",
-      "production": "5px 11px",
-      "local": "4px 12px"
-    },
-    {
-      "screen": "audit",
-      "element": "sm button (Next)",
-      "property": "font-weight",
-      "production": "600",
-      "local": "500"
-    },
-    {
-      "screen": "audit",
       "element": "sm button (Next)",
       "property": "line-height",
       "production": "18.6px",
       "local": "16px"
-    },
-    {
-      "screen": "audit",
-      "element": "sm button (Next)",
-      "property": "color",
-      "production": "oklch(0.24 0.02 256)",
-      "local": "oklch(0.31 0.02 256)"
-    },
-    {
-      "screen": "audit",
-      "element": "sm button (Next)",
-      "property": "border-color",
-      "production": "oklch(0.76 0.013 78)",
-      "local": "oklch(0.89 0.009 83)"
     },
     {
       "screen": "audit",
@@ -228,7 +118,7 @@
       "element": "sm button (Next)",
       "property": "width",
       "production": "51px",
-      "local": "52px"
+      "local": "53px"
     },
     {
       "screen": "audit",
@@ -247,37 +137,9 @@
     {
       "screen": "audit",
       "element": "secondary button (Clear)",
-      "property": "font-weight",
-      "production": "600",
-      "local": "500"
-    },
-    {
-      "screen": "audit",
-      "element": "secondary button (Clear)",
-      "property": "color",
-      "production": "oklch(0.24 0.02 256)",
-      "local": "oklch(0.31 0.02 256)"
-    },
-    {
-      "screen": "audit",
-      "element": "secondary button (Clear)",
-      "property": "border-color",
-      "production": "oklch(0.76 0.013 78)",
-      "local": "oklch(0.89 0.009 83)"
-    },
-    {
-      "screen": "audit",
-      "element": "secondary button (Clear)",
       "property": "gap",
       "production": "7px",
       "local": "8px"
-    },
-    {
-      "screen": "audit",
-      "element": "primary button (Search)",
-      "property": "font-weight",
-      "production": "600",
-      "local": "500"
     },
     {
       "screen": "audit",
@@ -345,13 +207,6 @@
     {
       "screen": "settings",
       "element": "save button",
-      "property": "font-weight",
-      "production": "600",
-      "local": "500"
-    },
-    {
-      "screen": "settings",
-      "element": "save button",
       "property": "box-shadow",
       "production": "oklch(0.28 0.02 256 / 0.07) 0px 1px 2px 0px",
       "local": "none"
@@ -368,7 +223,7 @@
       "element": "save button",
       "property": "width",
       "production": "114px",
-      "local": "115px"
+      "local": "116px"
     },
     {
       "screen": "settings",

--- a/tests/e2e/live/batch6-kit-parity.spec.ts
+++ b/tests/e2e/live/batch6-kit-parity.spec.ts
@@ -200,6 +200,17 @@ async function read(page: Page, probes: Probe[]): Promise<ScreenReading> {
     try {
       out[probe.name] = await page.locator(probe.selector).first().evaluate(
         (node, props: string[]) => {
+          // 🔴 A detached node is not a measurement. `getComputedStyle` returns empty strings
+          // for an element that is no longer in the document, and `locator.evaluate` resolves
+          // the element before it runs — so a re-render in between leaves the handle pointing
+          // at the old node and the call succeeds with nothing in it. No exception, so the
+          // catch below never sees it, and nine empty values line up next to real ones as if
+          // the whole component differed (measured 2026-08-24 on `sm button (Previous)`).
+          //
+          // ⚠️ Deliberately not retried. That this happened is itself information — a screen
+          // that re-renders under the probe is worth knowing about, and quietly taking the
+          // measurement again erases it.
+          if (!(node as Element).isConnected) return null;
           const cs = getComputedStyle(node as Element);
           const m: Record<string, string> = {};
           for (const p of props) m[p] = cs.getPropertyValue(p).trim();
@@ -508,8 +519,10 @@ test('VLT-K1-01: kit parity — production vs local, computed styles', async ({ 
       const pm = p[probeDef.name];
       const lm = l[probeDef.name];
       if (pm === null || pm === undefined || lm === null || lm === undefined) {
+        // "matched nothing" covers both a selector that found no element and one whose element
+        // had gone by the time it was read — from here they are the same fact: no measurement.
         unresolved.push(
-          `${screen.name} / ${probeDef.name} — ${pm == null ? 'production' : ''}${pm == null && lm == null ? ' and ' : ''}${lm == null ? 'local' : ''} matched nothing`,
+          `${screen.name} / ${probeDef.name} — ${pm == null ? 'production' : ''}${pm == null && lm == null ? ' and ' : ''}${lm == null ? 'local' : ''} did not yield a measurement`,
         );
         continue;
       }


### PR DESCRIPTION
Closes #413

差分表に**空の値が9行**並んでいた。差ではなく、**DOM から外れた要素を測ったもの**。

## 実測（2026-08-24 09:44・main）

```
audit | sm button (Previous) | font-size        | prod=12px                  | local=
audit | sm button (Previous) | font-weight      | prod=600                   | local=
audit | sm button (Previous) | line-height      | prod=18.6px                | local=
audit | sm button (Previous) | color            | prod=oklch(0.24 0.02 256)  | local=
audit | sm button (Previous) | background-color | prod=oklch(0.994 0.004 83) | local=
audit | sm button (Previous) | border-color     | prod=oklch(0.76 0.013 78)  | local=
audit | sm button (Previous) | height           | prod=30.5938px             | local=
audit | sm button (Previous) | border-width     | prod=1px                   | local=
audit | sm button (Previous) | border-radius    | prod=4px                   | local=
```

隣の `(Next)` は**同じ画面・同じ部品**で正しく測れている。部品の問題ではない。

## 原因

`getComputedStyle()` は**接続されていない要素に空文字を返す**。
`locator.evaluate()` は要素を解決してから評価するので、その間に React が再描画すると
**ハンドルは detach された古いノードを指す。例外は出ない。**

## 🔴 3つ目の変種

このファイルは「照合できなかった」と「差が無かった」を区別するために書かれている
（`unresolved` を別枠で出す設計）。ところが **detach は `unresolved` にも入らない**
——`read()` は例外を捕まえて `null` にするが、**例外が起きていない**ので素通りする。

| | measured nothing が何に見えたか |
|---|---|
| ① ハング・30秒タイムアウト | **still working** |
| ② 別ビルドを測った差分表37行 | **findings** |
| ③ **detach された要素の空文字** | **differences** ← 本 PR |

③は**本物の差の隣に並ぶ**ので、表を読む人は「この部品は全部違う」と読む。

## 直したこと

`node.isConnected` を見て、外れていたら `null` を返す（＝`unresolved` へ落ちる）。
**空文字は測定結果ではない。**

⚠️ **リトライは足していない。** detach が起きたこと自体が情報で、
黙って取り直すと「その画面は測りにくい」という事実が消える。

## 🔴 壊して確かめた

| 変異 | 結果 |
|---|---|
| `sm button (Next)` だけを読む直前に `remove()` | 🔴 **`unresolved` に落ち、rows から消えた**（差 47 → 27） |
| 変異を戻す | 🟢 一致 **192** / 差 **32**・**空の値を持つ行 0**・`unresolved` は自然発生の1件のみ |

⚠️ 最初の変異は**全 probe を `remove()`** したため **rail ごと消え**、
別の検査（rail のラベル不一致で実在ラベル一覧を投げる）が発火した。
⇒ **変異は検証したい経路だけに当てる。** 広く壊すと、どの検査が反応したのか分からない。
