### PR TITLE
docs(owner-review): 本番の基準を 9d455a1（0.9.3・2026-08-28 19:03:02）へ（#488）

### DIFF
--- a/docs/qa/owner-review/README.md
+++ b/docs/qa/owner-review/README.md
@@ -50,7 +50,13 @@ org is minted per side per run; the viewport is switched on the same page.
 
 | column | is |
 | --- | --- |
-| **production** | whatever `vault.ayane.co.jp` served at run time — **not "the current design"**. Establish which build that is before reading a row (from 2026-08-26 01:32:50 JST: `c6890e4`, 0.9.2.1; earlier that night: `d2f0920`, 0.9.2; 2026-08-25: `6da5eb0`, 0.9.1; before that: `97da1e0`, 2026-07-12) |
+| **production** | whatever `vault.ayane.co.jp` served at run time — **not "the current design"**. **Do not establish this by hand — the manifest records it.** `meta.json` carries the content-hashed
+asset names production referenced at run time, which identify the build exactly: build the candidate
+commit and the filenames either match or they do not (added 2026-08-28, #487).
+History: from 2026-08-28 19:03:02 JST **`9d455a1`, 0.9.3** (`index-BKF0C1Uw.js` / `index-kqGaLvK2.css`);
+2026-08-26 01:32:50: `c6890e4`, 0.9.2.1 (`index-tudmWql9.js` / `index-DRS_fEZs.css`, verified by
+rebuild); earlier that night: `d2f0920`, 0.9.2; 2026-08-25: `6da5eb0`, 0.9.1; before that: `97da1e0`,
+2026-07-12 |
 | **local** | the build named in `meta.json` (`local HEAD`, `local nene2-ui`) |
 
 Content differs between the columns by design (each side has its own disposable org):


### PR DESCRIPTION
配備完了（19:03:02）に伴う本番履歴の更新。

併せて「**行を読む前に本番のビルドを確定せよ**」という**人への要求**を、「**manifest が記録している**」という事実の記述へ書き換えました（#487 で自動記録になったため）。要求を文書に書いても、絵を見ている人はその作業をしません。

各版に指紋（内容ハッシュのアセット名）を併記。0.9.2.1 の指紋は 08-28 に worktree で再ビルドして一致を確認済みなので、**配備メモが正しかったことを検算した上での記載**です。

配備後スモーク（本番・実ブラウザ・ja）:
- 指紋 `index-BKF0C1Uw.js` / `index-kqGaLvK2.css` = 新ビルドと一致
- `/health` 200・`/demo/standard` 200・一覧19行・詳細・無効化ダイアログまで到達・JS エラーなし
- danger 2箇所とも fg `oklch(0.98 0.01 83)` / bg `oklch(0.56 0.097 33)` / border 透明 / 影あり / 高さ 38.14px（隣の outline と一致）・折り返し 0