### PR TITLE
feat(frontend): .card をキットの Card へ載せ替える（#417・allowlist 49→48）

### DIFF
--- a/frontend/registries.jsonc
+++ b/frontend/registries.jsonc
@@ -16,7 +16,6 @@
         ".avatar",
         ".b",
         ".body",
-        ".card",
         ".cell-title",
         ".center-card",
         ".chev-cell",

--- a/frontend/src/features/document-search/ui/DocumentSearchForm.tsx
+++ b/frontend/src/features/document-search/ui/DocumentSearchForm.tsx
@@ -26,7 +26,11 @@ export function DocumentSearchForm({
       onSubmit={(e) => {
         void onSubmit(e);
       }}
-      className="card p-x-md"
+      /* Not the kit's Card: it renders a `<div>` and this is the search form itself.
+         The four declarations of the retired `.card` rule are spelled out instead — the
+         same drain the class would have had, done at the one call site that cannot take
+         the component (#417). */
+      className="bg-surface-raised border border-border rounded-md shadow-sm p-x-md"
     >
       <Stack gap="sm">
         <Grid cols={{ base: 1, sm: 2 }} gap="sm">

--- a/frontend/src/pages/AuditPage.tsx
+++ b/frontend/src/pages/AuditPage.tsx
@@ -1,6 +1,6 @@
 import {
-  Box,
   Button,
+  Card,
   EmptyState,
   FormField,
   Grid,
@@ -383,7 +383,7 @@ export function AuditPage() {
         <p className="text-text-muted text-sm max-w-lede">{t('audit_event.list.lede')}</p>
       </Stack>
 
-      <Box className="card" pad="md">
+      <Card raised pad="md">
         <Stack gap="sm">
           <Grid cols={3} gap="sm">
             <FormField
@@ -429,14 +429,14 @@ export function AuditPage() {
             </Button>
           </Stack>
         </Stack>
-      </Box>
+      </Card>
 
       {isError && <InlineAlert tone="danger">{t('common.status.error')}</InlineAlert>}
 
       {isLoading ? (
         <EmptyState message={t('common.status.loading')} />
       ) : (
-        <div className="card shadow-none">
+        <Card pad="none">
           {events.length === 0 ? (
             <EmptyState message={t('audit_event.list.empty')} />
           ) : (
@@ -515,7 +515,7 @@ export function AuditPage() {
             previousLabel={t('common.buttons.previous')}
             nextLabel={t('common.buttons.next')}
           />
-        </div>
+        </Card>
       )}
 
       <AuditDetailDrawer

--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -1,4 +1,4 @@
-import { Button, EmptyState, InlineAlert, Stack } from '@hideyukimori/nene2-ui';
+import { Button, Card, EmptyState, InlineAlert, Stack } from '@hideyukimori/nene2-ui';
 import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useDocumentById, fetchDocumentBlob, useOcrSuggest } from '@/entities/document';
@@ -169,7 +169,7 @@ export function DocumentDetailPage() {
             </Stack>
           </div>
 
-          <section className="card p-4.5">
+          <Card raised pad="md">
             <div className="flex items-center gap-2 mb-stack-md">
               <span className="inline-block w-0.75 h-3.75 bg-x-brass rounded-px flex-none" />
               <h2 className="text-h2 font-semibold tracking-tight text-x-ink-deep flex items-center gap-2.25">
@@ -219,9 +219,9 @@ export function DocumentDetailPage() {
                 </div>
               )}
             </dl>
-          </section>
+          </Card>
 
-          <section className="card p-4.5">
+          <Card raised pad="md">
             <div className="flex items-center gap-2 mb-stack-md">
               <span className="inline-block w-0.75 h-3.75 bg-x-brass rounded-px flex-none" />
               <h2 className="text-h2 font-semibold tracking-tight text-x-ink-deep flex items-center gap-2.25">
@@ -238,9 +238,9 @@ export function DocumentDetailPage() {
                 <dd className="font-mono zero-slash break-all">{doc.file_sha256}</dd>
               </div>
             </dl>
-          </section>
+          </Card>
 
-          <section className="card p-4.5">
+          <Card raised pad="md">
             <div className="flex items-center gap-2 mb-stack-md">
               <span className="inline-block w-0.75 h-3.75 bg-x-brass rounded-px flex-none" />
               <h2 className="text-h2 font-semibold tracking-tight text-x-ink-deep flex items-center gap-2.25">
@@ -248,7 +248,7 @@ export function DocumentDetailPage() {
               </h2>
             </div>
             <DocumentHistoryTable events={history?.audit_events ?? []} />
-          </section>
+          </Card>
         </>
       )}
 

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -1,4 +1,4 @@
-import { Button, EmptyState, Icon, InlineAlert, Stack } from '@hideyukimori/nene2-ui';
+import { Button, Card, EmptyState, Icon, InlineAlert, Stack } from '@hideyukimori/nene2-ui';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useDocumentSearch, DocumentSearchForm, DocumentTable } from '@/features/document-search';
@@ -62,7 +62,7 @@ export function DocumentsPage() {
       {isLoading ? (
         <EmptyState message={t('common.status.loading')} />
       ) : (
-        <div className="card shadow-none">
+        <Card pad="none">
           <DocumentTable
             documents={documents}
             onSelectDocument={(id) => {
@@ -83,7 +83,7 @@ export function DocumentsPage() {
             previousLabel={t('common.buttons.previous')}
             nextLabel={t('common.buttons.next')}
           />
-        </div>
+        </Card>
       )}
 
       {showUpload && (

--- a/frontend/src/pages/ExportPage.tsx
+++ b/frontend/src/pages/ExportPage.tsx
@@ -1,6 +1,6 @@
 import {
-  Box,
   Button,
+  Card,
   Checkbox,
   FormField,
   Grid,
@@ -84,7 +84,7 @@ export function ExportPage() {
         <p className="text-text-muted text-sm max-w-lede">{t('export.description')}</p>
       </Stack>
 
-      <Box className="card" pad="md">
+      <Card raised pad="md">
         <Stack gap="sm">
           <Grid cols={{ base: 1, sm: 2 }} gap="sm">
             <FormField id="export-date-from" label={t('export.form.date_from_label')}>
@@ -165,7 +165,7 @@ export function ExportPage() {
             </Button>
           </div>
         </Stack>
-      </Box>
+      </Card>
     </AppChrome>
   );
 }

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -103,7 +103,9 @@ export function SettingsPage() {
         <EmptyState message={t('common.status.loading')} />
       ) : (
         <form
-          className="card p-x-md"
+          /* `<form>`, so not the kit's Card (which is a `<div>`) — the retired `.card`
+             rule is spelled out here instead (#417). */
+          className="bg-surface-raised border border-border rounded-md shadow-sm p-x-md"
           onSubmit={(e) => {
             void form.handleSubmit((values) => {
               mutation.mutate({

--- a/frontend/src/pages/UsersPage.tsx
+++ b/frontend/src/pages/UsersPage.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  Card,
   EmptyState,
   FormField,
   InlineAlert,
@@ -223,7 +224,7 @@ export function UsersPage() {
       {isLoading ? (
         <EmptyState message={t('common.status.loading')} />
       ) : (
-        <div className="card shadow-none">
+        <Card pad="none">
           {users.length === 0 ? (
             <EmptyState message={t('user.list.empty')} />
           ) : (
@@ -269,7 +270,7 @@ export function UsersPage() {
             previousLabel={t('common.buttons.previous')}
             nextLabel={t('common.buttons.next')}
           />
-        </div>
+        </Card>
       )}
 
       {showCreate && (

--- a/frontend/src/shared/ui/theme/themes/default.components.css
+++ b/frontend/src/shared/ui/theme/themes/default.components.css
@@ -256,14 +256,6 @@
 
     /* ---- layout primitives ---- */
 
-    /* ---- cards / panels ---- */
-    .card {
-      background: var(--color-surface-raised);
-      border: 1px solid var(--color-border);
-      border-radius: var(--radius-md);
-      box-shadow: var(--shadow-sm);
-    }
-
     /* ---- buttons ---- */
 
     /* ---- forms ---- */

--- a/frontend/src/shared/ui/theme/themes/default.css
+++ b/frontend/src/shared/ui/theme/themes/default.css
@@ -255,6 +255,13 @@
   --radius-x-slot-button: var(--radius-x-xs); /* 4px — was `rounded-sm` */
   --radius-x-slot-alert: var(--radius-x-sm); /* 6px — was `rounded-md` */
 
+  /* 🔴 6px, not the kit's 8px default. The retired `.card` rule used `--radius-md` (6px);
+     the kit's `--radius-x-slot-card` points at `--radius-x-md`, which is 8px on the fleet's
+     scale. Left unset, migrating to the kit's `Card` rounds every panel 2px more — measured
+     on all seven of them, 2026-08-24 (#417). Same shape as the three button slots in #407:
+     the defect is not a wrong value, it is a slot nobody set. */
+  --radius-x-slot-card: var(--radius-x-sm);
+
   /* Control colours. Three of the four differ from the kit's defaults — measured against
      the pre-migration `FIELD_BASE` and confirmed in a real browser against production
      (#399). `bg` already matches, so it is not restated. */

--- a/tests/e2e/live/batch6-kit-parity.spec.ts
+++ b/tests/e2e/live/batch6-kit-parity.spec.ts
@@ -128,6 +128,14 @@ const SCREENS: Screen[] = [
       { name: 'choice box', selector: 'input[type="checkbox"]', props: [...BOX, 'accent-color'] },
       { name: 'field label', selector: 'form label:not(:has(input))', props: TYPE },
       { name: 'rail nav (own markup — control row)', selector: 'nav.rail-nav', props: [...FILL, 'width'] },
+      // 🔴 The card, probed before it is migrated. `.card` is one CSS rule of four
+      // declarations and the kit's `Card` carries all four in slots — but it is also
+      // `flex flex-col`, and a flex container blockifies its children. That is the same
+      // mechanism that produced a regression in wave 1 when a `<div>` became a `<Stack>`.
+      // Probing the card and the first thing inside it is what makes that measurable
+      // rather than a thing to be careful about.
+      { name: 'card (search form)', selector: 'form.card, .card', props: [...FILL, ...BOX] },
+      { name: 'card first child', selector: '.card > *', props: ['display', 'width', 'height'] },
     ],
   },
   {


### PR DESCRIPTION
④の一般則（施主承認・2026-08-24）——**キット部品で置き換えられるなら載せ替える。
drain は副産物としてついてくる。置き換えられないものだけ drain する。**——の1件目。

## なぜ `Card` が載せ替え側なのか

`.card` は **CSS 1ルール4宣言だけ**（`default.components.css`）:

```css
.card { background: var(--color-surface-raised); border: 1px solid var(--color-border);
        border-radius: var(--radius-md); box-shadow: var(--shadow-sm); }
```

キットの `Card` は4つとも**スロットで持ち**、さらに `pad` / `gap` / `raised` / `className` を受ける。
使用は **10箇所**。

🔑 **drain すると10箇所に utility を書き、そのあと結局載せ替えるなら同じ10箇所を2回触る。**
載せ替えれば **allowlist からも同時に落ちる**（49 → 48）。

## 🔴 ただし、キットの `Card` は `<div>` 固定でした

`as` / `component` prop は無く、`...rest` は `<div>` へ展開されるだけ。
⇒ **10箇所のうち2つは `<form>`** なので**載せ替えられません**。

⇒ **一般則は「クラス単位」ではなく「呼び出し箇所単位」で当たる。**
1つのクラスが、載せ替えられる箇所と drain すべき箇所に割れることがある。

| 形 | 数 | 対応 |
|---|---:|---|
| `<div className="card shadow-none">` | 3 | `<Card pad="none">`（`raised` 既定 false ＝影なし） |
| `<Box className="card" pad="md">` | 2 | `<Card raised pad="md">`（`Box` が未使用になり import も除去） |
| `<section className="card p-4.5">` | 3 | `<Card raised pad="md">` |
| **`<form className="card p-x-md">`** | **2** | 🔴 **載せ替え不可 → その場で drain**（4宣言を utility で明記） |

⚠️ `<section>` を `<div>` にしてよい根拠: **3つとも `aria-label` / `aria-labelledby` を持たない**。
名前の無い `<section>` は landmark として公開されないので、**意味論の損失は無い**（実測）。
⚠️ `<form>` は **onSubmit を持つフォーム本体**なので `<div>` にはできない。

## 🔴 実測で回帰を1件捕まえた（出荷前）

載せ替え**前後**の計算済みスタイルを、5画面・カード7枚・その子10個で突合:

| | |
|---|---|
| **`border-radius: 6px → 8px`** | 🔴 **全7枚**。`--radius-x-slot-card` 未設定＝キット既定（`--radius-x-md` = 8px）を拾っていた |

⇒ `--radius-x-slot-card: var(--radius-x-sm)`（6px）を設定して解消。
🔑 **#407 と同じ形**——**間違った値ではなく、誰も置かなかったスロット。**

## 実測（`--radius-x-slot-card` 設定後・2026-08-24 20:2x JST）

**一致 255 / 差 17。差は2種類だけ。**

| 差 | 件数 | 判定 |
|---|---:|---|
| `display: block → flex` ＋ `flex-direction: row → column` | 10 | 🟢 キットの `Card` が `flex flex-col`。**意図どおり** |
| `box-shadow` の**文字列形**（`shadow-sm` が ring プレースホルダを伴う／`none`） | 7 | 🟢 **描画は同一**（最終レイヤが一致・空レイヤは何も描かない） |

🔴 **子要素の差は 0。** 比較した子10個すべて、**寸法まで同一**
（例: `1082.00x284.98 → 1082.00x284.98`）。

⇒ **W1 で実際に踏んだ「`<div>`→`<Stack>` は無害でない」（flex コンテナが子を blockify する）は、
今回は発火しなかった。**「気をつける対象」ではなく**測る対象**にできた。

## 完了条件

- [x] 10箇所すべて処理（載せ替え8／drain 2）
- [x] `.card` を allowlist と CSS から除去（**49 → 48**）
- [x] 載せ替え前後の計算済みスタイル突合で、残る差が説明のつく2種だけ
- [x] `npm run check` 全緑
