### PR TITLE
feat(frontend): 詳細のメタ表示をキットの DetailList（0.17.0）へ載せ替える（#412 W1b）

### DIFF
--- a/frontend/src/pages/AuditPage.tsx
+++ b/frontend/src/pages/AuditPage.tsx
@@ -1,6 +1,7 @@
 import {
   Button,
   Card,
+  DetailList,
   EmptyState,
   FormField,
   Grid,
@@ -245,26 +246,42 @@ function AuditDetailDrawer({ event, open, onClose }: DrawerProps) {
             </div>
 
             <div className="overflow-auto flex-1 pt-5 px-5.5 pb-7">
-              <dl className="grid grid-cols-2 gap-x-5.5 gap-y-3.25 pb-4.5 border-b border-border mb-4.5 max-md:grid-cols-1 max-md:gap-3 [&_dt]:text-2xs [&_dt]:text-text-muted [&_dt]:uppercase [&_dt]:tracking-meta [&_dt]:font-semibold [&_dt]:mb-0.75 [&_dd]:text-sm [&_dd]:leading-inherit [&_dd]:text-x-ink-deep">
-                <div>
-                  <dt>{t('audit_event.list.table.actor')}</dt>
-                  <dd className="font-mono zero-slash">
-                    {event.actor_user_id !== null ? String(event.actor_user_id) : '—'}
-                  </dd>
-                </div>
-                <div>
-                  <dt>{t('audit_event.list.table.timestamp')}</dt>
-                  <dd className="font-mono zero-slash">
-                    {formatDateTime(event.created_at, locale)}
-                  </dd>
-                </div>
-                <div className="col-span-2 max-md:col-auto">
-                  <dt>{t('audit_event.detail.entity')}</dt>
-                  <dd className="font-mono zero-slash label-xs break-all">
-                    {event.entity_type}/{event.entity_id}
-                  </dd>
-                </div>
-              </dl>
+              <div className="mb-4.5">
+                <DetailList
+                  layout="columns"
+                  rows={[
+                    {
+                      label: t('audit_event.list.table.actor'),
+                      value: (
+                        <span className="font-mono zero-slash">
+                          {event.actor_user_id !== null ? String(event.actor_user_id) : '—'}
+                        </span>
+                      ),
+                    },
+                    {
+                      label: t('audit_event.list.table.timestamp'),
+                      value: (
+                        <span className="font-mono zero-slash">
+                          {formatDateTime(event.created_at, locale)}
+                        </span>
+                      ),
+                    },
+                  ]}
+                />
+                {/* Full-width row (entity path can be long); `.label-xs` was a dead class (#350). */}
+                <DetailList
+                  rows={[
+                    {
+                      label: t('audit_event.detail.entity'),
+                      value: (
+                        <span className="font-mono zero-slash break-all">
+                          {event.entity_type}/{event.entity_id}
+                        </span>
+                      ),
+                    },
+                  ]}
+                />
+              </div>
 
               <div className="flex items-center justify-between gap-3 mb-3.5">
                 <span className="text-body font-semibold tracking-tight text-x-ink-deep flex items-center gap-2.25">
@@ -493,7 +510,7 @@ export function AuditPage() {
                       <td className="pri">
                         {t(dynamicMessageKey(`audit_event.action.${event.action}`))}
                       </td>
-                      <td className="text-text-muted font-mono zero-slash label-xs">
+                      <td className="text-text-muted font-mono zero-slash">
                         {event.entity_type}/{event.entity_id}
                       </td>
                       <td className="text-text-muted">

--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -1,4 +1,12 @@
-import { Badge, Button, Card, EmptyState, InlineAlert, Stack } from '@hideyukimori/nene2-ui';
+import {
+  Badge,
+  Button,
+  Card,
+  DetailList,
+  EmptyState,
+  InlineAlert,
+  Stack,
+} from '@hideyukimori/nene2-ui';
 import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useDocumentById, fetchDocumentBlob, useOcrSuggest } from '@/entities/document';
@@ -173,49 +181,68 @@ export function DocumentDetailPage() {
                 {t('document.detail.metadata_section')}
               </h2>
             </div>
-            <dl className="grid grid-cols-2 gap-x-7 gap-y-4 max-sm:grid-cols-1 max-sm:gap-y-3.5 [&>div]:min-w-0 [&_dt]:text-2xs [&_dt]:text-text-muted [&_dt]:uppercase [&_dt]:tracking-meta [&_dt]:font-semibold [&_dt]:mb-0.75 [&_dd]:text-sm [&_dd]:leading-inherit [&_dd]:text-x-ink-deep">
-              <div>
-                <dt>{t('document.metadata.transaction_date')}</dt>
-                <dd className="font-mono zero-slash">{formatDate(doc.transaction_date)}</dd>
-              </div>
-              <div>
-                <dt>{t('document.metadata.amount_cents')}</dt>
-                <dd className="font-mono zero-slash tabular-nums">
-                  {formatJpy(doc.amount_cents, locale)}
-                </dd>
-              </div>
-              <div>
-                <dt>{t('document.metadata.category')}</dt>
-                <dd>{t(`document.category.${doc.category}`)}</dd>
-              </div>
-              <div>
-                <dt>{t('document.metadata.source')}</dt>
-                <dd>{t(`document.source.${doc.source}`)}</dd>
-              </div>
-              <div>
-                <dt>{t('document.metadata.uploaded_at')}</dt>
-                <dd className="font-mono zero-slash">{formatDateTime(doc.uploaded_at, locale)}</dd>
-              </div>
-              <div>
-                <dt>{t('document.metadata.retention_expires_at')}</dt>
-                <dd className="font-mono zero-slash">{formatDate(doc.retention_expires_at)}</dd>
-              </div>
-              {doc.tags.length > 0 && (
-                <div className="col-span-2 max-sm:col-auto">
-                  <dt>{t('document.metadata.tags')}</dt>
-                  <dd className="flex items-center gap-2 flex-wrap">
-                    {doc.tags.map((tag) => (
-                      <span
-                        key={tag}
-                        className="inline-flex rounded-sm bg-surface-overlay border border-x-line-mid px-2.25 py-0.75 text-2xs text-text-muted"
-                      >
-                        {tag}
+            <DetailList
+              layout="columns"
+              rows={[
+                {
+                  label: t('document.metadata.transaction_date'),
+                  value: (
+                    <span className="font-mono zero-slash">{formatDate(doc.transaction_date)}</span>
+                  ),
+                },
+                {
+                  label: t('document.metadata.amount_cents'),
+                  value: (
+                    <span className="font-mono zero-slash tabular-nums">
+                      {formatJpy(doc.amount_cents, locale)}
+                    </span>
+                  ),
+                },
+                {
+                  label: t('document.metadata.category'),
+                  value: t(`document.category.${doc.category}`),
+                },
+                { label: t('document.metadata.source'), value: t(`document.source.${doc.source}`) },
+                {
+                  label: t('document.metadata.uploaded_at'),
+                  value: (
+                    <span className="font-mono zero-slash">
+                      {formatDateTime(doc.uploaded_at, locale)}
+                    </span>
+                  ),
+                },
+                {
+                  label: t('document.metadata.retention_expires_at'),
+                  value: (
+                    <span className="font-mono zero-slash">
+                      {formatDate(doc.retention_expires_at)}
+                    </span>
+                  ),
+                },
+              ]}
+            />
+            {doc.tags.length > 0 && (
+              // Full-width row: the kit has no column span, so a one-row stacked list follows the grid.
+              <DetailList
+                rows={[
+                  {
+                    label: t('document.metadata.tags'),
+                    value: (
+                      <span className="flex items-center gap-2 flex-wrap">
+                        {doc.tags.map((tag) => (
+                          <span
+                            key={tag}
+                            className="inline-flex rounded-sm bg-surface-overlay border border-x-line-mid px-2.25 py-0.75 text-2xs text-text-muted"
+                          >
+                            {tag}
+                          </span>
+                        ))}
                       </span>
-                    ))}
-                  </dd>
-                </div>
-              )}
-            </dl>
+                    ),
+                  },
+                ]}
+              />
+            )}
           </Card>
 
           <Card raised pad="md">
@@ -225,16 +252,24 @@ export function DocumentDetailPage() {
                 {t('document.detail.file_section')}
               </h2>
             </div>
-            <dl className="grid grid-cols-2 gap-x-7 gap-y-4 max-sm:grid-cols-1 max-sm:gap-y-3.5 [&>div]:min-w-0 [&_dt]:text-2xs [&_dt]:text-text-muted [&_dt]:uppercase [&_dt]:tracking-meta [&_dt]:font-semibold [&_dt]:mb-0.75 [&_dd]:text-sm [&_dd]:leading-inherit [&_dd]:text-x-ink-deep">
-              <div>
-                <dt>{t('document.metadata.version_number')}</dt>
-                <dd className="font-mono zero-slash">{doc.version_number}</dd>
-              </div>
-              <div className="col-span-2 max-sm:col-auto">
-                <dt>{t('document.metadata.file_sha256')}</dt>
-                <dd className="font-mono zero-slash break-all">{doc.file_sha256}</dd>
-              </div>
-            </dl>
+            <DetailList
+              layout="columns"
+              rows={[
+                {
+                  label: t('document.metadata.version_number'),
+                  value: <span className="font-mono zero-slash">{doc.version_number}</span>,
+                },
+              ]}
+            />
+            {/* Full-width row: a 64-char hash needs the whole width; the kit has no column span. */}
+            <DetailList
+              rows={[
+                {
+                  label: t('document.metadata.file_sha256'),
+                  value: <span className="font-mono zero-slash break-all">{doc.file_sha256}</span>,
+                },
+              ]}
+            />
           </Card>
 
           <Card raised pad="md">


### PR DESCRIPTION
Refs #412（W1b 3本目）／Closes #350

## 変更
- DocumentDetailPage の Metadata・File、AuditPage drawer 冒頭の 2カラム `<dl>` → kit `DetailList layout="columns"`（md 未満で自動1列）
- 列スパンはキットに無いので、全幅の行（タグ・SHA-256・監査の対象パス）は1行の stack リストを続けて置く
- dead className `.label-xs`（#350）を撤去

## 受け入れる差（施主目視で見る）
行ごとの下罫線・dt の意匠（uppercase/字間 → キットの term スロット）・列間。ローカル実測: 1280 で `405px 405px`、375 で 1 列、SHA-256 行は全幅。

## 検査
`tsc -b` 0 / eslint 0 / vitest pages 24/24 / `npm run check`（CI）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ru1NA6yrbpSQSUJWGigiA
