### PR TITLE
chore(deps): nene2-ui 0.17.0 → 0.17.1 — DataTable collapse の読み上げ二重化を alt 構文で解消（#469）

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1711,9 +1711,9 @@
       }
     },
     "node_modules/@hideyukimori/nene2-ui": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@hideyukimori/nene2-ui/-/nene2-ui-0.17.0.tgz",
-      "integrity": "sha512-fKVvfEcPfzCLZJuSN16Vka7uMQ6G0lKNgM1fexoecaqd7kOtirxUUjPVmxh0hCI0a0oZrhTGdgueP/0NzxoawQ==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@hideyukimori/nene2-ui/-/nene2-ui-0.17.1.tgz",
+      "integrity": "sha512-3t6ikVwbUhzPfkV6wTpoUCRPZV+M14W0YEAVkzf1TNG+aY2ED8/t+GiW783Bx7Irin2RLwG5LTr1iZ9g0lI3ew==",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19",


### PR DESCRIPTION
Refs #469（本番 0.9.2.1 の live 確認で Closes）

## 変更
`package-lock.json` のみ（`nene2-ui` 0.17.0 → **0.17.1**・宣言 `^0.17.0` は範囲内）。

## 検収（ローカル build・375×812・Chromium 149）
| | 0.17.0 | **0.17.1** |
|---|---|---|
| `td::before` の computed content | `"Transaction Date"` | **`"Transaction Date" / ""`**（alt 構文） |
| cell の accessible name | `"Transaction Date 2026-08-22"`（二重） | **`"2026-08-22"`** |
| 見出し行 | columnheader ×7（sr-only） | 同（1回のみ） |

batch9（ローカル）**25/25**。fleet-tooling へ原文で返済。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ru1NA6yrbpSQSUJWGigiA
