### PR TITLE
qa(tools): 到達判定を「数えるものが出るまで待つ」形にする＋warn の出所を訂正

### DIFF
--- a/frontend/src/shared/ui/theme/themes/default.css
+++ b/frontend/src/shared/ui/theme/themes/default.css
@@ -73,10 +73,19 @@
      nene2-ui 0.20.0 gave the same token a second background. `Button` `solid` × `warn`
      paints `--color-on-warn` on the full `--color-warn`, and there the same value is
      **2.37:1 — below AA** (measured 2026-08-28, sRGB from oklch, in a browser).
-     The kit's own contrast test is not wrong; it computes against the *contract's* warn pair
-     (0.70/0.15/85 with 0.20/0.02/85 = 6.71:1). That guarantee does not survive a product
-     redefining `--color-warn`, which this one does — so an upstream green does not transfer
-     to any ship that repaints the token.
+     The kit's own contrast test is not wrong, and neither is the number it reports. Measured
+     2026-08-28 in a browser (canvas pixels, positive control white/black = 21.00:1), there are
+     **two** upstream warn pairs and they disagree:
+       nene2-tokens/themes/reference.css  0.70/0.15/85 with 0.20/0.02/85  → 6.73:1
+       nene2-ui/themes/default.css        0.63/0.135/75 with 0.21/0.04/75 → 4.98:1  ← the kit's
+     The kit's default is deliberately off the contract's reference — its comment gives the
+     reason, the median of eight ships' own `--color-warn` (2026-08-23) — and `contract-freeze`
+     records slot *names* only, so no value is frozen anywhere (fleet #504). What that means
+     here: redefining `--color-warn` is not a deviation, and an upstream green does not transfer
+     to a ship that repaints the token, whichever of the two it is measured against.
+     ⚠️ An earlier version of this comment called the 6.73 pair "the contract" and cited 6.71.
+     That named one of two files as if it were the only one; the arithmetic was right and the
+     attribution was wrong.
      ⚠️ Nothing renders it today: `tone="warn"` is used **zero** times here (all 25 call
      sites are accent, neutral or danger). No slot is set for it for the same reason
      `bare`'s ink is not set — a value nothing draws is a value nobody can check. This

--- a/frontend/tools/shoot-real-screens.mjs
+++ b/frontend/tools/shoot-real-screens.mjs
@@ -27,16 +27,33 @@ const BASE = process.env.VAULT_MSW_URL ?? 'http://localhost:5199';
 const OUT_DIR = process.argv[2] ?? join(ROOT, 'real-screens');
 const DOCUMENT_ID = 'doc-01J0000000000000000000000';
 
+/**
+ * 🔴 `minButtons` is the arrival check that matters, and `landmark` alone is not enough.
+ *
+ * A landmark says "something rendered", not "the thing I am about to count rendered". Measured
+ * on production 2026-08-28: on document-detail the `<h1>` paints before the toolbar, because
+ * the toolbar is gated on capabilities that arrive with a later response — so a sweep that
+ * waited for `h1` and then counted read **zero kit buttons on a page that has four**. It
+ * reported a clean zero, exactly the shape nene-deal hit the same day from a different cause
+ * (sitting on the login form). **A screen not finished and a screen with nothing on it return
+ * the same number.**
+ *
+ * So each screen declares how many kit buttons it must end up with, and the run *waits for
+ * that count* rather than sampling once. A screen that never reaches it fails loudly.
+ * Declaring the number also makes a regression visible: if a screen quietly loses a button,
+ * the wait times out instead of silently capturing one fewer.
+ */
 const SCREENS = [
-  { name: 'documents', path: '/documents', landmark: 'table, [role="table"]' },
+  { name: 'documents', path: '/documents', landmark: 'table, [role="table"]', minButtons: 1 },
   {
     name: 'document-detail',
     path: `/documents/${DOCUMENT_ID}`,
     landmark: 'h1',
+    minButtons: 4,
     openDialog: '無効化',
   },
-  { name: 'audit', path: '/audit', landmark: 'h1' },
-  { name: 'users', path: '/users', landmark: 'h1' },
+  { name: 'audit', path: '/audit', landmark: 'h1', minButtons: 1 },
+  { name: 'users', path: '/users', landmark: 'h1', minButtons: 1 },
 ];
 
 const VIEWPORTS = [
@@ -110,8 +127,8 @@ for (const vp of VIEWPORTS) {
     attempted += 1;
     await page.goto(`${BASE}${screen.path}`, { waitUntil: 'networkidle' });
 
-    // 🔴 Arrival check, before anything is counted. Zero buttons on a screen you never
-    // reached is indistinguishable from zero buttons on a screen that has none.
+    // 🔴 Arrival check, before anything is counted, in two steps: the landmark says the route
+    // resolved, and the button count says the part being measured has actually painted.
     const onLogin = page.url().includes('/login');
     const landmark = await page
       .locator(screen.landmark)
@@ -125,9 +142,26 @@ for (const vp of VIEWPORTS) {
       continue;
     }
 
+    // Wait for the declared count instead of sampling once — see the note on SCREENS.
+    const arrived = await page
+      .waitForFunction(
+        (min) =>
+          [...document.querySelectorAll('button')].filter(
+            (el) => el.className.includes('x-slot-button') && el.getBoundingClientRect().height > 0,
+          ).length >= min,
+        screen.minButtons,
+        { timeout: 15000 },
+      )
+      .then(() => true)
+      .catch(() => false);
+
     const buttons = await readButtons(page);
-    if (buttons.length === 0) {
-      failures.push(`${screen.name}@${vp.tag}: reached, but zero kit buttons — check selector`);
+    if (!arrived) {
+      // Never a clean zero: say what was expected, what was found, and that this is a failure.
+      failures.push(
+        `${screen.name}@${vp.tag}: reached, but only ${buttons.length} kit button(s) after 15s ` +
+          `(expected >= ${screen.minButtons}) — the page did not finish, or the selector is wrong`,
+      );
     }
 
     const file = `real-${screen.name}-${vp.tag}.png`;


### PR DESCRIPTION
## 到達判定 — `landmark` だけでは足りない

landmark は「何かが描画された」としか言わず、「**これから数えるものが描画された**」とは言いません。

**本番で実測（2026-08-28 配備後スモーク）**: 文書詳細の `<h1>` は**権限依存のツールバーより先に**描画されるので、`h1` を待ってから数える走査は **ボタン4個の画面でキット Button 0件**を返しました。**きれいな0**です——同じ日に nene-deal が**別の原因**（ログイン画面に居た）で出したのと同じ形。

> **未完成の画面と、何も無い画面は、同じ数を返す。**

⇒ 画面ごとに `minButtons`（最終的に在るべき数）を宣言し、**その数に達するまで待つ**形へ。達しなければ 0 を返さず異常終了します。

**変異テスト済み**: `minButtons: 4 → 99` で **rc=1**（`document-detail@desktop: reached, but only 4 kit button(s) after 15s (expected >= 99)`）、戻すと rc=0。

🔑 **数を宣言すると退行も見えます。** 画面が静かにボタンを1つ失えば待ちがタイムアウトします。「0でないこと」だけ見ていると気づけません。

⚠️ **その変異テストで自分も踏みました**: 「FAILED」と表示されているのに **rc=0** と読んだ。`| tail` の終了コードでした（直接実行なら rc=1）。**今日この形は3回目**——自分の docker 判定・deal の docker 判定（こちらが指摘した側）・今回。**rc を読むならパイプを通さない。**

## warn の出所を訂正

`default.css` の注記で 6.71:1 を「**契約の** warn 対」と書きましたが、上流には**2つあります**:

| ファイル | 対 | 実測 |
|---|---|---:|
| `nene2-tokens/themes/reference.css` | 0.70/0.15/85 × 0.20/0.02/85 | **6.73:1** |
| `nene2-ui/themes/default.css` | 0.63/0.135/75 × 0.21/0.04/75 | **4.98:1** ← キットの既定 |

キットの既定は**意図的に**参照値から離れています（コメント曰く「使用中8艦の `--color-warn` 定義の中央値」・2026-08-23）。`contract-freeze` はスロット**名**しか記録しないので**値はどこにも凍結されていない**（fleet #504）。

⇒ **`--color-warn` の再定義は逸脱ではない**、という理解に更新。「上流の green は塗り替えた艦へ伝播しない」という結論は**どちらの対を基準にしても成立**します。

🔴 私は fleet へ「**計算そのものが分岐している**」と返しましたが誤りでした。**同じ式に別の色を入れていただけ**です。「両方の数字が違う ⇒ 式が違う」は**入力が同じときにだけ成り立つ推論**で、その前提を確かめていませんでした。キットの `themes/default.css` は同日に3回開いているのに、`--color-x-slot-button-*` を grep していたので**素のトークン定義が視野に入っていなかった**——「接頭辞 grep の窓」を、同じファイルで踏んでいます。

数値はすべてブラウザの canvas ピクセル実測（**陽性対照 white × black = 21.00:1**）。

`npm run check` 🟢
