### PR TITLE
chore(css): C5 drain — B群 .dl を utility へ（#430・allowlist 38→36）

### DIFF
--- a/frontend/registries.jsonc
+++ b/frontend/registries.jsonc
@@ -14,8 +14,6 @@
         ".avatar",
         ".cell-title",
         ".chev-cell",
-        ".col2",
-        ".dl",
         ".ic",
         ".out",
         ".pri",

--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -176,7 +176,7 @@ export function DocumentDetailPage() {
                 {t('document.detail.metadata_section')}
               </h2>
             </div>
-            <dl className="dl">
+            <dl className="grid grid-cols-2 gap-x-7 gap-y-4 max-sm:grid-cols-1 max-sm:gap-y-3.5 [&>div]:min-w-0 [&_dt]:text-2xs [&_dt]:text-text-muted [&_dt]:uppercase [&_dt]:tracking-meta [&_dt]:font-semibold [&_dt]:mb-0.75 [&_dd]:text-sm [&_dd]:leading-inherit [&_dd]:text-x-ink-deep">
               <div>
                 <dt>{t('document.metadata.transaction_date')}</dt>
                 <dd className="font-mono zero-slash">{formatDate(doc.transaction_date)}</dd>
@@ -204,7 +204,7 @@ export function DocumentDetailPage() {
                 <dd className="font-mono zero-slash">{formatDate(doc.retention_expires_at)}</dd>
               </div>
               {doc.tags.length > 0 && (
-                <div className="col2">
+                <div className="col-span-2 max-sm:col-auto">
                   <dt>{t('document.metadata.tags')}</dt>
                   <dd className="flex items-center gap-2 flex-wrap">
                     {doc.tags.map((tag) => (
@@ -228,12 +228,12 @@ export function DocumentDetailPage() {
                 {t('document.detail.file_section')}
               </h2>
             </div>
-            <dl className="dl">
+            <dl className="grid grid-cols-2 gap-x-7 gap-y-4 max-sm:grid-cols-1 max-sm:gap-y-3.5 [&>div]:min-w-0 [&_dt]:text-2xs [&_dt]:text-text-muted [&_dt]:uppercase [&_dt]:tracking-meta [&_dt]:font-semibold [&_dt]:mb-0.75 [&_dd]:text-sm [&_dd]:leading-inherit [&_dd]:text-x-ink-deep">
               <div>
                 <dt>{t('document.metadata.version_number')}</dt>
                 <dd className="font-mono zero-slash">{doc.version_number}</dd>
               </div>
-              <div className="col2">
+              <div className="col-span-2 max-sm:col-auto">
                 <dt>{t('document.metadata.file_sha256')}</dt>
                 <dd className="font-mono zero-slash break-all">{doc.file_sha256}</dd>
               </div>

--- a/frontend/src/shared/ui/theme/themes/default.components.css
+++ b/frontend/src/shared/ui/theme/themes/default.components.css
@@ -216,30 +216,6 @@
        carried the class (#369). */
 
     /* ---- definition lists ---- */
-    .dl {
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      column-gap: 28px;
-      row-gap: 16px;
-    }
-    .dl > div {
-      min-width: 0;
-    }
-    .dl dt {
-      font-size: var(--text-2xs);
-      color: var(--color-text-muted);
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-      font-weight: 600;
-      margin-bottom: 3px;
-    }
-    .dl dd {
-      font-size: var(--text-sm);
-      color: var(--color-x-ink-deep);
-    }
-    .dl .col2 {
-      grid-column: span 2;
-    }
 
     /* ---- callouts ---- */
 
@@ -430,13 +406,6 @@
     @media (max-width: 1023px) {
     }
     @media (max-width: 640px) {
-      .dl {
-        grid-template-columns: 1fr;
-        row-gap: 14px;
-      }
-      .dl .col2 {
-        grid-column: auto;
-      }
     }
 
     /* ============================================================


### PR DESCRIPTION
Closes #430

③（施主 GO）の **B群 `#368` 解禁**の1本目。`#368` の3件のうち `.dl` を落とす。
**allowlist 38 → 36。** `default.components.css` 22,731 → 22,094 bytes（7規則削除）。

## drain した規則

| セレクタ | 宣言 |
|---|---|
| `.dl` | grid / `1fr 1fr` / column-gap 28px / row-gap 16px |
| `.dl > div` | min-width 0 |
| **`.dl dt`** | `--text-2xs` / muted / uppercase / `0.05em` / 600 / mb 3px |
| **`.dl dd`** | `--text-sm` / ink-deep |
| `.dl .col2` | grid-column span 2 |
| `.dl`（`max-width: 640px`） | `1fr` / row-gap 14px |
| `.dl .col2`（同上） | grid-column auto |

`dt` / `dd` は**要素セレクタで10組以上**あるので、`[&_dt]:*` / `[&_dd]:*` の variant で書きました。

⚠️ **`.crumbs b` では呼び出し側の2要素に直接書いたのに、ここでは variant を使う**——
基準は**同じ意匠が既にどう書かれているか**です。`AuditPage.tsx:238` に
**同型の `<dl>` が `[&_dt]:*` 形で既に存在**しており、そちらに揃えるほうが
**この製品の中で1つの書き方**になります。

🔴 **その2つを統合はしませんでした。**「似ているから共通化」ではなく実測で比べた結果:

| | `.dl` | `AuditPage:238` |
|---|---|---|
| column-gap / row-gap | 28px / 16px | 22px / 13px |
| 罫線 | なし | `border-b` ＋ `pb` ＋ `mb` |
| 1列に落ちる幅 | 640px | 768px |

**統合すると片方の値が動く。** 別物として残しました。

⚠️ `[&_dd]:leading-inherit` は判例40。`--text-sm` は相棒 line-height を持つので必要
（`--text-2xs` は持たないので `dt` 側には不要）。

---

# 🔴 計測が信用できないことが分かり、直しました

## 症状: 同一コードで2回測って **差11件**

`.dl` の前後差は当初18件。**しかし同じコードで2回測っても11件出ました。**

## 原因: **デモ org が毎回変わる**

`src/Demo/DemoDataSeeder.php:69`

```php
mt_srand(20260712 + $orgId);   // deterministic content; only T moves
...
tags: $i % 3 === 0 ? ['月次'] : [],
```

**内容は org id に対して決定的**ですが、**`/demo/standard` は毎回新しい使い捨て org を作る**ので
**org id が変わり、乱数列ごと変わります。**

⇒ 残っていた6件の内訳（ノイズを引いた後）:

| 差 | 実体 |
|---|---|
| `mobile/detail dl[0] height 311 → 370px` | **その回の文書に `tags` が有ったかどうか**。`col2` は `doc.tags.length > 0` の条件付きで、1行ぶん（59px）背が伸びる |
| `col2` の要素数 1 → 2 | 同上 |
| `audit col2` 0 → 1 | セレクタの非対称（前は `.col2`、後は `.col-span-2`。監査側の `<dl>` は元から `col-span-2` の子を持つ） |

⇒ **18件すべてが計測ばらつきで、コードによる差は1件も無かった。**

## 対処: 固定 org（`/demo/guided`）へ切り替え

`/demo/guided` は**固定の showcase org**（毎晩再 seed）。手元では未 seed で 404 だったので
`tools/seed-demo.php --force` で seed（org #183・20文書）。

| | 同一コード2回の差 |
|---|---:|
| `/demo/standard`（使い捨て org） | **11** |
| **`/demo/guided`（固定 org）** | **0** |

⚠️ guided は **viewer 席**なので `audit` / `settings` は role gate で到達できません。
⇒ **「無い画面は skip として記録する」**ようにしました（**0件採取を勝手に一致扱いにしない**）。

## 固定 org での再計測

```
一致 924 / 差 0
```

**`.dl` の drain は描画を1pxも変えていません。**

---

## 🔑 この campaign への含意

**波1〜波4 の計測は `/demo/standard`（使い捨て org）で行っています。**
⇒ **あの「差 N 件」には、この種のばらつきが混ざっていた可能性があります。**

ただし**判定は変わりません**——波1〜4 で「残った差」として報告したものは
`box-shadow` の文字列形・幅0の辺の色・margin の持ち主のように
**内容に依存しない性質のもの**で、`_box` の位置差は報告していません。
🔴 **とはいえ「混ざっていなかった」ことは確かめていないので、そう書いておきます。**

## 検査

`npm run check` 全緑（43ファイル / 248テスト）。