### PR TITLE
feat(frontend): 状態バッジをキットの Badge（0.17.0）へ載せ替える（#412 W1b）

### DIFF
--- a/frontend/src/features/document-search/ui/DocumentTable.test.tsx
+++ b/frontend/src/features/document-search/ui/DocumentTable.test.tsx
@@ -76,27 +76,23 @@ describe('DocumentTable', () => {
     expect(screen.getByText('Active')).toBeInTheDocument();
   });
 
-  // Regression guard for the `.badge` drain (#369) — asserts the replacement
-  // utilities rather than the retired class name (判例#34). The two tests above
-  // only assert the label text, so deleting the CSS would have gone unnoticed.
-  it('carries the regenerated badge utilities', () => {
+  // Regression guard: the status badge is the kit's `Badge` (0.17.0, W1b) carrying this
+  // product's dot through `className`. Asserts the kit's tone slot class and the dot
+  // utilities, not a retired class name (判例#34).
+  it('renders the status as the kit Badge with the product dot', () => {
     renderWithProviders(<DocumentTable documents={[mockDocument]} onSelectDocument={vi.fn()} />);
     const badge = screen.getByText('Active');
-    expect(badge).toHaveClass('inline-flex', 'items-center', 'gap-1.5', 'rounded-full');
-    expect(badge).toHaveClass('px-2.5', 'py-0.75', 'text-2xs', 'font-semibold');
-    // The old rule set `line-height: 1.4` explicitly; `text-2xs` has no partner
-    // `--text-2xs--line-height` to supply one, so the ratio needs its own token
-    // (判例40).
-    expect(badge).toHaveClass('leading-badge');
-    // `.badge::before` — the dot.
+    expect(badge).toHaveClass('inline-flex', 'items-center', 'border');
+    expect(badge).toHaveClass('bg-x-slot-badge-success-bg', 'text-x-slot-badge-success-fg');
+    // `.badge::before` — the dot, now `BADGE_DOT`.
     expect(badge).toHaveClass(
+      'gap-1.5',
       'before:w-1.5',
       'before:h-1.5',
       'before:rounded-full',
       'before:bg-current',
     );
-    // Tone stays runtime-driven at the use site.
-    expect(badge).toHaveAttribute('data-tone', 'success');
     expect(badge).not.toHaveClass('badge');
+    expect(badge).not.toHaveAttribute('data-tone');
   });
 });

--- a/frontend/src/features/document-search/ui/DocumentTable.tsx
+++ b/frontend/src/features/document-search/ui/DocumentTable.tsx
@@ -1,7 +1,7 @@
-import { EmptyState } from '@hideyukimori/nene2-ui';
+import { Badge, EmptyState } from '@hideyukimori/nene2-ui';
 import { useTranslation } from '@/shared/i18n/use-translation';
 import { formatJpy, formatDate } from '@/shared/lib/format';
-import { BADGE_BASE } from '@/shared/ui/primitives/badgeBase';
+import { BADGE_DOT } from '@/shared/ui/primitives/badgeBase';
 import type { VaultDocument } from '@/entities/document';
 
 interface DocumentTableProps {
@@ -55,12 +55,9 @@ export function DocumentTable({ documents, onSelectDocument }: DocumentTableProp
               </td>
               <td data-label={labels.category}>{t(`document.category.${doc.category}`)}</td>
               <td data-label={labels.status}>
-                <span
-                  className={`${BADGE_BASE} data-[tone=danger]:bg-danger-soft data-[tone=danger]:text-danger data-[tone=success]:bg-success-soft data-[tone=success]:text-success`}
-                  data-tone={doc.status === 'voided' ? 'danger' : 'success'}
-                >
+                <Badge tone={doc.status === 'voided' ? 'danger' : 'success'} className={BADGE_DOT}>
                   {t(`document.status.${doc.status}`)}
-                </span>
+                </Badge>
               </td>
               <td className="text-text-muted font-mono zero-slash" data-label={labels.uploaded}>
                 {doc.uploaded_at.slice(0, 10)}

--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -1,4 +1,4 @@
-import { Button, Card, EmptyState, InlineAlert, Stack } from '@hideyukimori/nene2-ui';
+import { Badge, Button, Card, EmptyState, InlineAlert, Stack } from '@hideyukimori/nene2-ui';
 import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useDocumentById, fetchDocumentBlob, useOcrSuggest } from '@/entities/document';
@@ -14,7 +14,7 @@ import type { OcrPrefill } from '@/features/document-detail';
 import { useTranslation } from '@/shared/i18n/use-translation';
 import { formatJpy, formatDate, formatDateTime } from '@/shared/lib/format';
 import { AppChrome } from '@/features/app-chrome';
-import { BADGE_BASE } from '@/shared/ui/primitives/badgeBase';
+import { BADGE_DOT } from '@/shared/ui/primitives/badgeBase';
 
 type Modal = 'void' | 'restore' | 'metadata-edit' | null;
 
@@ -100,21 +100,18 @@ export function DocumentDetailPage() {
                 {doc.counterparty_name}
               </h1>
               <Stack direction="horizontal" align="center" wrap gap="2xs">
-                <span
-                  className={`${BADGE_BASE} data-[tone=danger]:bg-danger-soft data-[tone=danger]:text-danger data-[tone=success]:bg-success-soft data-[tone=success]:text-success`}
-                  data-tone={doc.status === 'voided' ? 'danger' : 'success'}
-                >
+                <Badge tone={doc.status === 'voided' ? 'danger' : 'success'} className={BADGE_DOT}>
                   {t(`document.status.${doc.status}`)}
-                </span>
+                </Badge>
                 {doc.date_uncertain && (
-                  <span className={`${BADGE_BASE} bg-warn-soft text-warn`}>
+                  <Badge tone="warn" className={BADGE_DOT}>
                     {t('document.detail.date_uncertain_badge')}
-                  </span>
+                  </Badge>
                 )}
                 {!doc.is_metadata_confirmed && (
-                  <span className={`${BADGE_BASE} bg-x-sunk-deep text-text-muted`}>
+                  <Badge tone="neutral" className={BADGE_DOT}>
                     {t('document.detail.metadata_unconfirmed_badge')}
-                  </span>
+                  </Badge>
                 )}
               </Stack>
             </Stack>

--- a/frontend/src/pages/UsersPage.tsx
+++ b/frontend/src/pages/UsersPage.tsx
@@ -1,4 +1,5 @@
 import {
+  Badge,
   Button,
   Card,
   EmptyState,
@@ -22,7 +23,7 @@ import type { User } from '@/entities/user';
 import { messageKeyForError } from '@/shared/i18n/map-problem-details';
 import { useTranslation } from '@/shared/i18n/use-translation';
 import { AppChrome } from '@/features/app-chrome';
-import { BADGE_BASE } from '@/shared/ui/primitives/badgeBase';
+import { BADGE_DOT } from '@/shared/ui/primitives/badgeBase';
 
 const PAGE_SIZE = 20;
 
@@ -147,12 +148,9 @@ function UserRow({
       </td>
       <td data-label={t('user.list.table.role')}>{t(`user.role.${user.role}`)}</td>
       <td data-label={t('user.list.table.status')}>
-        <span
-          className={`${BADGE_BASE} data-[tone=success]:bg-success-soft data-[tone=success]:text-success data-[tone=muted]:bg-x-sunk-deep data-[tone=muted]:text-text-muted`}
-          data-tone={user.status === 'active' ? 'success' : 'muted'}
-        >
+        <Badge tone={user.status === 'active' ? 'success' : 'neutral'} className={BADGE_DOT}>
           {t(`user.status.${user.status}`)}
-        </span>
+        </Badge>
       </td>
       <td
         className="text-text-muted font-mono zero-slash"

--- a/frontend/src/shared/ui/primitives/badgeBase.ts
+++ b/frontend/src/shared/ui/primitives/badgeBase.ts
@@ -1,19 +1,8 @@
-// Shared base utilities for the status badges, regenerated from the retired
-// `.badge` component class (C5 W3 波(a), #369).
+// The status dot in front of a badge label — this product's own decoration, layered on the
+// kit's `Badge` through its `className` (0.17.0, fleet #390). The kit measured five ships and
+// none of the others draw a dot, so it stays here rather than upstream (fleet reply 2026-08-25).
 //
-// Five call sites carried the same rule, so the utility string lives here rather
-// than being repeated. Tone stays at the use site: it is runtime-driven
-// (`data-tone`) on three of them and a fixed pair on the other two.
-//
-// The dot is the old `.badge::before`. The `before:` variant already emits
-// `content: var(--tw-content)`, whose `@property` initial value is `""` — the
-// same declaration the old rule spelled out. `before:rounded-full` resolves to
-// `--radius-full` (999px); on a 6×6 box CSS scales the radii down to 50% of the
-// box, i.e. the identical circle the old `border-radius: 50%` drew.
-//
-// `text-2xs` is a font-size-only token (no `--text-2xs--line-height` partner), so
-// it cannot smuggle in a line-height — but the old rule set `line-height: 1.4`
-// explicitly, so `leading-badge` carries it (判例40).
-export const BADGE_BASE =
-  'inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.75 text-2xs font-semibold ' +
-  'leading-badge before:w-1.5 before:h-1.5 before:rounded-full before:bg-current';
+// `before:` already emits `content: var(--tw-content)` (initial `""`), so no explicit content
+// is needed. `before:rounded-full` on a 6×6 box scales down to the same circle the retired
+// `.badge::before { border-radius: 50% }` drew. `gap-1.5` is the space between dot and label.
+export const BADGE_DOT = 'gap-1.5 before:w-1.5 before:h-1.5 before:rounded-full before:bg-current';


### PR DESCRIPTION
Refs #412（W1b 2本目）

## 変更
- 5箇所の自前バッジ → kit `Badge`（`tone`: voided→danger / active→success / 日付不確実→warn / 未確認→neutral・ユーザー active→success / else neutral）
- 丸ドットは vault 自前の意匠として `BADGE_DOT`（`gap-1.5 before:…`）を `className` で
- `BADGE_BASE` と `data-tone` を撤去。DocumentTable.test の回帰ガードはキットのトーンクラス＋ドットを assert

## 受け入れる差（施主目視で見る）
キットのトーンは**塗り**（success = 緑地に白字・border 同色）。旧 badge は淡色地に色文字。ローカル実測: 13px/20px・padding 4px 8px・radius 8px・ドット 6px 白。

## 検査
`tsc -b` 0 / eslint 0 / vitest 41/41（features+pages）/ `npm run check`（CI）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ru1NA6yrbpSQSUJWGigiA
