### PR TITLE
chore(deps): キット4本を追随 — ui 0.21.0 / tokens 1.3.0 / standards 床 ^2.4.0（#502）

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@hideyukimori/nene2-client": "^1.1.0",
-        "@hideyukimori/nene2-ui": "^0.20.0",
+        "@hideyukimori/nene2-ui": "^0.21.0",
         "@hookform/resolvers": "^3.10.0",
         "@tanstack/react-query": "^5.62.11",
         "react": "^19.2.6",
@@ -20,8 +20,8 @@
       },
       "devDependencies": {
         "@hideyukimori/nene2-i18n": "^0.3.0",
-        "@hideyukimori/nene2-standards": "^2.1.1",
-        "@hideyukimori/nene2-tokens": "1.1.0",
+        "@hideyukimori/nene2-standards": "^2.4.0",
+        "@hideyukimori/nene2-tokens": "1.3.0",
         "@playwright/test": "^1.61.1",
         "@storybook/addon-a11y": "^10.1.4",
         "@storybook/addon-docs": "^10.1.4",
@@ -1699,9 +1699,9 @@
       }
     },
     "node_modules/@hideyukimori/nene2-tokens": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@hideyukimori/nene2-tokens/-/nene2-tokens-1.1.0.tgz",
-      "integrity": "sha512-Z1aMo17+8/qHUYUB6oiqmNAFapOcvZ4hyJShzQyGE8CBNGiemSQ9YFRZ/vhzW8r2VcyYXMZnXIgYUh8PrzIVAA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@hideyukimori/nene2-tokens/-/nene2-tokens-1.3.0.tgz",
+      "integrity": "sha512-alye5rOdEuGk5g4RyYJmIZPLRUXQHEZmVdLrjUBD8Aw0aFuNG6APRbBccTK4DvjHlSa8zCAOd1d0QvFNSks0Ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1712,9 +1712,9 @@
       }
     },
     "node_modules/@hideyukimori/nene2-ui": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@hideyukimori/nene2-ui/-/nene2-ui-0.20.0.tgz",
-      "integrity": "sha512-gkPbpmz9zn0fF3wtIZCLdoX6Y0CWCUQmnsLNurnERw1lqcuCj6oSP/SnvZw9uwmsgnKgIlsbHlxQ4o175d8aBg==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@hideyukimori/nene2-ui/-/nene2-ui-0.21.0.tgz",
+      "integrity": "sha512-VuzlBdb5oYCMUvtItFescFGJfq0r1ZTfCPJEkqgPEkk+lWsYZ+c/Z9FX0gQCulZpdckBRwdHYjgIrpcnPC0Egg==",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@hideyukimori/nene2-client": "^1.1.0",
-    "@hideyukimori/nene2-ui": "^0.20.0",
+    "@hideyukimori/nene2-ui": "^0.21.0",
     "@hookform/resolvers": "^3.10.0",
     "@tanstack/react-query": "^5.62.11",
     "react": "^19.2.6",
@@ -53,8 +53,8 @@
   },
   "devDependencies": {
     "@hideyukimori/nene2-i18n": "^0.3.0",
-    "@hideyukimori/nene2-standards": "^2.1.1",
-    "@hideyukimori/nene2-tokens": "1.1.0",
+    "@hideyukimori/nene2-standards": "^2.4.0",
+    "@hideyukimori/nene2-tokens": "1.3.0",
     "@playwright/test": "^1.61.1",
     "@storybook/addon-a11y": "^10.1.4",
     "@storybook/addon-docs": "^10.1.4",


### PR DESCRIPTION
実インストール版は5本とも latest（ui 0.21.0 / tokens 1.3.0 / standards 2.4.0 /
i18n 0.3.2 / client 1.4.0）。宣言を触ったのは3本で、i18n と client は caret が
既に latest を引いていたため据え置き。

🔴 遅れていたのは「宣言の床」であって動いているコードではない。standards は
`^2.1.1` の宣言で実体 2.4.0、i18n は `^0.3.0` で実体 0.3.2 が入っていた。
宣言と実体を1つの列に潰すと、真である前半が偽である後半を保証して見せる。

## ui 0.21.0 — 出荷物で検算した（申告を採らない）

`npm pack` で 0.20.0 と 0.21.0 を落として全ツリー diff。変更は5ファイル。
`themes/default.css` は**純粋な追加**で、既存スロットの右辺は1つも動いていない
（alert success 3本＝#486 / modal footer・description 3本＝#493、ほかは toast の
コメント訂正1件）。新スロット名6本はいずれも自艦テーマに未定義＝衝突なし。
唯一の挙動変更は `Button` の `BASE_CLASS` への `whitespace-nowrap`（#501）。

## #501 の効き目は vault では 0 だった — 射程は在るのに直すものが無い

375px・ja/en 両ロケール・7ルート＋ダイアログ4つを実ブラウザで測った
（`VITE_MSW=1` の dev サーバに Playwright・154要素／うち kit Button 36個）。

|                | 折り返し | 溢れ | 画面外 |
| -------------- | -------- | ---- | ------ |
| 昇格前 kit 36  | 0        | 0    | 0      |
| 昇格後 kit 36  | 0        | 0    | 0      |

⇒ 折り返しは昇格前から1件も無く、`nowrap` は何も直していない。溢れていた7件は
キットではなく製品自前の `.rail-link`（元から nowrap・既存挙動）。

🔑 **測定が本当に 0.21.0 を見たことは、対照で担保している**——kit Button 36個は
`white-space` が `normal` → `nowrap` に変わり、**残り118要素は不変・幾何は完全一致
（幅高さの変わったボタン 0件）**。効かなかったのではなく、効いた上で直す対象が
無かった。clear の15件は clear のラベルの性質であって、キットを載せていることの
帰結ではない。**部品を共有していても、ラベルは共有していない。**

## tokens 1.1.0 → 1.3.0 はトークンの値を1つも変えない

1.1.0 / 1.2.0 / 1.3.0 を落として全ツリー diff。`themes/` と
`contract-freeze.json` は 1.1.0 と 1.3.0 で**バイト一致**。変わるのは `dist/`
（CLI・codemod・contract の JS）と `exports` への `"./package.json"` 追加だけ。
vault は tokens の CLI をどの npm script からも呼んでおらず、ソースからの import も
0（`knip.json` の ignoreDependencies に在る）。`exports` 欠落が壊す provenance は
standards 2.4.0 が既に exports 非依存の fallback（`resolveVersion` 経路2・#182）を
持つので vault では無害だった。

⇒ current.md の「contract-v2 第一波まで 1.1.0 固定」は**値を凍結する決定**であり、
その値が 1.3.0 でも同一である以上、昇格は契約 v2 の裁定を先取りしない。

## 検査

`npm run check` 緑（rc=0）。42 files / 241 tests passed、coverage ratchet OK、
slot-values / slot-pairs / assert-no-msw / source-probe / registries:check すべて OK。
⚠️ knip の Configuration hint 1件（tailwindcss）は**昇格前の状態へ戻して実測し、
同一に出ることを確認済み**＝本 PR 由来ではない。

配備は含まない（波3の出荷と施主目視は別便）。


Closes #502
