### PR TITLE
ci: weekly-audit.yml を入れる — PHP の週次再検査が存在しなかった（#492・fleet #502 の適用1号）

### DIFF
--- a/.github/workflows/weekly-audit.yml
+++ b/.github/workflows/weekly-audit.yml
@@ -1,0 +1,113 @@
+# weekly-audit.yml — PHP 依存の週次再検査（nene-vault・#492）
+#
+# 原本: nene2-fleet-tooling `docs/ci/weekly-audit.yml`（`21c4897`）。fleet #502 の適用1号。
+# 🔴 原本を更新したら、ここも追随すること（写しは中央に自動追随しない・フリート #240 の型）。
+#
+# 🔴 なぜ専用 workflow を1本立てるのか（施主決定 2026-08-22 (c)）
+#    vault の現状は `schedule` が frontend-ci.yml（`35 0 * * 1`）・`composer audit` が
+#    backend-ci.yml にあり、**交差していない**＝ PHP 側が週次で一度も再検査されていなかった。
+#    (a) backend に schedule を足す … cron が艦あたり2本になる ⇒ 却下
+#    (b) audit を frontend へ寄せる … 名前が実態と乖離する    ⇒ 却下
+#    (c) 週次専用を1本                                        ⇒ 採用
+#
+#    🔑 advisory は**我々のコミットではなく向こう側の時計で公開される**ので、
+#       PR 時の検査だけでは「世界が動いたか」を見られない。
+#
+# この写しで vault 固有に決めたもの:
+#   - cron の分 = `40`（フリート割当。NENE2 が `30 1 * * 1` を使用済みなので 1時台25分以降に配分）
+#   - php-version = `8.4`（composer.json の `"php": ">=8.4.1 <9.0"` に合わせた）
+#   - ISSUE_TITLE = 既存2本（Backend CI / 週次 CI）と衝突しない題
+#   - notify の `if` = 🔴 **この workflow が持つ event から導出**（下のコメント参照）
+
+name: Weekly audit
+
+on:
+  schedule:
+    # 🔴 分は艦ごとに変えること（上の割当表）。ここは原本なので未割当の 25 を置いてある。
+    - cron: '40 1 * * 1'
+  workflow_dispatch:
+    inputs:
+      simulate_failure:
+        description: '陽性対照: 意図的に赤にして notify を発火させる'
+        required: false
+        default: false
+        type: boolean
+
+# 週次なので同時実行は起きない想定だが、dispatch と重なりうるので明示する。
+concurrency:
+  group: weekly-audit-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: composer audit
+    runs-on: ubuntu-latest
+    # 🔴 値ではなく手順を写す（上の 3）。この 10 は原本の暫定値。
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      # 🔴 陽性対照は checkout の直後に置く（#289）。後ろに置くと
+      #    「別の理由の赤」と区別がつかず、何を確かめたのか分からなくなる。
+      - name: Simulate failure (rehearsal only)
+        if: inputs.simulate_failure
+        run: exit 1
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+
+      # 🔴 `composer install` はしない。audit は lock を読むだけで足りる。
+      #    install を挟むと「依存が壊れている赤」と「advisory の赤」が混ざる。
+      #
+      # 🔴 setup-php は COMPOSER_NO_AUDIT=1 を立てる（#281 の実測・3艦で再現）。
+      #    これが殺すのは **install/update に付随する暗黙の audit** であって、
+      #    **明示的に呼ぶ `composer audit` は生きている**。だから明示で呼ぶ。
+      #    ⚠️ 「setup-php を使っているから audit は死んでいる」と読まないこと——
+      #       暗黙は死んでいるが明示は生きている、が実測の結論。
+      - name: composer audit
+        run: composer audit --locked --no-interaction
+
+  notify-failure:
+    name: Open an issue when an unattended run fails
+    # 🔴 **この workflow が「無人で走る」event を列挙する**（hub 裁定 2026-08-22・vault 発）。
+    #   - `schedule`          … 常に無人
+    #   - `workflow_dispatch` … 叩いた人が見ているが、`simulate_failure` は陽性対照専用なので通す
+    #   - `push`              … 🔴 **この原本には push トリガが無いので含めていない。足した艦は足すこと**
+    #   - `pull_request`      … 🔴 含めない（作者が見ているのでノイズ）
+    if: >-
+      failure() && (github.event_name == 'schedule'
+      || inputs.simulate_failure)
+    needs: [audit]
+    runs-on: ubuntu-latest
+    # gh の API 呼び出し2本だけ。ここが吊ると「赤が通知されない」に化ける。
+    timeout-minutes: 5
+    permissions:
+      issues: write
+    env:
+      # 🔴 艦名を自艦のものへ変えること。
+      ISSUE_TITLE: '🔴 nene-vault: 週次 composer audit が失敗しています'
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      - name: Create or update the failure issue
+        run: |
+          set -euo pipefail
+          # 🔴 --limit は 100 では足りない。open が 100 件を超えると同名を取りこぼして
+          #    重複起票へフォールバックする。しかも壊れ方が悪い——壊れた側の挙動が
+          #    「毎週新しい issue が立つ」で一見すると装置が動いて見え、かつ発現条件
+          #    （open 100 件超）は「通知が読まれず溜まっている状態」そのもの。
+          #    ＝この仕掛けが守ろうとしているものを、最も必要なときに自分で壊す。
+          #    （vault #379 発見・NENE2 #1656 起票）
+          existing="$(gh issue list --state open --limit 1000 --json number,title \
+            | jq -r --arg t "$ISSUE_TITLE" 'map(select(.title == $t)) | .[0].number // empty')"
+          body="無人実行（${{ github.event_name }}）で週次の composer audit が失敗しました。 実行: ${RUN_URL}"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "$ISSUE_TITLE" --body "$body"
+          fi

--- a/.github/workflows/weekly-audit.yml
+++ b/.github/workflows/weekly-audit.yml
@@ -23,7 +23,8 @@ name: Weekly audit
 
 on:
   schedule:
-    # 🔴 分は艦ごとに変えること（上の割当表）。ここは原本なので未割当の 25 を置いてある。
+    # 分は艦ごとに割り当てられている（NENE2 の `30` を避けて1時台に7艦を散らした表が原本にある）。
+    # vault は `40`。原本の割当表を変えたときはここも合わせること。
     - cron: '40 1 * * 1'
   workflow_dispatch:
     inputs:
@@ -45,7 +46,8 @@ jobs:
   audit:
     name: composer audit
     runs-on: ubuntu-latest
-    # 🔴 値ではなく手順を写す（上の 3）。この 10 は原本の暫定値。
+    # 原本の暫定値をそのまま採っている。audit は lock を読むだけなので通常は数十秒で終わる。
+    # ここが効くのは「吊った」ときだけで、その場合は赤になって notify が拾う。
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -88,7 +90,9 @@ jobs:
     permissions:
       issues: write
     env:
-      # 🔴 艦名を自艦のものへ変えること。
+      # 既存2本（Backend CI / Frontend CI の通知）と衝突しない題。
+      # 🔴 この文字列は下の `jq` で**完全一致**の鍵として使われる。変えると、変える前に
+      #    立った issue が二度と見つからなくなり、重複が1本立つ。変えるなら既存を先に閉じる。
       ISSUE_TITLE: '🔴 nene-vault: 週次 composer audit が失敗しています'
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
Fixes #492

**fleet-tooling #502 の適用1号。** 原本 = `nene2-fleet-tooling/docs/ci/weekly-audit.yml`（`21c4897`）。
板 (A) 2026-08-22 L99・due 2026-08-29・施主決定 08-22 (c)・hub 裁定。

## 何が無かったか〔fleet 実測〕

| | どこに在るか |
| --- | --- |
| `schedule` | **`frontend-ci.yml` にだけ**（`35 0 * * 1`） |
| `composer audit` | **`backend-ci.yml` にだけ** |

⇒ 🔴 **交差していない＝ PHP 側が週次で一度も再検査されていなかった。**
🔑 **advisory は我々のコミットではなく向こう側の時計で公開される**ので、
**PR 時の検査だけでは「世界が動いたか」を見られません。**

## vault 固有に決めた4点（原本から文字列を写していない）

| # | 値 | 根拠 |
| --- | --- | --- |
| cron の分 | **`40 1 * * 1`** | フリート割当。NENE2 が `30 1 * * 1` 使用済み ⇒ 1時台25分以降に7艦を配分 |
| `php-version` | **`8.4`** | `composer.json` の `"php": ">=8.4.1 <9.0"` に合わせた |
| `ISSUE_TITLE` | `🔴 nene-vault: 週次 composer audit が失敗しています` | 既存2本（Backend CI / 週次 CI）と**衝突しない題**（重複検出は題名一致で効くため） |
| notify の `if` | `schedule` と `simulate_failure` **のみ** | 🔴 **この workflow が持つ event から導出** |

🔴 **`push` を含めていません**——この workflow に `push` トリガが無いからです。
⚠️ **#379 の指摘そのもの**: **写す先が持っていない event を条件に書くと、simulate 以外で永久に発火しない**
（＝きれいな inert）。**条件は「持っている event」から導出する。**

## 設計の細部

- **`composer install` はしない**（`--locked`）。install を挟むと**「依存が壊れている赤」と「advisory の赤」が混ざる。**
- 🔴 **`setup-php` は `COMPOSER_NO_AUDIT=1` を立てる**（#281・3艦で再現）。
  殺されるのは **install/update に付随する暗黙の audit** で、**明示的な `composer audit` は生きている。**
  ⇒ 「setup-php を使っているから audit は死んでいる」と読まないこと。
- **陽性対照（`simulate_failure`）は checkout の直後**（#289）。後ろに置くと「別の理由の赤」と区別がつかない。
- **PR 時の `composer audit` と週次は両方残す**（hub 裁定・目的が違う）。

## 実測

| | |
| --- | --- |
| `composer audit --locked` をローカルで実走 | 🟢 **EXIT=0**（`No security vulnerability advisories found.`）⇒ **初回の週次実行は緑になる見込み** |
| YAML パース | 🟢 成功 |
| トリガ列挙 ⇄ notify の `if` | 🟢 **一致**（`schedule` / `workflow_dispatch` のみ） |

⚠️ 終了コードは **`PIPESTATUS[0]`** で取りました（`| tail` の終了コードを読まないため——**そちらが今日踏んだ形**）。

## マージ後（DoD・2段の陽性対照）

**基準値**〔vault 実測 20:05:26・fleet が独立照合 20:06:29〕: **open Issue = 17**

1. `simulate_failure=true` ⇒ **Issue が1本立つ**
2. 🔴 **もう一度叩く** ⇒ **新規作成されず既存へコメント**
3. テスト由来の Issue を説明付きで閉じ、**open が 17 に戻る**

⚠️ **陽性対照で本物の Issue が1件立ちます**（予告済み・vault 了承済み）。

### 🔴 今回取れない層を明記します

**「`--limit 1000` でなければ壊れる」は取れません。** vault は open 17 で `--limit` の既定 30 の内側なので、
**`--limit 100` のままでも2段とも緑になります。**
⇒ **取れるのは「直した経路が実行された」まで**であって、**「直した値でなければ落ちる」ではない。**
🔑 **取れなかった層を明記しない実験は、後から「全部確かめた」と読まれます。**
