### PR TITLE
chore(theme): Badge の gap をスロット化する — nene2-ui 0.19.0 への事前対応（#479 段階1・見た目不変）

### DIFF
--- a/frontend/src/shared/ui/theme/themes/default.css
+++ b/frontend/src/shared/ui/theme/themes/default.css
@@ -195,6 +195,27 @@
      always been the soft pill — tinted ground, coloured text, no visible border, fully round.
      Slots choose steps, so the pill lives here as slot values; the type (2xs, semibold,
      leading-badge) and the dot ride on `BADGE_CHROME` because the kit has no text-size slot. */
+  /* 🔴 gap: chosen ahead of nene2-ui 0.19.0, which gives `Badge` a gap / font-size /
+     font-weight of its own (kit #463). `className` loses to the kit's `BASE_CLASS` — same
+     specificity, decided by the order the CSS is generated in — so `gap-1.5` stops winning
+     the moment that version lands, and the value has to be a slot to survive.
+
+     This is 6px → 4px, and it is deliberate. 6px cannot be written here: `slot-values` fails
+     on a literal, and the kit's scale has no 6px step (3xs 4px · 2xs 8px · xs 12px …) — a
+     slot chooses a step, it may not invent one. Routing through this product's own
+     `--spacing-stack-xs` (0.375rem) would pass the checker and defeat it: that is exactly
+     the drift the scale exists to stop. The kit keeps 4px as its default because the two
+     ships that overrode it disagreed — 6px here, 5px in deal — and neither is a step, so
+     honouring one would only make the other's drift canonical.
+
+     ⚠️ Inert until 0.19.0: 0.17.1's `Badge` does not read this slot, so the rendered gap is
+     still `gap-1.5`'s 6px. It becomes 4px when the caret is raised and `gap-1.5` comes off
+     `BADGE_CHROME` (#479 step 3) — that step is a visible change and takes the owner's look.
+
+     Only the type and the dot stay on `BADGE_CHROME`: `--text-x-slot-badge` needs no override
+     (this product's `--text-2xs` is 0.6875rem = 11px, the kit's default exactly) and the kit
+     ships no companion `--text-x-slot-badge--line-height`, so `leading-badge` still applies. */
+  --spacing-x-slot-badge-gap: var(--spacing-x-3xs);
   --color-x-slot-badge-success-bg: var(--color-success-soft);
   --color-x-slot-badge-success-fg: var(--color-success);
   --color-x-slot-badge-success-border: var(--color-success-soft);


### PR DESCRIPTION
Closes #479（段階1）

上流 `@hideyukimori/nene2-ui` 0.19.0（**未 publish**・kit #463）が `Badge` に gap / font-size / font-weight を持たせる。その前に、本製品が `className` で補っている値のうち**動くものだけ**をスロットへ移す。

## 変更

`themes/default.css` の Badge スロット群に1行:

```css
--spacing-x-slot-badge-gap: var(--spacing-x-3xs);
```

## なぜ gap だけか（実測 2026-08-26）

| プロパティ | 本製品の現在値 | 0.19.0 の既定 | 動くか |
| --- | --- | --- | --- |
| `gap` | `gap-1.5` = **6px** | 4px | **動く** |
| `font-size` | `--text-2xs: 0.6875rem` = **11px** | 11px | 動かない |
| `font-weight` | `font-semibold` = 600 | 600 | 動かない |

`--text-2xs` は 11px（root の `font-size` 上書きは無い＝`base.css` の `html {}` は `-webkit-text-size-adjust` のみ）。上流の既定と同値なので `--text-x-slot-badge` の再定義は不要。相棒 `--text-x-slot-badge--line-height` も上流は持たせない（Tailwind の生成 CSS を陽性対照つきで実測済み。相棒が未定義の `--text-*` は line-height を出さない）ので `leading-badge` はそのまま効く。`before:*` のドットは本製品固有の装飾なので対象外。

## なぜ 4px か（6px は書けない）

`tools/slot-values.mjs` に4値を当てた実測（リテラル2・参照2の対照）:

```
FAIL (literal: 6px)        --spacing-x-slot-badge-gap: 6px;
FAIL (literal: 0.375rem)   --spacing-x-slot-badge-gap: 0.375rem;
PASS                       --spacing-x-slot-badge-gap: var(--spacing-x-3xs);
PASS                       --spacing-x-slot-badge-gap: var(--spacing-stack-xs);
```

キットのスケールに 6px の step は無い（3xs 4px · 2xs 8px · xs 12px · sm 16px · md 20px · lg 24px · xl 32px · 2xl 48px）。旧 token `--spacing-stack-xs`（0.375rem）を経由すれば検査器は通るが、**通ること自体が検査器の穴**で、参照先がキットのスケールではないためこの検査が止めたかった drift そのもの。⇒ 採らない（上流も同意）。

上流が既定 4px を据え置いた理由は、上書きした2艦が **6px（本製品）と 5px（deal）で食い違い、どちらも段に乗っていない**ため。片方に合わせれば、もう片方の drift を正典にするだけになる。両艦の値は実測で確認済み。

## 🟢 見た目は変わらない（実測）

0.17.1 の `Badge` の `BASE_CLASS` はこのスロットを読まない（`node_modules` 内の `x-slot-badge-gap` 参照が0件）。生成 CSS を実測:

- `--spacing-x-slot-badge-gap` は**出力に現れない**（Tailwind が未使用の theme 変数として落とす）
- バッジの gap は `.gap-1\.5{gap:calc(var(--spacing) * 1.5)}` の **6px のまま**

⇒ この PR 単独では**完全に不活性**。

## 段取り（本 PR は段階1のみ）

1. **本 PR** — スロット行のみ。無風
2. 上流が 0.19.0 を publish（本 PR のマージを待って出す、と上流から連絡あり）
3. **別 Issue** — caret 上げ ＋ `badgeBase.ts` から `gap-1.5` 除去。**ここで初めて gap が 4px になる**＝見える変更なので、08-23 裁定の施主目視ゲートにかけ、次のリリース波に乗せる

caret の書き換えを本 PR に入れていないのは、0.19.0 が未 publish で `npm i` が解決できないため。

## 検査

`npm run check` 全段緑（type-check / lint / format / coverage:check / knip / stylelint / **slot-values** / **slot-pairs** / registries:check / build / source-probe / build-storybook）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016yoeVURotw4eeyLF9SL76q