### PR TITLE
fix(build): msw の service worker を本番ビルドから外し、見逃していた検知器を直す（#485）

### DIFF
--- a/frontend/tools/assert-no-msw-in-build.mjs
+++ b/frontend/tools/assert-no-msw-in-build.mjs
@@ -1,38 +1,95 @@
 /**
- * Fail if msw reaches the production bundle.
+ * Fail if msw reaches the production bundle — as bundled code, or as a file.
  *
- * `src/main.tsx` starts a mock service worker behind `import.meta.env.DEV &&
- * import.meta.env.VITE_MSW === '1'`. In a production build `DEV` is a compile-time `false`,
- * so the branch and its dynamic import are dropped and msw — a devDependency — never ships.
+ * Two ways it can get there, and they need different checks:
  *
- * 🔴 That is a claim about a bundler's behaviour, and a comment cannot enforce it. A future
- * refactor that lifts the import to the top of the module, or a config change that stops
- * constant-folding `DEV`, would ship an interception layer to real users and break nothing
- * that any existing check looks at. This reads the built output instead.
+ *   1. **Bundled.** `src/main.tsx` starts a mock worker behind `import.meta.env.DEV &&
+ *      import.meta.env.VITE_MSW === '1'`. In a production build `DEV` is a compile-time
+ *      `false`, so the branch and its dynamic import are dropped. That is a claim about a
+ *      bundler's behaviour and a comment cannot enforce it, so this reads the built output.
  *
- * Positive control: `node tools/assert-no-msw-in-build.mjs --self-test` proves the detector
- * can fail, by scanning a fixture that does contain the marker. A checker nobody has seen go
- * red is not evidence.
+ *   2. **Copied.** `msw init` writes `public/mockServiceWorker.js`, and Vite copies `public/`
+ *      into `dist/` verbatim. The `vault-strip-msw-worker` plugin in `vite.config.ts` removes
+ *      it again; this checks that it actually did.
+ *
+ * 🔴 This file previously missed (2) completely, and the reason is worth keeping. Its markers
+ * were invented — `msw/browser`, `setupWorker`, `mockServiceWorker`, `msw/core` — and then
+ * "proved" against a string written by hand in the self-test. Measured 2026-08-28: the real
+ * `mockServiceWorker.js` contains **none of those four**. So the checker reported
+ * "OK — no msw markers" while the worker sat in `dist/`, and its positive control passed the
+ * whole time, because the control tested the matcher against fiction rather than against the
+ * artifact. The markers below are now quoted out of the shipped file, and the self-test scans
+ * that file.
+ *
+ * Usage:  node tools/assert-no-msw-in-build.mjs [--self-test]
  */
 import { readdir, readFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 
-const DIST = new URL('../dist', import.meta.url).pathname;
+const ROOT = new URL('..', import.meta.url).pathname;
+const DIST = join(ROOT, 'dist');
+const WORKER_SOURCE = join(ROOT, 'public/mockServiceWorker.js');
 
-// Strings that only appear if msw's browser runtime was bundled. Not the bare word "msw":
-// that occurs in unrelated identifiers and would make this checker fire on noise.
-const MARKERS = ['msw/browser', 'setupWorker', 'mockServiceWorker', 'msw/core'];
+// Verbatim from `public/mockServiceWorker.js` (msw 2.x) and from msw's browser runtime.
+// Not the bare word "msw": it occurs inside unrelated identifiers and would fire on noise.
+const CONTENT_MARKERS = [
+  'Mock Service Worker', // the worker file's own header comment
+  'mswjs/msw', // the @see URL in that header
+  'msw/browser', // the module specifier, if the dev branch were ever bundled
+  'setupWorker', // its export
+];
 
-const scan = (text) => MARKERS.filter((m) => text.includes(m));
+// A file can carry msw by its name alone — the worker's body never says "mockServiceWorker".
+const NAME_MARKERS = ['mockServiceWorker'];
+
+const SCANNABLE = /\.(js|mjs|cjs|css|html|json|map)$/;
+
+const walk = async (dir) => {
+  const out = [];
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...(await walk(p)));
+    else out.push(p);
+  }
+  return out;
+};
+
+const inspect = async (file) => {
+  const name = file.slice(DIST.length + 1);
+  const hits = NAME_MARKERS.filter((m) => name.includes(m)).map((m) => `name:${m}`);
+  if (SCANNABLE.test(file)) {
+    const text = await readFile(file, 'utf8');
+    hits.push(...CONTENT_MARKERS.filter((m) => text.includes(m)).map((m) => `content:${m}`));
+  }
+  return { name, hits };
+};
 
 if (process.argv.includes('--self-test')) {
-  const hits = scan('const x = setupWorker(); // from "msw/browser"');
-  if (hits.length === 0) {
-    console.error('self-test FAILED: the detector did not fire on text that contains markers.');
+  // 🔴 The control scans the real artifact. Proving the matcher fires on a hand-written
+  // string proves nothing about whether the markers describe what actually ships.
+  if (!existsSync(WORKER_SOURCE)) {
+    console.error(`self-test FAILED: ${WORKER_SOURCE} not found — run \`npx msw init public/\`.`);
     process.exit(1);
   }
-  console.log(`self-test OK — detector fires on ${hits.length} marker(s): ${hits.join(', ')}`);
+  const text = await readFile(WORKER_SOURCE, 'utf8');
+  const contentHits = CONTENT_MARKERS.filter((m) => text.includes(m));
+  const nameHits = NAME_MARKERS.filter((m) => 'mockServiceWorker.js'.includes(m));
+  if (contentHits.length === 0) {
+    console.error(
+      'self-test FAILED: no content marker matches the real worker file. ' +
+        'The markers describe something other than what ships.',
+    );
+    process.exit(1);
+  }
+  if (nameHits.length === 0) {
+    console.error("self-test FAILED: no name marker matches 'mockServiceWorker.js'.");
+    process.exit(1);
+  }
+  console.log(
+    `self-test OK — the real worker is caught by ${contentHits.length} content marker(s) ` +
+      `(${contentHits.join(', ')}) and ${nameHits.length} name marker(s) (${nameHits.join(', ')}).`,
+  );
   process.exit(0);
 }
 
@@ -41,28 +98,21 @@ if (!existsSync(DIST)) {
   process.exit(1);
 }
 
-const walk = async (dir) => {
-  const out = [];
-  for (const entry of await readdir(dir, { withFileTypes: true })) {
-    const path = join(dir, entry.name);
-    if (entry.isDirectory()) out.push(...(await walk(path)));
-    else if (/\.(js|mjs|css|html)$/.test(entry.name)) out.push(path);
-  }
-  return out;
-};
-
 const files = await walk(DIST);
 const bad = [];
 for (const file of files) {
-  const hits = scan(await readFile(file, 'utf8'));
-  if (hits.length > 0) bad.push({ file: file.slice(DIST.length + 1), hits });
+  const { name, hits } = await inspect(file);
+  if (hits.length > 0) bad.push({ name, hits });
 }
 
 if (bad.length > 0) {
   console.error('msw reached the production bundle:');
-  for (const b of bad) console.error(`  ${b.file} — ${b.hits.join(', ')}`);
-  console.error('\nThe dev-only guard in src/main.tsx is no longer doing its job.');
+  for (const b of bad) console.error(`  ${b.name} — ${b.hits.join(', ')}`);
+  console.error('\nEither the dev-only guard in src/main.tsx or vite.config.ts’s');
+  console.error('`vault-strip-msw-worker` plugin is no longer doing its job.');
   process.exit(1);
 }
 
-console.log(`assert-no-msw-in-build: OK — ${files.length} built file(s), no msw markers.`);
+console.log(
+  `assert-no-msw-in-build: OK — ${files.length} built file(s), no msw by name or content.`,
+);

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,10 +1,36 @@
+import { rm } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
-import { defineConfig, loadEnv } from 'vite';
+import { defineConfig, loadEnv, type Plugin } from 'vite';
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Keep msw's service worker out of production builds.
+ *
+ * `msw init` puts `mockServiceWorker.js` in `public/`, which is where it has to be for the
+ * dev-only mock to register it (`VITE_MSW=1`, see `src/main.tsx`). Vite copies everything in
+ * `public/` into `dist/` verbatim, so without this the worker would be deployed and sit at
+ * `https://…/mockServiceWorker.js` on the production host.
+ *
+ * 🔴 It would be inert there — a service worker does nothing until a page registers it, and
+ * the only code that registers this one is dropped from production builds. "Inert" is not
+ * "should ship": it is a request-interception layer published on the origin that serves
+ * received-document archives, and nothing in the product needs it.
+ *
+ * Verified from the other side by `tools/assert-no-msw-in-build.mjs`, which reads `dist/`
+ * after the build rather than trusting this plugin ran.
+ */
+const stripMswWorker = (): Plugin => ({
+  name: 'vault-strip-msw-worker',
+  apply: 'build',
+  // `closeBundle` runs after Vite has copied `public/`, which `generateBundle` does not.
+  closeBundle: async () => {
+    await rm(path.resolve(dirname, 'dist/mockServiceWorker.js'), { force: true });
+  },
+});
 
 export default defineConfig(({ mode }) => {
   // Read NENE_VAULT_PORT and NENE_VAULT_APP_HOST from the project-root .env
@@ -17,7 +43,7 @@ export default defineConfig(({ mode }) => {
   const target = `http://${appHost}:${appPort}`;
 
   return {
-    plugins: [react(), tailwindcss()],
+    plugins: [react(), tailwindcss(), stripMswWorker()],
     resolve: {
       alias: {
         '@': path.resolve(dirname, './src'),


### PR DESCRIPTION
Closes #485. `f9cd55b`（#484）の後続。**本番配備前に発見**（本番 `c6890e4` に当該ファイルは無い）。

## 欠陥2件

**1. `mockServiceWorker.js` が本番ビルドに同梱されていた。** `msw init` → `public/` → Vite が `dist/` へコピー → `build-release.sh:86` が `frontend/dist/` を `public_html/` へ丸ごとコピー。⇒ 修正前にリリース zip を作っていたら `https://vault.ayane.co.jp/mockServiceWorker.js` が公開されていた。

登録する側のコードは本番ビルドから落ちているので**不活性ではある**。ただし「不活性」は「出してよい」ではない——**受領書類のアーカイブを配信するオリジンにリクエスト横取り層を1つ置く**ことになり、製品側でそれを必要とする箇所は無い。

**2. 🔴 その検知器が見逃していた。** `assert-no-msw-in-build.mjs` は「dist に msw が出ていないこと」を検査するために書いたのに、`dist/mockServiceWorker.js` が在る状態で `OK` を返し続けた。

| 原因 | |
|---|---|
| マーカーを**発明した** | `msw/browser` / `setupWorker` / `mockServiceWorker` / `msw/core`。**実物の worker にはこの4つが1件も含まれていない**（実測）。worker が自分を名乗るのは `Mock Service Worker` と `mswjs/msw` の2つ |
| **ファイル名を見ていなかった** | worker の本文に `mockServiceWorker` という語は出てこない。**名前にしか無い** |

🔴 **そして陽性対照が通っていた。** `--self-test` は**手で書いた文字列**にマッチャを当てていたので、「マッチャは動く」ことは示せても「**そのマーカーが出荷物を describe しているか**」は一度も検証していなかった。⇒ **代理（マッチャ）を検査して、本体（出荷物との対応）を検査していなかった。**

## 直したもの

- `vite.config.ts` に `vault-strip-msw-worker`（`apply: 'build'` / `closeBundle`）。`public/` のコピーは `generateBundle` より後に走るので `closeBundle` でないと消せない
- 検知器を**名前と内容の両方**で判定する形へ。マーカーは**出荷物から逐語で取った**
- `--self-test` を**実物の `public/mockServiceWorker.js` を走査する**形へ（マーカーが実物に当たらなければ self-test 自体が落ちる）
- 変異テストで確認: worker を `dist/` へ戻すと `rc=1` で赤（`name:mockServiceWorker, content:Mock Service Worker, content:mswjs/msw`）

## 教訓

**検証対象は出荷物から逐語抽出する。** 思い出して書いたマーカーは、思い出した通りの物にしか当たらない。そして**陽性対照は、検知器が守るべき現物に対して回す**——作り物に対して回した陽性対照は、検知器が「動くこと」しか言わない。

`composer check` 🟢 `npm run check` 🟢
