### PR TITLE
fix(frontend): W1b の意匠を vault の旧意匠へ寄せ直す — 施主 NG 3点（#412）

### DIFF
--- a/frontend/src/features/document-detail/ui/DocumentHistoryTable.tsx
+++ b/frontend/src/features/document-detail/ui/DocumentHistoryTable.tsx
@@ -1,6 +1,7 @@
 import { DataTable, type DataColumn } from '@hideyukimori/nene2-ui';
 import { dynamicMessageKey } from '@/shared/i18n/catalogs';
 import { useTranslation } from '@/shared/i18n/use-translation';
+import { TABLE_CARDS, TABLE_CHROME } from '@/shared/ui/primitives/tableChrome';
 import { formatDateTime } from '@/shared/lib/format';
 import type { AuditEvent } from '@/entities/audit';
 
@@ -66,6 +67,7 @@ export function DocumentHistoryTable({ events }: DocumentHistoryTableProps) {
   return (
     <div className="overflow-x-auto">
       <DataTable
+        className={`${TABLE_CHROME} ${TABLE_CARDS}`}
         columns={columns}
         rows={events}
         rowKey={(event) => String(event.id)}

--- a/frontend/src/features/document-search/ui/DocumentTable.test.tsx
+++ b/frontend/src/features/document-search/ui/DocumentTable.test.tsx
@@ -84,7 +84,8 @@ describe('DocumentTable', () => {
     const badge = screen.getByText('Active');
     expect(badge).toHaveClass('inline-flex', 'items-center', 'border');
     expect(badge).toHaveClass('bg-x-slot-badge-success-bg', 'text-x-slot-badge-success-fg');
-    // `.badge::before` — the dot, now `BADGE_DOT`.
+    expect(badge).toHaveClass('text-2xs', 'font-semibold', 'leading-badge');
+    // `.badge::before` — the dot, now `BADGE_CHROME`.
     expect(badge).toHaveClass(
       'gap-1.5',
       'before:w-1.5',

--- a/frontend/src/features/document-search/ui/DocumentTable.tsx
+++ b/frontend/src/features/document-search/ui/DocumentTable.tsx
@@ -1,7 +1,12 @@
 import { Badge, DataTable, EmptyState, type DataColumn } from '@hideyukimori/nene2-ui';
 import { useTranslation } from '@/shared/i18n/use-translation';
+import {
+  TABLE_CARDS,
+  TABLE_CHROME,
+  TABLE_CARD_TITLE_COL2,
+} from '@/shared/ui/primitives/tableChrome';
 import { formatJpy, formatDate } from '@/shared/lib/format';
-import { BADGE_DOT } from '@/shared/ui/primitives/badgeBase';
+import { BADGE_CHROME } from '@/shared/ui/primitives/badgeBase';
 import type { VaultDocument } from '@/entities/document';
 
 interface DocumentTableProps {
@@ -59,7 +64,7 @@ export function DocumentTable({ documents, onSelectDocument }: DocumentTableProp
       key: 'status',
       header: t('document.list.table.status'),
       cell: (doc) => (
-        <Badge tone={doc.status === 'voided' ? 'danger' : 'success'} className={BADGE_DOT}>
+        <Badge tone={doc.status === 'voided' ? 'danger' : 'success'} className={BADGE_CHROME}>
           {t(`document.status.${doc.status}`)}
         </Badge>
       ),
@@ -92,6 +97,7 @@ export function DocumentTable({ documents, onSelectDocument }: DocumentTableProp
   return (
     <div className="overflow-x-auto">
       <DataTable
+        className={`${TABLE_CHROME} ${TABLE_CARDS} ${TABLE_CARD_TITLE_COL2}`}
         columns={columns}
         rows={documents}
         rowKey={(doc) => doc.id}

--- a/frontend/src/pages/AuditPage.tsx
+++ b/frontend/src/pages/AuditPage.tsx
@@ -17,6 +17,7 @@ import { useAuditEvents, diffAuditEvent, formatAuditValue } from '@/entities/aud
 import type { ListAuditEventsParams, AuditEvent, AuditDiffField } from '@/entities/audit';
 import { authStore } from '@/shared/api/auth-session';
 import { useTranslation } from '@/shared/i18n/use-translation';
+import { PAGINATION_CHROME } from '@/shared/ui/primitives/paginationChrome';
 import { formatDateTime } from '@/shared/lib/format';
 import { AppChrome } from '@/features/app-chrome';
 
@@ -538,9 +539,8 @@ export function AuditPage() {
           {total > 0 && (
             <Pagination
               label={t('common.pagination.label')}
-              className="px-4 py-3 border-t border-border text-xs leading-inherit text-text-muted"
+              className={PAGINATION_CHROME}
               size="sm"
-              stackOnMobile
               statusPlacement="start"
               canPrev={offset > 0}
               canNext={offset + PAGE_SIZE < total}

--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -23,7 +23,7 @@ import type { OcrPrefill } from '@/features/document-detail';
 import { useTranslation } from '@/shared/i18n/use-translation';
 import { formatJpy, formatDate, formatDateTime } from '@/shared/lib/format';
 import { AppChrome } from '@/features/app-chrome';
-import { BADGE_DOT } from '@/shared/ui/primitives/badgeBase';
+import { BADGE_CHROME } from '@/shared/ui/primitives/badgeBase';
 
 type Modal = 'void' | 'restore' | 'metadata-edit' | null;
 
@@ -112,16 +112,19 @@ export function DocumentDetailPage() {
                 {doc.counterparty_name}
               </h1>
               <Stack direction="horizontal" align="center" wrap gap="2xs">
-                <Badge tone={doc.status === 'voided' ? 'danger' : 'success'} className={BADGE_DOT}>
+                <Badge
+                  tone={doc.status === 'voided' ? 'danger' : 'success'}
+                  className={BADGE_CHROME}
+                >
                   {t(`document.status.${doc.status}`)}
                 </Badge>
                 {doc.date_uncertain && (
-                  <Badge tone="warn" className={BADGE_DOT}>
+                  <Badge tone="warn" className={BADGE_CHROME}>
                     {t('document.detail.date_uncertain_badge')}
                   </Badge>
                 )}
                 {!doc.is_metadata_confirmed && (
-                  <Badge tone="neutral" className={BADGE_DOT}>
+                  <Badge tone="neutral" className={BADGE_CHROME}>
                     {t('document.detail.metadata_unconfirmed_badge')}
                   </Badge>
                 )}

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -14,6 +14,7 @@ import { DocumentUploadModal } from '@/features/document-upload';
 import { authStore } from '@/shared/api/auth-session';
 import { roleHasCapability } from '@/shared/auth/capabilities';
 import { useTranslation } from '@/shared/i18n/use-translation';
+import { PAGINATION_CHROME } from '@/shared/ui/primitives/paginationChrome';
 import { AppChrome } from '@/features/app-chrome';
 
 export function DocumentsPage() {
@@ -91,9 +92,8 @@ export function DocumentsPage() {
           {pagination.total > 0 && (
             <Pagination
               label={t('common.pagination.label')}
-              className="px-4 py-3 border-t border-border text-xs leading-inherit text-text-muted"
+              className={PAGINATION_CHROME}
               size="sm"
-              stackOnMobile
               statusPlacement="start"
               canPrev={pagination.canPrev}
               canNext={pagination.canNext}

--- a/frontend/src/pages/UsersPage.tsx
+++ b/frontend/src/pages/UsersPage.tsx
@@ -24,8 +24,14 @@ import { useUsers, useCreateUser, useDeleteUser } from '@/entities/user';
 import type { User } from '@/entities/user';
 import { messageKeyForError } from '@/shared/i18n/map-problem-details';
 import { useTranslation } from '@/shared/i18n/use-translation';
+import { PAGINATION_CHROME } from '@/shared/ui/primitives/paginationChrome';
 import { AppChrome } from '@/features/app-chrome';
-import { BADGE_DOT } from '@/shared/ui/primitives/badgeBase';
+import { BADGE_CHROME } from '@/shared/ui/primitives/badgeBase';
+import {
+  TABLE_CARDS,
+  TABLE_CHROME,
+  TABLE_CARD_TITLE_COL1,
+} from '@/shared/ui/primitives/tableChrome';
 
 const PAGE_SIZE = 20;
 
@@ -149,7 +155,7 @@ function userColumns(
       key: 'status',
       header: t('user.list.table.status'),
       cell: (user) => (
-        <Badge tone={user.status === 'active' ? 'success' : 'neutral'} className={BADGE_DOT}>
+        <Badge tone={user.status === 'active' ? 'success' : 'neutral'} className={BADGE_CHROME}>
           {t(`user.status.${user.status}`)}
         </Badge>
       ),
@@ -238,6 +244,7 @@ export function UsersPage() {
           ) : (
             <div className="overflow-x-auto">
               <DataTable
+                className={`${TABLE_CHROME} ${TABLE_CARDS} ${TABLE_CARD_TITLE_COL1}`}
                 columns={userColumns(t, currentUserId, handleDelete)}
                 rows={users}
                 rowKey={(user) => String(user.id)}
@@ -249,9 +256,8 @@ export function UsersPage() {
           {total > 0 && (
             <Pagination
               label={t('common.pagination.label')}
-              className="px-4 py-3 border-t border-border text-xs leading-inherit text-text-muted"
+              className={PAGINATION_CHROME}
               size="sm"
-              stackOnMobile
               statusPlacement="start"
               canPrev={offset > 0}
               canNext={offset + PAGE_SIZE < total}

--- a/frontend/src/shared/ui/primitives/badgeBase.ts
+++ b/frontend/src/shared/ui/primitives/badgeBase.ts
@@ -1,8 +1,10 @@
-// The status dot in front of a badge label — this product's own decoration, layered on the
-// kit's `Badge` through its `className` (0.17.0, fleet #390). The kit measured five ships and
-// none of the others draw a dot, so it stays here rather than upstream (fleet reply 2026-08-25).
+// What this product adds on top of the kit's `Badge` (0.17.0) through `className`:
+// the type the kit has no slot for (2xs, semibold, the explicit 1.4 line-height — 判例40)
+// and the status dot in front of the label, which no other ship draws (fleet reply
+// 2026-08-25). Colours, radius and padding are slot values in `themes/default.css`.
 //
-// `before:` already emits `content: var(--tw-content)` (initial `""`), so no explicit content
-// is needed. `before:rounded-full` on a 6×6 box scales down to the same circle the retired
-// `.badge::before { border-radius: 50% }` drew. `gap-1.5` is the space between dot and label.
-export const BADGE_DOT = 'gap-1.5 before:w-1.5 before:h-1.5 before:rounded-full before:bg-current';
+// `before:` already emits `content: var(--tw-content)` (initial `""`); `before:rounded-full`
+// on a 6×6 box is the same circle the retired `.badge::before { border-radius: 50% }` drew.
+export const BADGE_CHROME =
+  'text-2xs font-semibold leading-badge gap-1.5 ' +
+  'before:w-1.5 before:h-1.5 before:rounded-full before:bg-current';

--- a/frontend/src/shared/ui/primitives/paginationChrome.ts
+++ b/frontend/src/shared/ui/primitives/paginationChrome.ts
@@ -1,0 +1,9 @@
+// The page-level pagination row on top of the kit's `Pagination` (0.17.0): the rule above
+// it, the muted 12px type with an inherited line-height (判例40), the range on the left with
+// the buttons pushed right; below `md` the range takes its own line and the two buttons
+// share the next one side by side (owner NG 2026-08-26 on the kit's fully stacked column).
+export const PAGINATION_CHROME =
+  'px-4 py-3 border-t border-border text-xs leading-inherit text-text-muted ' +
+  '[&>div>span]:mr-auto ' +
+  'max-md:[&>div]:flex-wrap max-md:[&>div>span]:basis-full max-md:[&>div>span]:mr-0 ' +
+  'max-md:[&>div>span]:text-center max-md:[&>div>button]:flex-1';

--- a/frontend/src/shared/ui/primitives/tableChrome.ts
+++ b/frontend/src/shared/ui/primitives/tableChrome.ts
@@ -1,0 +1,43 @@
+// This product's table look on top of the kit's `DataTable` (0.17.0), applied through
+// `className` (owner NG on the kit defaults, 2026-08-26). What a slot can express — header
+// weight, cell padding, border colour — is a slot value in `themes/default.css`; what it
+// cannot — the header's size / case / tracking / ground, the hover, the last row's border —
+// is here, scoped with arbitrary variants so no component class comes back (規約⑤).
+
+/** Desktop chrome: the retired `table.tbl` / `thead th` rules, expressed as variants. */
+export const TABLE_CHROME =
+  'text-sm ' +
+  '[&_thead_th]:bg-surface-sunken [&_thead_th]:text-2xs [&_thead_th]:uppercase ' +
+  '[&_thead_th]:tracking-meta [&_thead_th]:whitespace-nowrap [&_thead_th]:border-x-line-mid ' +
+  '[&_tbody_tr:last-child_td]:border-b-0 [&_tbody_tr:hover]:bg-surface-overlay';
+
+/**
+ * Card chrome below `sm`, on top of the kit's `collapse="sm"` (which provides the structure:
+ * block cells, `sr-only` header, `data-label` in `::before`). The retired `.tbl-cards` drew
+ * each cell as one row — label on the left in a fixed column, value on the right.
+ */
+export const TABLE_CARDS =
+  'max-sm:[&_tbody_tr]:px-4 max-sm:[&_tbody_tr]:py-3.5 max-sm:[&_tbody_tr:hover]:bg-transparent ' +
+  'max-sm:[&_tbody_td]:flex max-sm:[&_tbody_td]:items-baseline max-sm:[&_tbody_td]:gap-3 ' +
+  'max-sm:[&_tbody_td]:px-0 max-sm:[&_tbody_td]:py-1 max-sm:[&_tbody_td]:border-0 ' +
+  'max-sm:[&_tbody_td::before]:inline-block max-sm:[&_tbody_td::before]:w-26 max-sm:[&_tbody_td::before]:flex-none ' +
+  'max-sm:[&_tbody_td::before]:text-2xs max-sm:[&_tbody_td::before]:font-semibold max-sm:[&_tbody_td::before]:uppercase ' +
+  'max-sm:[&_tbody_td::before]:tracking-meta max-sm:[&_tbody_td::before]:text-text-muted';
+
+/**
+ * The card's title cell (the retired `.cell-title`): full width, body size, bold, a rule
+ * beneath it, no label. One literal per column index — Tailwind's scanner only sees class
+ * names that exist verbatim in the source, so these cannot be built from a template.
+ */
+export const TABLE_CARD_TITLE_COL1 =
+  'max-sm:[&_tbody_td:nth-child(1)]:block max-sm:[&_tbody_td:nth-child(1)]:text-body ' +
+  'max-sm:[&_tbody_td:nth-child(1)]:font-semibold max-sm:[&_tbody_td:nth-child(1)]:text-x-ink-deep ' +
+  'max-sm:[&_tbody_td:nth-child(1)]:pb-2 max-sm:[&_tbody_td:nth-child(1)]:mb-1.5 ' +
+  'max-sm:[&_tbody_td:nth-child(1)]:border-b max-sm:[&_tbody_td:nth-child(1)]:border-border ' +
+  'max-sm:[&_tbody_td:nth-child(1)::before]:hidden';
+export const TABLE_CARD_TITLE_COL2 =
+  'max-sm:[&_tbody_td:nth-child(2)]:block max-sm:[&_tbody_td:nth-child(2)]:text-body ' +
+  'max-sm:[&_tbody_td:nth-child(2)]:font-semibold max-sm:[&_tbody_td:nth-child(2)]:text-x-ink-deep ' +
+  'max-sm:[&_tbody_td:nth-child(2)]:pb-2 max-sm:[&_tbody_td:nth-child(2)]:mb-1.5 ' +
+  'max-sm:[&_tbody_td:nth-child(2)]:border-b max-sm:[&_tbody_td:nth-child(2)]:border-border ' +
+  'max-sm:[&_tbody_td:nth-child(2)::before]:hidden';

--- a/frontend/src/shared/ui/theme/themes/default.css
+++ b/frontend/src/shared/ui/theme/themes/default.css
@@ -190,6 +190,33 @@
      Losing it is not a cosmetic regression: a warning and a failure would become
      indistinguishable to anyone looking at the screen. `role` still differs, but the role is
      read out — it is not seen. Guarded by Alert.tones.test.ts. */
+  /* ── Badge (W1b, owner NG 2026-08-26) ────────────────────────────────────────
+     The kit's tones are solid fills (colour on white text); this product's status badges have
+     always been the soft pill — tinted ground, coloured text, no visible border, fully round.
+     Slots choose steps, so the pill lives here as slot values; the type (2xs, semibold,
+     leading-badge) and the dot ride on `BADGE_CHROME` because the kit has no text-size slot. */
+  --color-x-slot-badge-success-bg: var(--color-success-soft);
+  --color-x-slot-badge-success-fg: var(--color-success);
+  --color-x-slot-badge-success-border: var(--color-success-soft);
+  --color-x-slot-badge-danger-bg: var(--color-danger-soft);
+  --color-x-slot-badge-danger-fg: var(--color-danger);
+  --color-x-slot-badge-danger-border: var(--color-danger-soft);
+  --color-x-slot-badge-warn-bg: var(--color-warn-soft);
+  --color-x-slot-badge-warn-fg: var(--color-warn);
+  --color-x-slot-badge-warn-border: var(--color-warn-soft);
+  --color-x-slot-badge-neutral-bg: var(--color-x-sunk-deep);
+  --color-x-slot-badge-neutral-fg: var(--color-text-muted);
+  --color-x-slot-badge-neutral-border: var(--color-x-sunk-deep);
+  --radius-x-slot-badge: var(--radius-full);
+  --spacing-x-slot-badge-pad-y: var(--spacing-x-3xs);
+
+  /* ── Table (W1b, owner NG 2026-08-26) ────────────────────────────────────────
+     Header weight and cell padding are slots; the header's size / case / tracking / ground
+     and the card layout below `sm` are not, and ride on `TABLE_CHROME` / `TABLE_CARDS`. */
+  --font-weight-x-slot-table-header: var(--font-weight-semibold);
+  --spacing-x-slot-table-cell-pad-x: var(--spacing-x-sm);
+  --spacing-x-slot-table-cell-pad-y: var(--spacing-x-xs);
+
   --color-x-slot-alert-warn-bg: var(--color-warn-soft);
   --color-x-slot-alert-warn-fg: var(--color-on-warn);
   --color-x-slot-alert-warn-border: var(--color-warn);


### PR DESCRIPTION
Refs #412（施主目視 NG 3点への是正）

## 何を
キットの**構造**は残し、**意匠**を vault の旧意匠へ:
| 指摘 | 手当 |
|---|---|
| バッジのスタイル | スロット値で淡色ピル（`*-soft` 地＋色文字・neutral は sunk-deep・`radius-full`）。文字と丸ドットは `BADGE_CHROME` |
| PC の表ヘッダ | スロット値（semibold・余白）＋ `TABLE_CHROME`（`[&_thead_th]:` で大文字・2xs・字間・沈み背景・nowrap） |
| SP の表カード | kit `collapse="sm"` の構造の上に `TABLE_CARDS`（ラベル左 6.5rem・値右）＋見出しセル `TABLE_CARD_TITLE_COL1/2` |
| 監査フッターの縦積み | `stackOnMobile` をやめ `PAGINATION_CHROME`：PC は件数左・ボタン右、SP は件数の下にボタン2つ横並び |

## ローカル実測（1280 / 375）
ヘッダ 11px・600・uppercase・`surface-sunken`／バッジ `success-soft` 地・999px・11px/15.4px／SP 値セル `display: flex`・`::before` 幅 104px・見出しセル block 太字ラベル無し／SP ページ送り: 件数（w309）の下にボタン x33・x192（各 w151）

## 検査
tsc 0 / eslint 0 / stylelint 0 / slot-values・slot-pairs OK / vitest 78/78 / `npm run check`（CI）／目視束は同じ URL で差し替え

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ru1NA6yrbpSQSUJWGigiA
