### PR TITLE
feat(frontend): 3つの表をキットの DataTable（0.17.0・collapse="sm"）へ載せ替える（#412 W1b）

### DIFF
--- a/frontend/registries.jsonc
+++ b/frontend/registries.jsonc
@@ -10,7 +10,6 @@
       "classes": [
         ".audit-row",
         ".audit-table",
-        ".cell-title",
         ".chev-cell",
         ".pri",
         ".rail",
@@ -22,7 +21,6 @@
         ".right",
         ".row-chev",
         ".tbl",
-        ".tbl-cards",
         ".tbl-wrap",
       ],
     },

--- a/frontend/src/features/document-detail/ui/DocumentHistoryTable.tsx
+++ b/frontend/src/features/document-detail/ui/DocumentHistoryTable.tsx
@@ -1,3 +1,4 @@
+import { DataTable, type DataColumn } from '@hideyukimori/nene2-ui';
 import { dynamicMessageKey } from '@/shared/i18n/catalogs';
 import { useTranslation } from '@/shared/i18n/use-translation';
 import { formatDateTime } from '@/shared/lib/format';
@@ -7,6 +8,14 @@ interface DocumentHistoryTableProps {
   events: AuditEvent[];
 }
 
+const PRE =
+  'font-mono text-2xs text-text-muted bg-surface-sunken border border-border rounded-sm py-1.75 px-2.25 whitespace-pre-wrap max-w-56 leading-normal overflow-hidden';
+
+function Json({ value }: { value: unknown }) {
+  return value !== null ? <pre className={PRE}>{JSON.stringify(value, null, 2)}</pre> : <>—</>;
+}
+
+/** The per-document change history on the kit's `DataTable` (0.17.0, W1b). */
 export function DocumentHistoryTable({ events }: DocumentHistoryTableProps) {
   const { t, locale } = useTranslation();
 
@@ -14,54 +23,55 @@ export function DocumentHistoryTable({ events }: DocumentHistoryTableProps) {
     return <p className="text-text-muted body-sm">{t('document.history.no_history')}</p>;
   }
 
+  const columns: DataColumn<AuditEvent>[] = [
+    {
+      key: 'action',
+      header: t('document.history.table.action'),
+      cell: (event) => (
+        <span className="font-semibold text-x-ink-deep">
+          {t(dynamicMessageKey(`audit_event.action.${event.action}`))}
+        </span>
+      ),
+    },
+    {
+      key: 'actor',
+      header: t('document.history.table.actor'),
+      cell: (event) => (
+        <span className="text-text-muted font-mono zero-slash">
+          {event.actor_user_id !== null ? String(event.actor_user_id) : '—'}
+        </span>
+      ),
+    },
+    {
+      key: 'timestamp',
+      header: t('document.history.table.timestamp'),
+      cell: (event) => (
+        <span className="text-text-muted font-mono zero-slash">
+          {formatDateTime(event.created_at, locale)}
+        </span>
+      ),
+    },
+    {
+      key: 'before',
+      header: t('document.history.table.before'),
+      cell: (event) => <Json value={event.before_json} />,
+    },
+    {
+      key: 'after',
+      header: t('document.history.table.after'),
+      cell: (event) => <Json value={event.after_json} />,
+    },
+  ];
+
   return (
-    <div className="tbl-wrap">
-      <table className="tbl">
-        <thead>
-          <tr>
-            <th>{t('document.history.table.action')}</th>
-            <th>{t('document.history.table.actor')}</th>
-            <th>{t('document.history.table.timestamp')}</th>
-            <th>{t('document.history.table.before')}</th>
-            <th>{t('document.history.table.after')}</th>
-          </tr>
-        </thead>
-        <tbody>
-          {events.map((event) => (
-            <tr key={event.id}>
-              <td>
-                <span className="pri">
-                  {t(dynamicMessageKey(`audit_event.action.${event.action}`))}
-                </span>
-              </td>
-              <td className="text-text-muted font-mono zero-slash">
-                {event.actor_user_id !== null ? String(event.actor_user_id) : '—'}
-              </td>
-              <td className="text-text-muted font-mono zero-slash">
-                {formatDateTime(event.created_at, locale)}
-              </td>
-              <td>
-                {event.before_json !== null ? (
-                  <pre className="font-mono text-2xs text-text-muted bg-surface-sunken border border-border rounded-sm py-1.75 px-2.25 whitespace-pre-wrap max-w-56 leading-normal overflow-hidden">
-                    {JSON.stringify(event.before_json, null, 2)}
-                  </pre>
-                ) : (
-                  '—'
-                )}
-              </td>
-              <td>
-                {event.after_json !== null ? (
-                  <pre className="font-mono text-2xs text-text-muted bg-surface-sunken border border-border rounded-sm py-1.75 px-2.25 whitespace-pre-wrap max-w-56 leading-normal overflow-hidden">
-                    {JSON.stringify(event.after_json, null, 2)}
-                  </pre>
-                ) : (
-                  '—'
-                )}
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+    <div className="overflow-x-auto">
+      <DataTable
+        columns={columns}
+        rows={events}
+        rowKey={(event) => String(event.id)}
+        caption={t('document.history.title')}
+        collapse="sm"
+      />
     </div>
   );
 }

--- a/frontend/src/features/document-search/ui/DocumentTable.tsx
+++ b/frontend/src/features/document-search/ui/DocumentTable.tsx
@@ -1,4 +1,4 @@
-import { Badge, EmptyState } from '@hideyukimori/nene2-ui';
+import { Badge, DataTable, EmptyState, type DataColumn } from '@hideyukimori/nene2-ui';
 import { useTranslation } from '@/shared/i18n/use-translation';
 import { formatJpy, formatDate } from '@/shared/lib/format';
 import { BADGE_DOT } from '@/shared/ui/primitives/badgeBase';
@@ -9,6 +9,14 @@ interface DocumentTableProps {
   onSelectDocument: (id: string) => void;
 }
 
+/**
+ * The received-documents list on the kit's `DataTable` (0.17.0, W1b). `collapse="sm"` reflows
+ * each row into a label/value card below `sm`, which is what the retired `.tbl-cards` did with
+ * `data-label` and `::before` — the kit now owns that mechanism (fleet #423).
+ *
+ * ⚠️ Whether the collapsed card reads the label twice (the `sr-only` header row plus the
+ * `data-label` pseudo-element) is not measurable in jsdom; the live lane checks it (#412).
+ */
 export function DocumentTable({ documents, onSelectDocument }: DocumentTableProps) {
   const { t, locale } = useTranslation();
 
@@ -16,67 +24,80 @@ export function DocumentTable({ documents, onSelectDocument }: DocumentTableProp
     return <EmptyState message={t('document.list.empty')} />;
   }
 
-  const labels = {
-    date: t('document.list.table.transaction_date'),
-    amount: t('document.list.table.amount'),
-    category: t('document.list.table.category'),
-    status: t('document.list.table.status'),
-    uploaded: t('document.list.table.uploaded_at'),
-    actions: t('document.list.table.actions'),
-  };
+  const columns: DataColumn<VaultDocument>[] = [
+    {
+      key: 'transaction_date',
+      header: t('document.list.table.transaction_date'),
+      cell: (doc) => (
+        <span className="font-mono zero-slash">
+          {formatDate(doc.transaction_date)}
+          {doc.date_uncertain && <span className="text-text-faint"> *</span>}
+        </span>
+      ),
+    },
+    {
+      key: 'counterparty_name',
+      header: t('document.list.table.counterparty_name'),
+      cell: (doc) => <span className="font-semibold text-x-ink-deep">{doc.counterparty_name}</span>,
+    },
+    {
+      key: 'amount',
+      header: t('document.list.table.amount'),
+      align: 'end',
+      cell: (doc) => (
+        <span className="tabular-nums font-mono zero-slash">
+          {formatJpy(doc.amount_cents, locale)}
+        </span>
+      ),
+    },
+    {
+      key: 'category',
+      header: t('document.list.table.category'),
+      cell: (doc) => t(`document.category.${doc.category}`),
+    },
+    {
+      key: 'status',
+      header: t('document.list.table.status'),
+      cell: (doc) => (
+        <Badge tone={doc.status === 'voided' ? 'danger' : 'success'} className={BADGE_DOT}>
+          {t(`document.status.${doc.status}`)}
+        </Badge>
+      ),
+    },
+    {
+      key: 'uploaded_at',
+      header: t('document.list.table.uploaded_at'),
+      cell: (doc) => (
+        <span className="text-text-muted font-mono zero-slash">{doc.uploaded_at.slice(0, 10)}</span>
+      ),
+    },
+    {
+      key: 'actions',
+      header: t('document.list.table.actions'),
+      align: 'end',
+      cell: (doc) => (
+        <button
+          type="button"
+          className="text-accent bg-none border-0 cursor-pointer text-sm leading-inherit no-underline hover:text-x-navy-deep hover:underline hover:underline-offset-2"
+          onClick={() => {
+            onSelectDocument(doc.id);
+          }}
+        >
+          {t('common.buttons.view_detail')}
+        </button>
+      ),
+    },
+  ];
 
   return (
-    <div className="tbl-wrap">
-      {/* tbl-cards: on mobile each row reflows into a label/value card */}
-      <table className="tbl tbl-cards">
-        <thead>
-          <tr>
-            <th>{labels.date}</th>
-            <th>{t('document.list.table.counterparty_name')}</th>
-            <th className="right">{labels.amount}</th>
-            <th>{labels.category}</th>
-            <th>{labels.status}</th>
-            <th>{labels.uploaded}</th>
-            <th />
-          </tr>
-        </thead>
-        <tbody>
-          {documents.map((doc) => (
-            <tr key={doc.id}>
-              <td className="font-mono zero-slash" data-label={labels.date}>
-                {formatDate(doc.transaction_date)}
-                {doc.date_uncertain && <span className="text-text-faint"> *</span>}
-              </td>
-              <td className="cell-title">
-                <span className="pri">{doc.counterparty_name}</span>
-              </td>
-              <td className="right tabular-nums font-mono zero-slash" data-label={labels.amount}>
-                {formatJpy(doc.amount_cents, locale)}
-              </td>
-              <td data-label={labels.category}>{t(`document.category.${doc.category}`)}</td>
-              <td data-label={labels.status}>
-                <Badge tone={doc.status === 'voided' ? 'danger' : 'success'} className={BADGE_DOT}>
-                  {t(`document.status.${doc.status}`)}
-                </Badge>
-              </td>
-              <td className="text-text-muted font-mono zero-slash" data-label={labels.uploaded}>
-                {doc.uploaded_at.slice(0, 10)}
-              </td>
-              <td className="right" data-label={labels.actions}>
-                <button
-                  type="button"
-                  className="text-accent bg-none border-0 cursor-pointer text-sm leading-inherit no-underline hover:text-x-navy-deep hover:underline hover:underline-offset-2"
-                  onClick={() => {
-                    onSelectDocument(doc.id);
-                  }}
-                >
-                  {t('common.buttons.view_detail')}
-                </button>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+    <div className="overflow-x-auto">
+      <DataTable
+        columns={columns}
+        rows={documents}
+        rowKey={(doc) => doc.id}
+        caption={t('document.list.title')}
+        collapse="sm"
+      />
     </div>
   );
 }

--- a/frontend/src/pages/UsersPage.tsx
+++ b/frontend/src/pages/UsersPage.tsx
@@ -2,6 +2,8 @@ import {
   Badge,
   Button,
   Card,
+  type DataColumn,
+  DataTable,
   EmptyState,
   FormField,
   InlineAlert,
@@ -131,39 +133,43 @@ function UserFormModal({ onClose }: { onClose: () => void }) {
   );
 }
 
-function UserRow({
-  user,
-  currentUserId,
-  onDelete,
-}: {
-  user: User;
-  currentUserId: number | null;
-  onDelete: (id: number, email: string) => void;
-}) {
-  const { t } = useTranslation();
-  return (
-    <tr>
-      <td className="cell-title">
-        <span className="pri">{user.email}</span>
-      </td>
-      <td data-label={t('user.list.table.role')}>{t(`user.role.${user.role}`)}</td>
-      <td data-label={t('user.list.table.status')}>
+function userColumns(
+  t: ReturnType<typeof useTranslation>['t'],
+  currentUserId: number | null,
+  onDelete: (id: number, email: string) => void,
+): DataColumn<User>[] {
+  return [
+    {
+      key: 'email',
+      header: t('user.list.table.email'),
+      cell: (user) => <span className="font-semibold text-x-ink-deep">{user.email}</span>,
+    },
+    { key: 'role', header: t('user.list.table.role'), cell: (user) => t(`user.role.${user.role}`) },
+    {
+      key: 'status',
+      header: t('user.list.table.status'),
+      cell: (user) => (
         <Badge tone={user.status === 'active' ? 'success' : 'neutral'} className={BADGE_DOT}>
           {t(`user.status.${user.status}`)}
         </Badge>
-      </td>
-      <td
-        className="text-text-muted font-mono zero-slash"
-        data-label={t('user.list.table.created_at')}
-      >
-        {user.created_at.slice(0, 10)}
-      </td>
-      <td data-label={t('user.list.table.actions')}>
-        {user.id !== currentUserId && (
+      ),
+    },
+    {
+      key: 'created_at',
+      header: t('user.list.table.created_at'),
+      cell: (user) => (
+        <span className="text-text-muted font-mono zero-slash">{user.created_at.slice(0, 10)}</span>
+      ),
+    },
+    {
+      key: 'actions',
+      header: t('user.list.table.actions'),
+      cell: (user) =>
+        user.id !== currentUserId ? (
           <button
             type="button"
             /* `.link.is-danger` was one rule overriding the colour; the override is just the later
-   utility here (#428). */
+               utility here (#428). */
             className="text-accent bg-none border-0 cursor-pointer text-sm leading-inherit no-underline hover:text-x-navy-deep hover:underline hover:underline-offset-2 text-danger"
             onClick={() => {
               onDelete(user.id, user.email);
@@ -171,10 +177,9 @@ function UserRow({
           >
             {t('common.buttons.delete')}
           </button>
-        )}
-      </td>
-    </tr>
-  );
+        ) : null,
+    },
+  ];
 }
 
 export function UsersPage() {
@@ -231,28 +236,14 @@ export function UsersPage() {
           {users.length === 0 ? (
             <EmptyState message={t('user.list.empty')} />
           ) : (
-            <div className="tbl-wrap">
-              <table className="tbl tbl-cards">
-                <thead>
-                  <tr>
-                    <th>{t('user.list.table.email')}</th>
-                    <th>{t('user.list.table.role')}</th>
-                    <th>{t('user.list.table.status')}</th>
-                    <th>{t('user.list.table.created_at')}</th>
-                    <th>{t('user.list.table.actions')}</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {users.map((user) => (
-                    <UserRow
-                      key={user.id}
-                      user={user}
-                      currentUserId={currentUserId}
-                      onDelete={handleDelete}
-                    />
-                  ))}
-                </tbody>
-              </table>
+            <div className="overflow-x-auto">
+              <DataTable
+                columns={userColumns(t, currentUserId, handleDelete)}
+                rows={users}
+                rowKey={(user) => String(user.id)}
+                caption={t('user.list.title')}
+                collapse="sm"
+              />
             </div>
           )}
           {total > 0 && (

--- a/frontend/src/shared/ui/theme/themes/default.components.css
+++ b/frontend/src/shared/ui/theme/themes/default.components.css
@@ -400,66 +400,6 @@
         padding: 11px 13px;
       }
 
-      /* opt-in card tables (.tbl.tbl-cards): label/value rows, no horizontal scroll */
-      .tbl-wrap:has(.tbl-cards) {
-        overflow-x: visible;
-      }
-      .tbl.tbl-cards,
-      :where(.tbl.tbl-cards) tbody {
-        display: block;
-        width: 100%;
-      }
-      :where(.tbl.tbl-cards) thead {
-        display: none;
-      }
-      :where(.tbl.tbl-cards) tr {
-        display: block;
-        padding: 14px 16px;
-        border-bottom: 1px solid var(--color-border);
-      }
-      :where(.tbl.tbl-cards) tr:last-child {
-        border-bottom: 0;
-      }
-      :where(.tbl.tbl-cards) tr:hover {
-        background: transparent;
-      }
-      :where(.tbl.tbl-cards) td {
-        display: flex;
-        align-items: baseline;
-        gap: 12px;
-        padding: 4px 0;
-        border: 0;
-        text-align: left;
-      }
-      :where(.tbl.tbl-cards) td::before {
-        content: attr(data-label);
-        flex: none;
-        width: 6.5rem;
-        text-align: left;
-        font-size: var(--text-2xs);
-        font-weight: 600;
-        color: var(--color-text-muted);
-        text-transform: uppercase;
-        letter-spacing: 0.04em;
-      }
-      /* title cell (.cell-title): full-width heading, no label */
-      :where(.tbl.tbl-cards) td.cell-title {
-        display: block;
-        text-align: left;
-        font-size: var(--text-body);
-        font-weight: 600;
-        color: var(--color-x-ink-deep);
-        padding: 0 0 8px;
-        margin-bottom: 6px;
-        border-bottom: 1px solid var(--color-border);
-      }
-      :where(.tbl.tbl-cards) td.cell-title::before {
-        display: none;
-      }
-      :where(.tbl.tbl-cards td.cell-title) .pri {
-        font-weight: 600;
-      }
-
       /* audit detail drawer becomes a bottom sheet with a grab handle */
       /* the diff's vertical stacking (before above, arrow turned down, after
          below) is now the *default* at the call site, with the 3-column form


### PR DESCRIPTION
Refs #412（W1b 4本目）・#367（A群 `.tbl-cards` はこれで解消）

## 変更
- DocumentTable / DocumentHistoryTable / UsersPage → kit `DataTable`（`collapse="sm"`・`caption`・`align="end"`）。`.pri` は utility へ
- `.tbl-cards` / `.cell-title` を components CSS（card-table ブロック 60 行）と `registries.jsonc` から drain（allowlist **16 → 14**）。`.tbl` 系は監査テーブルが使うので残す

## ローカル実測（kit 0.17.0・375×812）
`table`/`tr`/`td` が `block`・`thead` が sr-only・`td::before` に `data-label`。body の横はみ出しなし。

⚠️ **#423（読み上げ二重化）の実測**: アクセシビリティツリー（Playwright `ariaSnapshot`）で
- `rowgroup` に `columnheader "Transaction Date" …` の見出し行が**残り**（sr-only）
- かつ各 `cell` の名前が **`"Transaction Date 2026-08-22"`** のように `::before` のラベルを含む
⇒ 見出しが**二重に読まれる形**。表示・機能は正常。fleet-tooling へ返す（`content: attr(data-label) / ""` の alt 構文で ::before を AT から隠す案）。

## 検査
`tsc -b` 0 / eslint 0 / stylelint 0 / vitest 236/236 / `npm run check` 緑（knip の ignoreDependencies ヒントは既存）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ru1NA6yrbpSQSUJWGigiA
