### PR TITLE
qa(e2e): 監査ログの件数は2回一致するまで待つ — poll 直後の再レンダーでも 0 を読んだ（#450）

### DIFF
--- a/tests/e2e/live/batch9-feature-sweep.spec.ts
+++ b/tests/e2e/live/batch9-feature-sweep.spec.ts
@@ -460,10 +460,19 @@ test('FEATURE-SWEEP: one happy + one failure path per feature, on production', a
     async () => {
       // The list re-renders once after its first paint (loading → rows); a count taken in
       // between reads 0 (measured locally 2026-08-25). Poll instead of counting once.
-      await expect
-        .poll(() => page.locator('table tbody tr').count(), { timeout: 20_000 })
-        .toBeGreaterThan(0);
-      const before = await page.locator('table tbody tr').count();
+      // …and it can re-render more than once, so wait until two reads 300ms apart agree and
+      // are both > 0 rather than trusting the first non-zero count.
+      const stableRows = async (): Promise<number> => {
+        let prev = -1;
+        for (let i = 0; i < 40; i++) {
+          const n = await page.locator('table tbody tr').count();
+          if (n > 0 && n === prev) return n;
+          prev = n;
+          await page.waitForTimeout(300);
+        }
+        return prev;
+      };
+      const before = await stableRows();
       const action = page.locator('#audit-filter-action').first();
       await action.fill('document.voided'); // exact match on the stored action (measured)
       await page.getByRole('button', { name: 'Search', exact: true }).click();


### PR DESCRIPTION
Refs #450。#464 の poll の直後にも再レンダーで 0 を読むことがあった（ローカル W1b build で実測・画面は正しい）。2回一致するまで待つ。これで最終 main のローカル batch9 は 25/25（33.4s）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ru1NA6yrbpSQSUJWGigiA