### PR TITLE
docs: 本番の基準を 6da5eb0（0.9.1・2026-08-25 配備）へ・backup.md に MySQL 事前ダンプ節（#448）

### DIFF
--- a/docs/operator/backup.md
+++ b/docs/operator/backup.md
@@ -129,6 +129,39 @@ the next section, by reconciling the database against the files — which is als
 what catches the empty-backup case, since zero rows cannot account for the files
 on disk.
 
+## MySQL on shared hosting (pre-deploy dump)
+
+The public demo (`DB_ADAPTER=mysql`) is the one install that is not SQLite. Take a
+manual dump before every deploy; the DB user on shared hosting has no `PROCESS`
+privilege, so **`--no-tablespaces` is required** or `mysqldump` prints an
+`Access denied … PROCESS privilege` line (the dump is still complete, but the
+non-zero exit makes a scripted run look failed — measured 2026-08-25 on HETEML).
+
+```bash
+# credentials never reach stdout or `ps`: a 0600 defaults file read from .env
+umask 077
+CNF=~/.my-vault-cnf-$$            # HETEML has no mktemp
+printf '[client]\nuser=%s\npassword=%s\nhost=%s\n' \
+  "$(grep ^DB_USER= .env | cut -d= -f2-)" \
+  "$(grep ^DB_PASSWORD= .env | cut -d= -f2-)" \
+  "$(grep ^DB_HOST= .env | cut -d= -f2-)" > "$CNF"
+OUT=~/backups/vault-pre-<version>-$(date +%Y%m%d-%H%M%S).sql.gz
+mysqldump --defaults-extra-file="$CNF" --single-transaction --no-tablespaces \
+  --routines --triggers "$(grep ^DB_NAME= .env | cut -d= -f2-)" | gzip > "$OUT"
+rm -f "$CNF"
+```
+
+Verify four things before deploying — a dump that exists is not a dump that works:
+
+1. `gzip -t "$OUT"` — readable archive
+2. `zcat "$OUT" | head -3 | grep -q 'MySQL dump'` — a real dump header
+3. `CREATE TABLE` present for `organizations users vault_documents document_versions audit_events phinxlog`
+4. `phinxlog` row count equals the number of files in `database/migrations` (pending migrations
+   show up here as a mismatch, before `phinx status` is ever run)
+
+Shared hosting also lacks `sha256sum` and `df`; verify an uploaded release ZIP with
+`php8.4 -r 'echo hash_file("sha256", "nene-vault-<version>.zip");'` against the sidecar.
+
 ### File backup
 
 Copy the entire storage directory:

--- a/docs/qa/owner-review/README.md
+++ b/docs/qa/owner-review/README.md
@@ -37,7 +37,7 @@ org is minted per side per run; the viewport is switched on the same page.
 
 | column | is |
 | --- | --- |
-| **production** | whatever `vault.ayane.co.jp` served at run time — **not "the current design"**. Establish which build that is before reading a row (2026-08-25: pre-`a941a87`, 2026-07-22) |
+| **production** | whatever `vault.ayane.co.jp` served at run time — **not "the current design"**. Establish which build that is before reading a row (from 2026-08-25 20:22:53 JST: `6da5eb0`, 0.9.1; before that: `97da1e0`, 2026-07-12) |
 | **local** | the build named in `meta.json` (`local HEAD`, `local nene2-ui`) |
 
 Content differs between the columns by design (each side has its own disposable org):

--- a/tests/e2e/live/batch6-kit-parity.spec.ts
+++ b/tests/e2e/live/batch6-kit-parity.spec.ts
@@ -17,10 +17,11 @@ import { seatAdmin } from './_helpers';
  * reports rather than asserts.
  *
  * 🔴 KNOW WHAT THE REFERENCE IS BEFORE READING A ROW. Production is not "the current design";
- * it is whatever was last deployed. Measured 2026-08-24, nene-vault's demo still serves
- * `class="btn btn-primary"` — the component-class era, which ended at `a941a87` on
- * **2026-07-22**, a month before the kit migration. So a row here can mean any of three
- * things and the table cannot tell them apart:
+ * it is whatever was last deployed. Until 2026-08-25 that was the build of `97da1e0`
+ * (2026-07-12 — the component-class era, `class="btn btn-primary"`), a month before the kit
+ * migration. **Since 2026-08-25 20:22:53 JST production is `6da5eb0` (0.9.1)**, the kit
+ * build itself, so the two columns compare the same generation until the next wave deploys.
+ * A row here can mean any of three things and the table cannot tell them apart:
  *
  *   1. a regression the migration introduced   → fix it (three were, and were)
  *   2. a change made deliberately since        → expected; the drain rounded 7px gaps to 8px


### PR DESCRIPTION
Closes #448 / Closes #447

0.9.1 配備（main 6da5eb0・2026-08-25 20:22:53 切替）に伴う記述の更新と、配備で実測した MySQL 事前ダンプ手順の文書化。コード変更なし（コメントと docs のみ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ru1NA6yrbpSQSUJWGigiA