### PR TITLE
fix(frontend): viewer に Upload / Edit / OCR / Void / Restore を見せない — capability で出し分ける（#451）

### DIFF
--- a/frontend/src/pages/DocumentDetailPage.test.tsx
+++ b/frontend/src/pages/DocumentDetailPage.test.tsx
@@ -70,3 +70,38 @@ describe('DocumentDetailPage download', () => {
     expect(mirrorHeader).toBe('Bearer test-jwt-token');
   });
 });
+
+/** #451 — a viewer must not be offered actions the API refuses (edit / void / restore). */
+describe('DocumentDetailPage action gate (#451)', () => {
+  function renderAs(role: string) {
+    authStore.setSession({
+      token: 'test-jwt-token',
+      userId: 1,
+      email: 'someone@example.com',
+      role,
+      orgId: 1,
+    });
+    return renderWithProviders(
+      <MemoryRouter initialEntries={[`/documents/${DOCUMENT_ID}`]}>
+        <Routes>
+          <Route path="/documents/:id" element={<DocumentDetailPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+  }
+
+  it('offers Edit and Void to an admin', async () => {
+    renderAs('admin');
+    await screen.findByRole('button', { name: 'Download' }, { timeout: 5000 });
+    expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Void' })).toBeInTheDocument();
+  });
+
+  it('hides Edit, OCR Suggest and Void from a viewer, keeps Download', async () => {
+    renderAs('viewer');
+    await screen.findByRole('button', { name: 'Download' }, { timeout: 5000 });
+    expect(screen.queryByRole('button', { name: 'Edit' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /OCR Suggest/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Void' })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -12,6 +12,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { useDocumentById, fetchDocumentBlob, useOcrSuggest } from '@/entities/document';
 import { useDocumentHistory } from '@/entities/audit';
 import { authStore } from '@/shared/api/auth-session';
+import { roleHasCapability } from '@/shared/auth/capabilities';
 import {
   VoidModal,
   RestoreModal,
@@ -31,6 +32,9 @@ export function DocumentDetailPage() {
   const { t, locale } = useTranslation();
   const navigate = useNavigate();
   const session = authStore.getSession();
+  // #451: mirror the backend capabilities so a viewer is not shown actions that 403.
+  const canEdit = roleHasCapability(session?.role, 'EditMetadata');
+  const canVoid = roleHasCapability(session?.role, 'VoidDocument');
   const [modal, setModal] = useState<Modal>(null);
   const [ocrPrefill, setOcrPrefill] = useState<OcrPrefill | undefined>(undefined);
   const { suggest: ocrSuggest, isLoading: ocrLoading } = useOcrSuggest();
@@ -134,43 +138,50 @@ export function DocumentDetailPage() {
               >
                 {t('document.detail.download_button')}
               </Button>
-              <Button
-                variant="secondary"
-                onClick={() => {
-                  void handleOcrSuggest();
-                }}
-                disabled={ocrLoading}
-              >
-                {ocrLoading ? t('common.status.loading') : t('document.detail.ocr_suggest_button')}
-              </Button>
-              <Button
-                variant="secondary"
-                onClick={() => {
-                  setOcrPrefill(undefined);
-                  setModal('metadata-edit');
-                }}
-              >
-                {t('common.buttons.edit')}
-              </Button>
-              {doc.status === 'active' ? (
-                <Button
-                  variant="danger"
-                  onClick={() => {
-                    setModal('void');
-                  }}
-                >
-                  {t('common.buttons.void')}
-                </Button>
-              ) : (
-                <Button
-                  variant="secondary"
-                  onClick={() => {
-                    setModal('restore');
-                  }}
-                >
-                  {t('common.buttons.restore')}
-                </Button>
+              {canEdit && (
+                <>
+                  <Button
+                    variant="secondary"
+                    onClick={() => {
+                      void handleOcrSuggest();
+                    }}
+                    disabled={ocrLoading}
+                  >
+                    {ocrLoading
+                      ? t('common.status.loading')
+                      : t('document.detail.ocr_suggest_button')}
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    onClick={() => {
+                      setOcrPrefill(undefined);
+                      setModal('metadata-edit');
+                    }}
+                  >
+                    {t('common.buttons.edit')}
+                  </Button>
+                </>
               )}
+              {canVoid &&
+                (doc.status === 'active' ? (
+                  <Button
+                    variant="danger"
+                    onClick={() => {
+                      setModal('void');
+                    }}
+                  >
+                    {t('common.buttons.void')}
+                  </Button>
+                ) : (
+                  <Button
+                    variant="secondary"
+                    onClick={() => {
+                      setModal('restore');
+                    }}
+                  >
+                    {t('common.buttons.restore')}
+                  </Button>
+                ))}
             </Stack>
           </div>
 

--- a/frontend/src/pages/DocumentsPage.test.tsx
+++ b/frontend/src/pages/DocumentsPage.test.tsx
@@ -1,0 +1,44 @@
+import { screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import { renderWithProviders } from '@tests/render/render-with-providers';
+import { authStore } from '@/shared/api/auth-session';
+import { DocumentsPage } from './DocumentsPage';
+
+function signInAs(role: string) {
+  authStore.setSession({
+    token: 'test-jwt-token',
+    userId: 1,
+    email: 'someone@example.com',
+    role,
+    orgId: 1,
+  });
+}
+
+function renderPage() {
+  return renderWithProviders(
+    <MemoryRouter>
+      <DocumentsPage />
+    </MemoryRouter>,
+  );
+}
+
+/**
+ * #451 — measured on production 2026-08-25: a viewer saw "Upload Document", clicked it, and
+ * landed on the Forbidden page because the API answers 403. The button now follows the same
+ * capability table the rail and HomePage use.
+ */
+describe('DocumentsPage upload gate (#451)', () => {
+  it('shows the Upload button to a role that may upload', async () => {
+    signInAs('admin');
+    renderPage();
+    expect(await screen.findByRole('button', { name: 'Upload Document' })).toBeInTheDocument();
+  });
+
+  it('hides the Upload button from a viewer', async () => {
+    signInAs('viewer');
+    renderPage();
+    await screen.findByRole('heading', { name: 'Received Documents' });
+    expect(screen.queryByRole('button', { name: 'Upload Document' })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -12,6 +12,7 @@ import { useNavigate } from 'react-router-dom';
 import { useDocumentSearch, DocumentSearchForm, DocumentTable } from '@/features/document-search';
 import { DocumentUploadModal } from '@/features/document-upload';
 import { authStore } from '@/shared/api/auth-session';
+import { roleHasCapability } from '@/shared/auth/capabilities';
 import { useTranslation } from '@/shared/i18n/use-translation';
 import { AppChrome } from '@/features/app-chrome';
 
@@ -19,6 +20,9 @@ export function DocumentsPage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const session = authStore.getSession();
+  // #451: a viewer saw the button and got a 403 on click. The gate mirrors the backend's
+  // CapabilityResolver (viewer = ViewDocuments only), the same way the rail and HomePage do.
+  const canUpload = roleHasCapability(session?.role, 'UploadDocument');
   const [showUpload, setShowUpload] = useState(false);
 
   const { form, onSubmit, onReset, result, pagination } = useDocumentSearch();
@@ -47,19 +51,27 @@ export function DocumentsPage() {
             and a label sat on the text baseline with nothing between them and this call site
             carried `inline-flex items-center gap-x-2xs` itself (#398). The kit lays out its
             own children now; the gap is `--spacing-x-slot-button-gap` in the theme. */}
-        <Button
-          variant="primary"
-          onClick={() => {
-            setShowUpload(true);
-          }}
-        >
-          <Icon decorative size="sm" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round">
-            <path d="M12 19V6" />
-            <path d="m6 11 6-6 6 6" />
-            <path d="M5 20h14" />
-          </Icon>
-          {t('document.list.upload_button')}
-        </Button>
+        {canUpload && (
+          <Button
+            variant="primary"
+            onClick={() => {
+              setShowUpload(true);
+            }}
+          >
+            <Icon
+              decorative
+              size="sm"
+              strokeWidth={1.8}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M12 19V6" />
+              <path d="m6 11 6-6 6 6" />
+              <path d="M5 20h14" />
+            </Icon>
+            {t('document.list.upload_button')}
+          </Button>
+        )}
       </div>
 
       <DocumentSearchForm form={form} onSubmit={onSubmit} onReset={onReset} isLoading={isLoading} />
@@ -99,7 +111,7 @@ export function DocumentsPage() {
         </Card>
       )}
 
-      {showUpload && (
+      {canUpload && showUpload && (
         <DocumentUploadModal
           onClose={() => {
             setShowUpload(false);


### PR DESCRIPTION
Closes #451（#450 打鍵スイープの所見）

## 変更
- DocumentsPage: Upload ボタン／モーダルは `roleHasCapability(role, 'UploadDocument')` のときだけ
- DocumentDetailPage: OCR Suggest / Edit は `EditMetadata`、Void / Restore は `VoidDocument`。Download は全員
- テスト: `DocumentsPage.test.tsx`（新設・admin/viewer）・`DocumentDetailPage.test.tsx` に admin/viewer の2本

バックエンドの拒否（403）は変えていない＝二重防御のまま。UI 側で「押せるのに 403」を無くすだけ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ru1NA6yrbpSQSUJWGigiA
