### PR TITLE
chore(deps): nene2-ui ^0.16.0 → ^0.17.0 — W1b の入口（#412）

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@hideyukimori/nene2-client": "^1.1.0",
-        "@hideyukimori/nene2-ui": "^0.16.0",
+        "@hideyukimori/nene2-ui": "^0.17.0",
         "@hookform/resolvers": "^3.10.0",
         "@tanstack/react-query": "^5.62.11",
         "react": "^19.2.6",
@@ -1711,9 +1711,9 @@
       }
     },
     "node_modules/@hideyukimori/nene2-ui": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@hideyukimori/nene2-ui/-/nene2-ui-0.16.1.tgz",
-      "integrity": "sha512-ZM8P9ZHUE2faIX88rxcg+d/tIHlTil4c0B+69uMZTmDlGuNspzWQm8Z9jxR6zh4K+MxPFXGpWJmYFwwVULU+7A==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@hideyukimori/nene2-ui/-/nene2-ui-0.17.0.tgz",
+      "integrity": "sha512-fKVvfEcPfzCLZJuSN16Vka7uMQ6G0lKNgM1fexoecaqd7kOtirxUUjPVmxh0hCI0a0oZrhTGdgueP/0NzxoawQ==",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@hideyukimori/nene2-client": "^1.1.0",
-    "@hideyukimori/nene2-ui": "^0.16.0",
+    "@hideyukimori/nene2-ui": "^0.17.0",
     "@hookform/resolvers": "^3.10.0",
     "@tanstack/react-query": "^5.62.11",
     "react": "^19.2.6",


### PR DESCRIPTION
Refs #412

宣言 `^0.17.0`・lock 0.17.0（`npm ls` で実版確認・lock diff あり）。0.17.0 は任意 prop のみで既定の描画は 0.16.1 と同じ。載せ替え本体（Pagination / Badge / DetailList / DataTable）は部品ごとに続く PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ru1NA6yrbpSQSUJWGigiA