### PR TITLE
fix(css): 判例40 の漏れを是正 — pagination / lede / audit dl に leading-inherit（#410）

### DIFF
--- a/frontend/src/pages/AuditPage.tsx
+++ b/frontend/src/pages/AuditPage.tsx
@@ -245,7 +245,7 @@ function AuditDetailDrawer({ event, open, onClose }: DrawerProps) {
             </div>
 
             <div className="overflow-auto flex-1 pt-5 px-5.5 pb-7">
-              <dl className="grid grid-cols-2 gap-x-5.5 gap-y-3.25 pb-4.5 border-b border-border mb-4.5 max-md:grid-cols-1 max-md:gap-3 [&_dt]:text-2xs [&_dt]:text-text-muted [&_dt]:uppercase [&_dt]:tracking-meta [&_dt]:font-semibold [&_dt]:mb-0.75 [&_dd]:text-sm [&_dd]:text-x-ink-deep">
+              <dl className="grid grid-cols-2 gap-x-5.5 gap-y-3.25 pb-4.5 border-b border-border mb-4.5 max-md:grid-cols-1 max-md:gap-3 [&_dt]:text-2xs [&_dt]:text-text-muted [&_dt]:uppercase [&_dt]:tracking-meta [&_dt]:font-semibold [&_dt]:mb-0.75 [&_dd]:text-sm [&_dd]:leading-inherit [&_dd]:text-x-ink-deep">
                 <div>
                   <dt>{t('audit_event.list.table.actor')}</dt>
                   <dd className="font-mono zero-slash">
@@ -399,7 +399,9 @@ export function AuditPage() {
         <h1 className="text-h1 font-semibold tracking-title text-x-ink-deep">
           {t('audit_event.list.title')}
         </h1>
-        <p className="text-text-muted text-sm max-w-lede">{t('audit_event.list.lede')}</p>
+        <p className="text-text-muted text-sm leading-inherit max-w-lede">
+          {t('audit_event.list.lede')}
+        </p>
       </Stack>
 
       <Card raised pad="md">

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -126,7 +126,7 @@ export function HomePage() {
           {t('home.eyebrow')}
         </span>
         <h1 className="text-h1 font-semibold tracking-title text-x-ink-deep">{t('home.title')}</h1>
-        <p className="text-text-muted text-sm max-w-lede">{t('home.lede')}</p>
+        <p className="text-text-muted text-sm leading-inherit max-w-lede">{t('home.lede')}</p>
       </Stack>
 
       <div>

--- a/frontend/src/shared/ui/components/Pagination.tsx
+++ b/frontend/src/shared/ui/components/Pagination.tsx
@@ -41,8 +41,22 @@ export function Pagination({
     return null;
   }
 
+  // 🔴 `leading-inherit` next to `text-xs`, and it is not decoration (#410).
+  //
+  // The retired `.pagination` rule set a font-size and no line-height, so everything inside
+  // inherited the body's 1.55. Draining it to `text-xs` on 2026-07-22 (08123b4) brought
+  // Tailwind's companion `--text-xs--line-height` (1.333) along, and the `sm` buttons in here
+  // inherited that instead — 18.6px became 16px and the buttons lost 4.6px of height. It has
+  // been in `main` since July; nothing compared against a rendered page until #404.
+  //
+  // 🔑 The `sm` size was a red herring. `sm` buttons exist nowhere else in this product, so
+  // "only sm is wrong" was really "only this container is wrong" (measured 2026-08-24).
+  //
+  // ⚠️ 判例40's neutraliser did not exist yet when this was drained — `leading-inherit` was
+  // added on 08-13, three weeks later. This is a regression nothing could have caught at the
+  // time, corrected now rather than a design value being changed back (owner ruling 08-24).
   return (
-    <div className="flex items-center justify-between px-4 py-3 border-t border-border text-xs text-text-muted max-md:flex-col max-md:gap-3 max-md:items-stretch max-md:text-center">
+    <div className="flex items-center justify-between px-4 py-3 border-t border-border text-xs leading-inherit text-text-muted max-md:flex-col max-md:gap-3 max-md:items-stretch max-md:text-center">
       <span>{showingLabel}</span>
       <div className="flex items-center gap-2 max-md:justify-center">
         {/* max-md:flex-1 preserves the retired `.pagination .btn { flex: 1 }`


### PR DESCRIPTION
Closes #410

施主裁定（2026-08-24）で **「戻す／戻さない」ではなく「当時は防ぐ手が無かった回帰の是正」**
として GO。判例40 の中和形 `leading-inherit` を、**同じ機構で漏れている全箇所**に当てる。

## 直した3箇所

| 箇所 | 由来 | 本番 | 修正前 | 修正後 |
|---|---|---|---|---|
| **`Pagination.tsx`** | `.pagination` の drain（`08123b4`・**2026-07-22**） | lh **18.6px** | 16px | **18.6px** 🟢 |
| **`HomePage` / `AuditPage` の lede** ×2 | `.lede` の drain | lh **20.15px**（高さ 40.28） | 18.57px（37.13） | **20.15px（40.28）** 🟢 |
| **`AuditPage:248` の `[&_dd]:text-sm`** | 元から utility | — | 1.4286 | **1.55**（`.dl` と統一） |

## 🔑 `sm` は無関係だった

「なぜ `md` は一致して `sm` だけ違うのか」の答えは **ボタンのサイズではなく親コンテナ**。

```
本番   BUTTON lh=18.6 ← DIV lh=18.6 ← .pagination lh=18.6 ← .card lh=21.7（1.55）
修正前 BUTTON lh=16   ← DIV lh=16   ← text-xs …  lh=16   ← Card   lh=21.7（1.55）
修正後 BUTTON lh=18.6 ← DIV lh=18.6 ← text-xs leading-inherit … ← Card lh=21.7  🟢 4階層とも一致
```

`sm` ボタンは**この製品では pagination にしか存在しない**（実測）ので、
**「`sm` だけ壊れている」は「このコンテナだけ壊れている」だった。**

## 🔴 `.lede` は、最初の掃き出しでは見つかりませんでした

#410 の調査では **「子が継承しうる位置（コンテナ）」**に絞って4箇所を洗い、
**同型は1件のみ**と報告しました。**それは射程の切り方が狭かった**——
`.lede` は `<p>` で**子を持たない葉**なので、その条件で落ちていました。

⚠️ **葉でも回帰します。** 継承しなくても、**その要素自身の行間が変わる**（高さ 40.28 → 37.13px）。

⇒ 是正の実測に合わせて **「相棒つきクラスを持ち、比が 1.55 でない要素」をページ全体から洗う**
方式へ変更（＝親子関係を条件にしない）。**3件出て、2件が回帰でした。**

## 残る2件は回帰ではありません（測って判定）

| | 判定 |
|---|---|
| `Modal` の閉じるボタン（`text-modal-close` 比 1.000） | 🟢 **`leading-none` を明示**している＝意図的 |
| `DiffView` の key（`font-mono text-xs` 比 1.333） | 🟢 子 `<span class="text-3xs">` が**自分でサイズを持つ**ので継承しない |

## 実測（2026-08-24 23:xx JST・本番 `vault.ayane.co.jp` と手元固定 org）

- **pagination の継承連鎖 4階層すべて一致**
- **lede は行間も高さも一致**（20.15px / 40.28px）
- **全体掃き出しで残る「1.55 でない相棒つき」は 2件のみ**、いずれも上記のとおり意図的

`npm run check` 全緑（43ファイル / 248テスト）。

## ⇒ `Pagination` 載せ替えのブロックが解けます

「載せ替えで変わった」と「もともと変わっていた」が混ざる懸念の**後者が消えた**ので、
#412 の `Pagination` は着手可能になります（載せ替えるかは別途）。
