### PR TITLE
chore(deps): フリート4本を最新へ・影のスロットを設定・slot-pairs 検知器を新設（#435）

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@hideyukimori/nene2-client": "^1.1.0",
-        "@hideyukimori/nene2-ui": "^0.14.0",
+        "@hideyukimori/nene2-ui": "^0.15.0",
         "@hookform/resolvers": "^3.10.0",
         "@tanstack/react-query": "^5.62.11",
         "react": "^19.2.6",
@@ -1616,9 +1616,9 @@
       }
     },
     "node_modules/@hideyukimori/nene2-client": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@hideyukimori/nene2-client/-/nene2-client-1.1.0.tgz",
-      "integrity": "sha512-s625luvNkeUZnunF2o3HInpExd6sORR929PFH1kCHtGnNwvlqC6CXK4RHoWCtrcDaHe94z464Eqnd75htSWlyA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@hideyukimori/nene2-client/-/nene2-client-1.4.0.tgz",
+      "integrity": "sha512-VmRwwRfOjVgCgasD5IEmZy+DhK1q9rvGYAWtQwLWZzADs9NHv1mxHYxnnrkmg++tJ6jhAVFxjqO1HHmUZtZ4wA==",
       "license": "MIT",
       "engines": {
         "node": ">=22 <25",
@@ -1626,9 +1626,9 @@
       }
     },
     "node_modules/@hideyukimori/nene2-i18n": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@hideyukimori/nene2-i18n/-/nene2-i18n-0.3.0.tgz",
-      "integrity": "sha512-2apRGsjZjxVaA69ypGnecjYD064eTpZu/FKZhFmYEWEA+4TwthLsKovHpwxAhtx4ysK4Q/jaUe6y1vM9EmLr7Q==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@hideyukimori/nene2-i18n/-/nene2-i18n-0.3.1.tgz",
+      "integrity": "sha512-VJww3DV1pDadNmJ0/qa180EPL419/wVn3CAhMbebY8MmYomB/nfTWaaWPC7GqhJyiYyXY1vKGw5xQNtNGgOS9Q==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -1649,9 +1649,9 @@
       }
     },
     "node_modules/@hideyukimori/nene2-standards": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@hideyukimori/nene2-standards/-/nene2-standards-2.1.1.tgz",
-      "integrity": "sha512-PAY/lPeoZaP9pDYdmkQvOniyiblc2RQsCtt77U9d6PcbMaGxBeMBFAn9iTE4yu4zHCRY2Nxa9QQLO3AqFuQk6Q==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@hideyukimori/nene2-standards/-/nene2-standards-2.3.0.tgz",
+      "integrity": "sha512-OrDuvCJ7NEjWfzreRpEyNflcQa2cpX+T4cOAGJL7pGnuezlaiuJMaBO8MEgeG6z845Ctxe6Mkf75QRVWSxaFTg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1711,9 +1711,9 @@
       }
     },
     "node_modules/@hideyukimori/nene2-ui": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@hideyukimori/nene2-ui/-/nene2-ui-0.14.0.tgz",
-      "integrity": "sha512-phfgrzYkCVzct9+4ufUyj/7gRYgIz/f2e2nd/rtXpwrhXPJ5kQUrXasrZMhR/VGmBtyoA4QAWEhzVzSwrm+cWw==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@hideyukimori/nene2-ui/-/nene2-ui-0.15.0.tgz",
+      "integrity": "sha512-SpzyjmxrL0+kMTwAoTwwD6fHeO3vNJZwxikvVH2ExeGAASXZohbU1IUJLdQLJ+5bpTkkHA3wNFQF7ZIPNhWV6g==",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,12 +26,13 @@
     "build-storybook": "storybook build",
     "knip": "knip",
     "stylelint": "stylelint \"src/**/*.css\"",
-    "check": "npm run type-check && npm run lint && npm run format && npm run coverage:check && npm run knip && npm run stylelint && npm run slot-values && npm run registries:check && npm run build && npm run source-probe && npm run build-storybook",
+    "check": "npm run type-check && npm run lint && npm run format && npm run coverage:check && npm run knip && npm run stylelint && npm run slot-values && npm run slot-pairs && npm run registries:check && npm run build && npm run source-probe && npm run build-storybook",
     "e2e:live": "NODE_PATH=./node_modules playwright test --config playwright.live.config.ts",
     "registries:check": "nene2-check init --check",
     "audit": "audit-ci --config audit-ci.jsonc",
     "source-probe": "node tools/source-probe.mjs",
-    "slot-values": "node tools/slot-values.mjs"
+    "slot-values": "node tools/slot-values.mjs",
+    "slot-pairs": "node tools/slot-pairs.mjs"
   },
   "//overrides": "js-yaml is pulled transitively by @redocly/openapi-core and trips the CI npm audit high gate (GHSA-52cp-r559-cp3m). Bump it here rather than via `npm audit fix` (platform-binary risk) or a redocly bump (churn). (#273)",
   "overrides": {
@@ -40,7 +41,7 @@
   },
   "dependencies": {
     "@hideyukimori/nene2-client": "^1.1.0",
-    "@hideyukimori/nene2-ui": "^0.14.0",
+    "@hideyukimori/nene2-ui": "^0.15.0",
     "@hookform/resolvers": "^3.10.0",
     "@tanstack/react-query": "^5.62.11",
     "react": "^19.2.6",

--- a/frontend/src/shared/ui/theme/themes/default.css
+++ b/frontend/src/shared/ui/theme/themes/default.css
@@ -311,6 +311,15 @@
      ⚠️ The weight one is the widest: it is in BASE, so it reaches all 39 buttons, and a
      500 next to a 600 is the kind of difference that reads as "this looks a bit off" rather
      than as a defect with a name. */
+  /* 🔴 The primary button's shadow, back. The retired `.btn` carried `shadow-sm` and the
+     migration dropped it — not because a value was wrong but because the kit had no shadow
+     slot at all (#409; `--shadow-x-slot-*` was the only dimension at zero). 0.15.0 added the
+     dimension with defaults that copy today's rendering, so this line is the one override
+     that restores this product's own value.
+     ⚠️ `--shadow-x-slot-card-raised` and `--shadow-x-slot-toast` default to `--shadow-sm`,
+     which is what this theme wants, so they are not restated. */
+  --shadow-x-slot-button-primary: var(--shadow-sm);
+
   --font-weight-x-slot-button: var(--font-weight-semibold);
   --color-x-slot-button-secondary-fg: var(--color-x-ink-deep);
   --color-x-slot-button-secondary-border: var(--color-border-strong);

--- a/frontend/tools/slot-pairs.mjs
+++ b/frontend/tools/slot-pairs.mjs
@@ -1,0 +1,43 @@
+// 対になっているスロットの「片側だけ上書き」を検出する（#435）。
+//
+// 🔴 なぜ要るか: `--text-x-slot-button-size` と `--text-x-slot-button-sm-size` は
+// どちらも既定が `inherit` で、両方が既定なら `sm` と `md` は同じ大きさになり反転しない。
+// 反転するのは **`md` だけを上書きした製品** ——このリポがまさにそれで、2026-08-24 に
+// `sm` を置かなければ `sm`(14px 継承) > `md`(13px) になるところだった（#402）。
+//
+// 対の一覧はキットが `themes/slot-pairs.json` で配布する（0.15.0〜）。**手で持たない。**
+// キットが対を増やせば、この検査の射程も自動で増える。
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const PAIRS = require('@hideyukimori/nene2-ui/themes/slot-pairs.json');
+const THEME = 'src/shared/ui/theme/themes/default.css';
+
+const css = readFileSync(THEME, 'utf8');
+/** そのカスタムプロパティを、このテーマが宣言しているか。 */
+const declares = (name) => new RegExp(`^\\s*${name.replace(/[-]/g, '\\-')}\\s*:`, 'm').test(css);
+
+const offenders = [];
+for (const pair of PAIRS.pairs) {
+  if (!pair.overrideTogether) continue;
+  const base = declares(pair.base);
+  const sm = declares(pair.sm);
+  if (base !== sm) {
+    offenders.push({ pair, missing: base ? pair.sm : pair.base, has: base ? pair.base : pair.sm });
+  }
+}
+
+const together = PAIRS.pairs.filter((p) => p.overrideTogether).length;
+if (offenders.length > 0) {
+  console.error(`slot-pairs: ${offenders.length} 件の片側上書き\n`);
+  for (const o of offenders) {
+    console.error(`  🔴 ${o.has} を上書きしているのに ${o.missing} を上書きしていない`);
+    console.error(
+      `     既定は両方 ${JSON.stringify(o.pair.defaults)} なので、片側だけだと段が反転する`,
+    );
+  }
+  console.error(`\n${THEME} に不足側を書くか、上書き側を外してください。`);
+  process.exit(1);
+}
+console.log(`slot-pairs: OK — overrideTogether の対 ${together} 件すべて、両方上書きか両方既定`);

--- a/tests/e2e/live/batch6-kit-parity.spec.ts
+++ b/tests/e2e/live/batch6-kit-parity.spec.ts
@@ -121,7 +121,15 @@ const SCREENS: Screen[] = [
     probes: [
       { name: 'primary button (Upload)', selector: 'button:has-text("Upload Document")', props: [...TYPE, ...FILL, ...BOX] },
       { name: 'secondary button (Clear)', selector: 'button:has-text("Clear")', props: [...TYPE, ...FILL, ...BOX] },
-      { name: 'submit button (Search)', selector: 'button[type="submit"]', props: [...TYPE, ...FILL, ...BOX] },
+      // ⚠️ Not `button[type="submit"]`. Production has **zero** of them on this screen
+      // (measured 2026-08-25): its pre-migration Button set no `type`, and a bare `<button>`
+      // defaults to `submit` only as an *IDL* value — `[type="submit"]` matches the attribute,
+      // which is absent. The kit sets `type="button"` explicitly, so the attribute selector
+      // resolved on one side and not the other, and the row it produced compared this
+      // product's Search button against whatever the auto-wait eventually settled on.
+      // 🔑 A probe that resolves on only one side does not report as unresolved — it reports
+      // as a difference. Match on the text, which is the same object on both sides.
+      { name: 'primary button (Search)', selector: 'button:has-text("Search")', props: [...TYPE, ...FILL, ...BOX] },
       { name: 'search text input', selector: 'input[type="text"]', props: [...TYPE, ...FILL, ...BOX] },
       { name: 'search select', selector: 'select', props: [...TYPE, ...FILL, ...BOX] },
       { name: 'choice label (include voided)', selector: 'label:has(input[type="checkbox"])', props: [...TYPE, ...FILL] },


### PR DESCRIPTION
Closes #435
Closes #409

施主指示（2026-08-25）の「版の取り込み」。**宣言を上げただけで終わらせず、
ブラウザが実行しているものまで確認**しています。

## 🔴 caret が付いていた3本が、lock で古いまま止まっていました

hub の指摘は `nene2-standards` が **2.2.0 で止まっている可能性**でしたが、**実測はもっと古い**:

| | 宣言 | **導入（修正前）** | latest |
|---|---|---:|---:|
| `nene2-ui` | `^0.14.0` → **`^0.15.0`** | 0.14.0 → **0.15.0** | 0.15.0 |
| **`nene2-standards`** | `^2.1.1`（据置） | **2.1.1** → **2.3.0** | 2.3.0 |
| **`nene2-i18n`** | `^0.3.0`（据置） | **0.3.0** → **0.3.1** | 0.3.1 |
| **`nene2-client`** | `^1.1.0`（据置） | **1.1.0** → **1.4.0** | 1.4.0 |
| `nene2-tokens` | `1.1.0`（exact・据置） | 1.1.0 | 1.3.0 |

🔑 **caret は「上がる」ことを意味しません。** `npm install` は lock を優先するので、
**範囲内でも lock が固定していれば動きません**。`npm update` が要ります。

⚠️ **`standards` は 2.1.1 でした。** hub が挙げた `#163` / `#164`（非 Tailwind 艦の
依存ルールを「緩和」と報告しない／HTML 埋め込み `<style>` の不可視領域で green を返さない）
の修正は **2.2.0 で入った**ので、**このリポは 2.2.0 も飛ばして 2.1.1 に居ました**。
⇒ **`check` の過去の green は、この2件について無罪証明になっていません。**

## 🟢 `#409` が着地しました — 影のスロット

0.15.0 で `--shadow-x-slot-*` が新設（**唯一ゼロだった次元**）:

```
--shadow-x-slot-button-primary: none;              ← Button は現状の写し
--shadow-x-slot-card-raised:    var(--shadow-sm);  ← Card / Toast も現状の写し
--shadow-x-slot-toast:          var(--shadow-sm);
```

**「無害な既定は `none` ではなく現状の写し。部品ごとに取れ」**という依頼どおりの形です。
⇒ 本リポは **`--shadow-x-slot-button-primary: var(--shadow-sm)`** の1行で影を復元。

### 実測（本番との突合）

```
本番: upload=oklch(0.28 0.02 256/0.07) 0 1 2 0 · search=同左 · clear=none
手元: upload=同左                            · search=同左 · clear=none   🟢 完全一致
```

突合ハーネス全画面でも **`box-shadow` の「最終レイヤが違う」件数 0**。
残る4件は ring プレースホルダを伴う**文字列形の違いのみ**です。

## 🟢 `slot-pairs` 検知器を新設し、`check` に配線しました

0.15.0 が配布する `themes/slot-pairs.json` を読み、**片側だけ上書きされた対**を検出します。
**対の一覧は手で持ちません**——キットが対を増やせば射程も自動で増えます。

🔴 **壊して確かめました:**

| 変異 | 結果 |
|---|---|
| `sm` 側だけ外す（#402 で実際に危なかった形） | 🔴 exit 1・不足側を名指し |
| `base` 側だけ外す | 🔴 exit 1 |
| **両方外す（＝両方既定＝正当）** | 🟢 **exit 0**（陰性対照を素通りさせる） |
| 復元 | 🟢 exit 0 |

## 🔴 ハーネスの probe を1本直しました

`submit button (Search)` が `button[type="submit"]` で、**本番にはそのボタンが 0 個**でした
（実測）。載せ替え前の Button は `type` を書いておらず、**素の `<button>` の既定 `submit` は
IDL 上の値**で、属性セレクタは**属性を見る**ため当たりません。

⇒ **片側でだけ解決する probe は、`unresolved` ではなく「差」として出ます。**
両側で同じものを指すテキスト一致へ変更。**一致 192 → 203。**

## `nene2-tokens` は pin を維持します（理由を記録）

**import ゼロの CLI 専用 devtool**であることを再確認（`knip.json` の `ignoreDependencies` にも在る）。
pin の目的は **provenance＝codemod を回した版を特定できること**（#265 / PR #266）で、
**古いままにすることではありません。**

⇒ **1.3.0 へ上げるのは筋が通りますが、この PR では上げません。**
理由: **codemod を回す予定が無い**ので、上げても**回した版の記録が変わるだけで検証の機会が無い**。
⇒ **次に codemod を回すときに、その版で上げて記録する**のが pin の趣旨に合います。

## 検査

`npm run check` 全緑（43ファイル / 248テスト）＋ **`slot-pairs: OK`**。
突合は **一致 203 / 差 36**、差の内訳は段への丸め（`gap` `padding` `width`）と
`box-shadow` の文字列形、`Stack` による `display` の blockify、`sm` の padding 2px。
**行間の差は `settings/field hint` の 1件のみ**（#410 の是正後に残った分・別途）。