### PR TITLE
fix(css): キットの Modal が (0,0) に張り付く — base 層で UA の dialog{margin:auto} を復元する橋渡し（#441）

### DIFF
--- a/frontend/src/shared/ui/theme/base.css
+++ b/frontend/src/shared/ui/theme/base.css
@@ -47,4 +47,16 @@
      🔑 And the kit's answer was better than the one asked for: it splits on `pointer-coarse`
      rather than width, because the zoom is a property of touch input, not of narrow
      windows — a landscape iPad is wide and still needs the floor. */
+
+  /* 🔴 #441 bridge — remove when `@hideyukimori/nene2-ui` ≥ 0.16.1 is applied (hub
+     ruling 2026-08-25: the kit adds `m-auto` to its `<dialog>`; this rule goes with that
+     bump). `showModal()` centres a dialog through the UA stylesheet's `dialog { margin:
+     auto }`; the `* { margin: 0 }` above (and Tailwind's preflight, same shape) wins from
+     the author origin, so the kit `Modal` rendered at (0, 0) — measured 2026-08-25 at 1280
+     and 375; production's old `.modal` centred at (380, 119). Restoring the UA value is the
+     whole fix: with this rule the dialog measures (380, 90). A default restored, not a
+     screen special case. */
+  dialog {
+    margin: auto;
+  }
 }


### PR DESCRIPTION
Refs #441（**Closes にしない**: `nene2-ui` 0.16.1 を適用する PR でこの規則を消し、そのとき閉じる）

## 何を直すか

キットの `Modal`（`<dialog>`）が desktop / mobile とも **(0, 0) に張り付く**。本番の旧 `.modal` は (380, 119)。

機構: `showModal()` した dialog を中央に置くのは UA の `dialog { margin: auto }`。本リポ `base.css` の `* { margin: 0 }`（と Tailwind preflight の同型）が author origin でそれを消す。キットの Modal は `m-auto` を持たず `className` も受けないので、画面側からは直せない。

## hub 裁定（2026-08-25）

- 上流: `Modal.tsx` の dialog に `m-auto` → **0.16.1**・回帰1本（fleet-tooling へ中継済み）
- vault: 上流が出るまで **base 層1行で橋渡し、適用時に消す** ← この PR
- 本番デプロイは 0.16.1 適用か この1行のどちらかが入ってから

## 変更

`frontend/src/shared/ui/theme/base.css` の唯一の `@layer base` ブロック内に `dialog { margin: auto }` を1規則（コメントに撤去条件を明記）。
⚠️ 初版は `index.css` に `@layer base {}` を足して **`nene2/layer-base-location`（ST-08）に止められた**。base の家は1つ、という歯止めが効いた。

## 実測

| | 1280×800 | 375×812 |
|---|---|---|
| 修正前 | (0, 0) | (0, 0) |
| 修正後 | **(380, 90)** | — |
| 変異テスト（注入）で予告した値 | (380, 90) | (10.5, 26.7) |

`npm run stylelint` 0・prettier OK。目視材料（batch8）はこの build で撮り直し、Artifact を差し替え（#439 に追記）。

## 0.16.1 適用時の予約

- [ ] `package.json` の `nene2-ui` を `^0.16.1` へ・`npm update`・`npm ls` で実版確認
- [ ] `base.css` からこの規則とコメントを消す
- [ ] 同じ測定（`getBoundingClientRect`）で (380, 90) のまま＝キット側で中央になっていることを確認
- [ ] Closes #441

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ru1NA6yrbpSQSUJWGigiA
