### PR TITLE
docs(css): stylelint.config.js のコメントを実態に合わせる — allowlist は repo ローカル・current.md は private（#356）

### DIFF
--- a/frontend/stylelint.config.js
+++ b/frontend/stylelint.config.js
@@ -1,6 +1,9 @@
 import { stylelintConfigFor } from '@hideyukimori/nene2-standards/stylelint';
 
-// #65 arm: the effective allowlist/manifest is baked from the central
-// registries (@hideyukimori/nene2-standards) keyed by this repo name — the
-// product never hand-maintains the list (G-7). See docs/todo/current.md #238.
+// The config itself comes from the central package; the components allowlist it
+// enforces is THIS repo's `frontend/registries.jsonc` (per-repo since the 2026-07-21
+// ruling — `nene2-check init --scan` seeds it, drains edit it by hand; the C5 drain
+// took it 153 → 16). `@hideyukimori/nene2-standards` ships only the schema, not the
+// list. History: #65 (central arm) → #238 → #356 (this comment). The living TODO is
+// private (`nene-origin/internal-docs/vault/todo/current.md`), not `docs/todo/`.
 export default stylelintConfigFor('nene-vault');


### PR DESCRIPTION
Closes #356

`frontend/stylelint.config.js` のコメント（4行・実体は1行）が #65 当時のまま、実態と2点食い違っていた。コメントのみの変更・挙動の変更なし。

| | コメント（旧） | 実測 2026-08-25 |
|---|---|---|
| allowlist の所在 | central registries から焼き込み・製品側は手で保守しない | **`frontend/registries.jsonc`（repo ローカル・16件）**。`nene2-standards` は schema のみ配布。C5 drain はこのファイルを手で削って 153→16 |
| 参照先 | `docs/todo/current.md #238` | `docs/todo/` は P3 で private（`nene-origin/internal-docs/vault/todo/current.md`）へ移動済み |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ru1NA6yrbpSQSUJWGigiA
