### PR TITLE
chore(deps): nene2-ui 0.16.1 / nene2-i18n 0.3.2 を適用 — #441 の橋渡しと dead utility を撤去

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1626,9 +1626,9 @@
       }
     },
     "node_modules/@hideyukimori/nene2-i18n": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@hideyukimori/nene2-i18n/-/nene2-i18n-0.3.1.tgz",
-      "integrity": "sha512-VJww3DV1pDadNmJ0/qa180EPL419/wVn3CAhMbebY8MmYomB/nfTWaaWPC7GqhJyiYyXY1vKGw5xQNtNGgOS9Q==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@hideyukimori/nene2-i18n/-/nene2-i18n-0.3.2.tgz",
+      "integrity": "sha512-hJ8vm8h/eFuVpySVluAJHCQ5rRh/ZI2JYgTzz7VAOTFr9Hs6qmqQzf6yY178feulemWMcjn+mD67/oo1As2qSg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -1711,9 +1711,9 @@
       }
     },
     "node_modules/@hideyukimori/nene2-ui": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@hideyukimori/nene2-ui/-/nene2-ui-0.16.0.tgz",
-      "integrity": "sha512-S0Y0tJO3fgi+vzyAtDJpeMHq8RtAz0R7DUuokW0jiSpTgJ8/ENKoV1EoJGuYF/mXG8knzlJfQOuFJBkVpJnedA==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@hideyukimori/nene2-ui/-/nene2-ui-0.16.1.tgz",
+      "integrity": "sha512-ZM8P9ZHUE2faIX88rxcg+d/tIHlTil4c0B+69uMZTmDlGuNspzWQm8Z9jxR6zh4K+MxPFXGpWJmYFwwVULU+7A==",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19",

--- a/frontend/src/shared/ui/theme/base.css
+++ b/frontend/src/shared/ui/theme/base.css
@@ -47,16 +47,4 @@
      🔑 And the kit's answer was better than the one asked for: it splits on `pointer-coarse`
      rather than width, because the zoom is a property of touch input, not of narrow
      windows — a landscape iPad is wide and still needs the floor. */
-
-  /* 🔴 #441 bridge — remove when `@hideyukimori/nene2-ui` ≥ 0.16.1 is applied (hub
-     ruling 2026-08-25: the kit adds `m-auto` to its `<dialog>`; this rule goes with that
-     bump). `showModal()` centres a dialog through the UA stylesheet's `dialog { margin:
-     auto }`; the `* { margin: 0 }` above (and Tailwind's preflight, same shape) wins from
-     the author origin, so the kit `Modal` rendered at (0, 0) — measured 2026-08-25 at 1280
-     and 375; production's old `.modal` centred at (380, 119). Restoring the UA value is the
-     whole fix: with this rule the dialog measures (380, 90). A default restored, not a
-     screen special case. */
-  dialog {
-    margin: auto;
-  }
 }

--- a/frontend/src/shared/ui/theme/index.css
+++ b/frontend/src/shared/ui/theme/index.css
@@ -47,6 +47,15 @@
   max-width: var(--content-max-wide);
 }
 
+/* Drawer max-height: TW4 has no vh token namespace, so this single-property viewport
+   height is @utility-ized (same precedent as page-glow) to keep the arbitrary-value ban
+   (規約⑤) intact. Used by the audit drawer (AuditPage). NOTE: dvh would be more correct on
+   mobile (iOS URL bar) — deferred. `max-h-sheet` / `z-modal` were removed with the kit Modal
+   (#455): the kit dialog sits in the top layer and needs neither. */
+@utility max-h-dialog {
+  max-height: 90vh;
+}
+
 /* `font-size: 0`（ラベル文字を視覚的に消し、支援技術には残す）。TW4 に段が無く
    arbitrary は規約⑤で禁止なので @utility 化が正道。単一宣言（#428）。 */
 /* `.avatar` の 0.8rem。段（0.6875 / 0.75 / 0.8125rem）に無い直値で、arbitrary は
@@ -74,25 +83,7 @@
   );
 }
 
-/* Dialog max-heights: TW4 has no vh token namespace, so these single-property
-   viewport heights are @utility-ized (same precedent as page-glow) to keep the
-   arbitrary-value ban (規約⑤) intact. NOTE: dvh would be more correct on mobile
-   (iOS URL bar) — deferred to a post-parity improvement PR to hold EXACT parity. */
-@utility max-h-dialog {
-  max-height: 90vh;
-}
-@utility max-h-sheet {
-  max-height: 92vh;
-}
-
-/* z-index:100 の named 参照。TW4 の z-index は静的値+arbitrary のみで named
-   namespace が無いため、既存 --z-modal トークンを @utility 経由で参照して
-   arbitrary（z-[100]）を回避する。 */
-@utility z-modal {
-  z-index: var(--z-modal);
-}
-
-/* 上部バーの named z-index と高さ。TW4 に z namespace が無いのは `z-modal` と同じ理由で、
+/* 上部バーの named z-index と高さ。TW4 に z namespace が無いので named 参照は @utility 経由になり、
    高さは `--topbar-height` が独自名トークン（段ではない）なので数値 utility では書けない。
    どちらも単一宣言・子孫なし・擬似要素なし＝`@utility` の歯止め基準を満たす（#419）。 */
 @utility z-topbar {


### PR DESCRIPTION
Refs #441 #453 #455（**Closes にしない**: 本番反映は 0.9.2 で、live 確認後に閉じる）

## 変更

| | |
|---|---|
| `package-lock.json` | `nene2-ui` 0.16.0 → **0.16.1**（Modal `<dialog>` に `m-auto`）／`nene2-i18n` 0.3.1 → **0.3.2**（lookup 最長一致＋後戻り）。宣言（`^0.16.0` / `^0.3.0`）は範囲内で変更なし。`npm ls` で実版確認 |
| `base.css` | #441 の橋渡し `dialog { margin: auto }` を撤去（PR #442 のチェックリスト） |
| `index.css` | 参照 0 の `@utility max-h-sheet` / `z-modal` を撤去。`max-h-dialog` は AuditPage の drawer が使用中なので**残す**（#455 の射程を訂正） |

## ローカル実測（2026-08-25 21:5x JST・コンテナの node_modules も更新・`.vite/deps` 掃除後）

| | 本番（0.16.0 / 0.3.1） | ローカル（0.16.1 / 0.3.2） |
|---|---|---|
| Upload modal の位置（1280×800） | (380, 90)＝橋渡しで中央 | **(380, 90)＝橋渡し無しで中央**（`m-auto` あり） |
| 監査ログ Action 列 | `audit_event.action.document.voided`（生キー 20 件） | **`Document Voided`（生キー 0 件）** |

## 本番反映

0.17.0（着手 08-26）と束ねて **0.9.2**（hub 裁定・08-29 までに出なければ 0.9.1.1）。配備後に batch8/batch9 で live 確認 → #441 / #453 / #455 close。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ru1NA6yrbpSQSUJWGigiA
