### PR TITLE
chore(deps): nene2-ui 0.17.1 → 0.19.0 — Badge の gap / size / weight をキットのスロットへ返す（#481）

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@hideyukimori/nene2-client": "^1.1.0",
-        "@hideyukimori/nene2-ui": "^0.17.0",
+        "@hideyukimori/nene2-ui": "^0.19.0",
         "@hookform/resolvers": "^3.10.0",
         "@tanstack/react-query": "^5.62.11",
         "react": "^19.2.6",
@@ -1712,9 +1712,9 @@
       }
     },
     "node_modules/@hideyukimori/nene2-ui": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@hideyukimori/nene2-ui/-/nene2-ui-0.17.1.tgz",
-      "integrity": "sha512-3t6ikVwbUhzPfkV6wTpoUCRPZV+M14W0YEAVkzf1TNG+aY2ED8/t+GiW783Bx7Irin2RLwG5LTr1iZ9g0lI3ew==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@hideyukimori/nene2-ui/-/nene2-ui-0.19.0.tgz",
+      "integrity": "sha512-lL829MYn/RhpN3ehGB9S+x/mV9Pzq6miCHLFrQeiJs1tgwAYkaDwXN/YVJVV710EejzM/U7KCtw8RFHcSl0LNw==",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@hideyukimori/nene2-client": "^1.1.0",
-    "@hideyukimori/nene2-ui": "^0.17.0",
+    "@hideyukimori/nene2-ui": "^0.19.0",
     "@hookform/resolvers": "^3.10.0",
     "@tanstack/react-query": "^5.62.11",
     "react": "^19.2.6",

--- a/frontend/src/features/document-search/ui/DocumentTable.test.tsx
+++ b/frontend/src/features/document-search/ui/DocumentTable.test.tsx
@@ -76,7 +76,7 @@ describe('DocumentTable', () => {
     expect(screen.getByText('Active')).toBeInTheDocument();
   });
 
-  // Regression guard: the status badge is the kit's `Badge` (0.17.0, W1b) carrying this
+  // Regression guard: the status badge is the kit's `Badge` (0.19.0, #481) carrying this
   // product's dot through `className`. Asserts the kit's tone slot class and the dot
   // utilities, not a retired class name (判例#34).
   it('renders the status as the kit Badge with the product dot', () => {
@@ -84,15 +84,21 @@ describe('DocumentTable', () => {
     const badge = screen.getByText('Active');
     expect(badge).toHaveClass('inline-flex', 'items-center', 'border');
     expect(badge).toHaveClass('bg-x-slot-badge-success-bg', 'text-x-slot-badge-success-fg');
-    expect(badge).toHaveClass('text-2xs', 'font-semibold', 'leading-badge');
-    // `.badge::before` — the dot, now `BADGE_CHROME`.
+    // Gap, size and weight are the kit's own slots since 0.19.0. Asserting them here would
+    // pin the kit's class names from a product test; the product's stake is that they come
+    // from the kit at all, which the `not.toHaveClass` below states directly.
+    expect(badge).toHaveClass('gap-x-slot-badge-gap', 'text-x-slot-badge', 'font-x-slot-badge');
+    // `.badge::before` — the dot, and the line-height the kit ships no companion slot for.
     expect(badge).toHaveClass(
-      'gap-1.5',
+      'leading-badge',
       'before:w-1.5',
       'before:h-1.5',
       'before:rounded-full',
       'before:bg-current',
     );
+    // 🔴 The three that moved to the kit in 0.19.0. They lose to `BASE_CLASS` on source
+    // order, so leaving them on `className` would read as if they still set something.
+    expect(badge).not.toHaveClass('gap-1.5', 'text-2xs', 'font-semibold');
     expect(badge).not.toHaveClass('badge');
     expect(badge).not.toHaveAttribute('data-tone');
   });

--- a/frontend/src/shared/ui/primitives/badgeBase.ts
+++ b/frontend/src/shared/ui/primitives/badgeBase.ts
@@ -1,10 +1,18 @@
-// What this product adds on top of the kit's `Badge` (0.17.0) through `className`:
-// the type the kit has no slot for (2xs, semibold, the explicit 1.4 line-height — 判例40)
+// What this product adds on top of the kit's `Badge` (0.19.0) through `className`: the
+// explicit 1.4 line-height (判例40 — a `--text-*` without its companion leaves line-height
+// to whatever the cascade supplies, and the kit ships no `--text-x-slot-badge--line-height`)
 // and the status dot in front of the label, which no other ship draws (fleet reply
-// 2026-08-25). Colours, radius and padding are slot values in `themes/default.css`.
+// 2026-08-25). Colours, radius, padding, gap, size and weight are the kit's own slots.
+//
+// 🔴 `gap-1.5`, `text-2xs` and `font-semibold` were here until 0.19.0 gave `Badge` a gap, a
+// size and a weight of its own (#481). They are not merely redundant now — they are inert:
+// `className` loses to the kit's `BASE_CLASS`, same specificity, decided by the order the CSS
+// is generated in, and the kit's slot-derived classes are emitted later. Keeping them would
+// have left three declarations that read as if they still set something. The rendered values
+// are unchanged: 4px replaces this product's 6px (deliberate, see `themes/default.css`),
+// while size and weight were already identical to the kit's defaults.
 //
 // `before:` already emits `content: var(--tw-content)` (initial `""`); `before:rounded-full`
 // on a 6×6 box is the same circle the retired `.badge::before { border-radius: 50% }` drew.
 export const BADGE_CHROME =
-  'text-2xs font-semibold leading-badge gap-1.5 ' +
-  'before:w-1.5 before:h-1.5 before:rounded-full before:bg-current';
+  'leading-badge before:w-1.5 before:h-1.5 before:rounded-full before:bg-current';

--- a/frontend/src/shared/ui/theme/themes/default.css
+++ b/frontend/src/shared/ui/theme/themes/default.css
@@ -193,29 +193,30 @@
   /* ── Badge (W1b, owner NG 2026-08-26) ────────────────────────────────────────
      The kit's tones are solid fills (colour on white text); this product's status badges have
      always been the soft pill — tinted ground, coloured text, no visible border, fully round.
-     Slots choose steps, so the pill lives here as slot values; the type (2xs, semibold,
-     leading-badge) and the dot ride on `BADGE_CHROME` because the kit has no text-size slot. */
-  /* 🔴 gap: chosen ahead of nene2-ui 0.19.0, which gives `Badge` a gap / font-size /
-     font-weight of its own (kit #463). `className` loses to the kit's `BASE_CLASS` — same
-     specificity, decided by the order the CSS is generated in — so `gap-1.5` stops winning
-     the moment that version lands, and the value has to be a slot to survive.
+     Slots choose steps, so the pill lives here as slot values; since 0.19.0 the size and
+     weight are the kit's slots too, and only `leading-badge` and the dot ride on
+     `BADGE_CHROME` (see below). */
+  /* 🔴 gap, size and weight are deliberately NOT overridden. 0.19.0 gave `Badge` all three
+     (kit #463), and this product's values did not survive the comparison:
 
-     This is 6px → 4px, and it is deliberate. 6px cannot be written here: `slot-values` fails
-     on a literal, and the kit's scale has no 6px step (3xs 4px · 2xs 8px · xs 12px …) — a
-     slot chooses a step, it may not invent one. Routing through this product's own
-     `--spacing-stack-xs` (0.375rem) would pass the checker and defeat it: that is exactly
-     the drift the scale exists to stop. The kit keeps 4px as its default because the two
-     ships that overrode it disagreed — 6px here, 5px in deal — and neither is a step, so
-     honouring one would only make the other's drift canonical.
+       gap     6px → the kit's 4px. 6px is unwritable here — `slot-values` rejects a literal
+               and the scale has no 6px step (3xs 4px · 2xs 8px · xs 12px …); a slot chooses
+               a step, it may not invent one. Routing through this product's own
+               `--spacing-stack-xs` (0.375rem) would pass the checker and defeat it, which is
+               the drift the scale exists to stop. The kit kept 4px because the two ships
+               that overrode it disagreed — 6px here, 5px in deal — and neither is a step.
+       size    already identical: `--text-2xs` and the kit's `--text-x-2xs` are both
+               0.6875rem. An override would restate the default.
+       weight  already identical: semibold both sides.
 
-     ⚠️ Inert until 0.19.0: 0.17.1's `Badge` does not read this slot, so the rendered gap is
-     still `gap-1.5`'s 6px. It becomes 4px when the caret is raised and `gap-1.5` comes off
-     `BADGE_CHROME` (#479 step 3) — that step is a visible change and takes the owner's look.
+     ⚠️ #479 wrote `--spacing-x-slot-badge-gap: var(--spacing-x-3xs)` here and #481 removed it
+     again — byte-identical to the kit's own default, so it changed nothing and only added a
+     place where a future retune of the kit's scale would be silently pinned. Accepting a
+     default means writing nothing. The rule the kit distributes says it plainly: measure your
+     current value, override only what differs.
 
-     Only the type and the dot stay on `BADGE_CHROME`: `--text-x-slot-badge` needs no override
-     (this product's `--text-2xs` is 0.6875rem = 11px, the kit's default exactly) and the kit
-     ships no companion `--text-x-slot-badge--line-height`, so `leading-badge` still applies. */
-  --spacing-x-slot-badge-gap: var(--spacing-x-3xs);
+     `BADGE_CHROME` keeps only what the kit has no slot for — `leading-badge` (no companion
+     `--text-x-slot-badge--line-height` is shipped) and the status dot. */
   --color-x-slot-badge-success-bg: var(--color-success-soft);
   --color-x-slot-badge-success-fg: var(--color-success);
   --color-x-slot-badge-success-border: var(--color-success-soft);


### PR DESCRIPTION
Closes #481 ／ #479 の続き（段階3）

上流 `@hideyukimori/nene2-ui` **0.19.0 が publish された**ので着手（kit #463）。`Badge` が gap / font-size / font-weight を自前のスロットで持つようになった。

## 変更

| | |
| --- | --- |
| `package.json` | `^0.17.0` → `^0.19.0`（`npm ls` 実測 **0.19.0**） |
| `badgeBase.ts` | `BADGE_CHROME` から `gap-1.5` `text-2xs` `font-semibold` を除去 |
| `themes/default.css` | **#479 で足したスロット行を撤回**（下記）＋コメントを実態へ |
| `DocumentTable.test.tsx` | バッジ回帰ガードを 0.19.0 の形へ |

`BADGE_CHROME` に残すのは、**キットにスロットが無いものだけ**:

```ts
'leading-badge before:w-1.5 before:h-1.5 before:rounded-full before:bg-current'
```

- `leading-badge` … 相棒 `--text-x-slot-badge--line-height` が出荷されていない（判例40）
- `before:*` … 本製品固有の状態ドット

除去した3つは**単に冗長なのではなく inert**。`className` は `BASE_CLASS` に負ける（同一詳細度・生成 CSS の出現順で、キットのスロット由来クラスが後に出る）。残せば「まだ何かを設定している」ように読める宣言が3つ残る。

## 描画値（生成 CSS で実測）

```
gap          var(--spacing-x-slot-badge-gap) → var(--spacing-x-3xs) → .25rem  = 4px
font-size    var(--text-x-slot-badge)        → var(--text-x-2xs)    → .6875rem = 11px
font-weight  var(--font-weight-x-slot-badge) → var(--font-weight-semibold) → 600
line-height  var(--leading-badge)            → 1.4
```

⇒ **動くのは gap 6px → 4px のみ。** size / weight / line-height / ドットは不変。

## 🔴 #479 で足したスロット行を撤回します

```css
--spacing-x-slot-badge-gap: var(--spacing-x-3xs);
```

これは **キット既定とバイト単位で同一**でした（`node_modules/@hideyukimori/nene2-ui/themes/default.css:172` と同一テキスト）。既定を再宣言しているだけで**何も変えず**、将来キットがスケールを調整した際に**誰も決めていない値を黙って固定する箇所**を1つ増やすだけになります。

上流が配布メモに書いた規則がそのまま当てはまります — **「自艦の現行値を測り、既定と違うものだけ再定義せよ」**。⇒ **既定を受け入れるとは、何も書かないこと。** #479 の実質的な差分は 0 でした（値の選定理由はコメントとして残してあります）。

## 検知器を壊して確かめました

バッジ回帰ガードを 0.19.0 の形へ更新し、**変異で赤にできること**を確認:

```
変異1: 除去した3つを className に戻す  → not.toHaveClass で FAIL
変異2: leading-badge を落とす          → toHaveClass で FAIL
```

どちらも復元済み。緑のままでは、ガードが実際に何かを守っている証拠になりません。

## 検査

`npm run check` 全段緑 — **241 tests** / type-check / lint / format / coverage:check / knip / stylelint / slot-values / slot-pairs / registries:check / build / source-probe / build-storybook。

## ⚠️ 本番へは出しません

**gap 6px → 4px は見える変更**です。08-23 裁定（本番デプロイ前に施主の目視・**波1回**）どおり、単独では出さず**次のリリース波の目視束に含めて GO を受けます**。本番は `c6890e4`（0.9.2.1）のまま。

⇒ 「npm に 0.19.0 が出た」と「vault の本番に 4px が載った」は**別の時点**として数えてください（上流とも合意済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016yoeVURotw4eeyLF9SL76q